### PR TITLE
CRaC support

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -17,9 +17,9 @@ name: "Validate"
 
 on:
   pull_request:
-#  push:
-#    branches-ignore: [ 'main', 'release-*' ]
-#    tags-ignore: [ '**' ]
+  push:
+    branches-ignore: [ 'main', 'release-*' ]
+    tags-ignore: [ '**' ]
   workflow_call:
     inputs:
       ref:
@@ -258,10 +258,10 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        os: [ ubuntu-22.04, windows-2022 ]
+        os: [ ubuntu-22.04 ]
+        # CRaC is only available on Linux
         include:
           - { os: ubuntu-22.04, platform: linux }
-          - { os: windows-2022, platform: windows }
     runs-on: ${{ matrix.os }}
     name: crac/${{ matrix.platform }}
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -253,9 +253,41 @@ jobs:
               -amd \
               -Pexamples,tests,spotbugs,javadoc \
               verify
+  crac:
+    needs: [ prime-build ]
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04, windows-2022 ]
+        include:
+          - { os: ubuntu-22.04, platform: linux }
+          - { os: windows-2022, platform: windows }
+    runs-on: ${{ matrix.os }}
+    name: crac/${{ matrix.platform }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - uses: ./.github/actions/common
+        with:
+          build-cache: read-only
+          maven-cache: read-only
+          test-artifact-name: crac-${{ matrix.platform }}
+          free-space: true
+          run: |
+            mvn --version
+            mvn ${MVN_ARGS} build-cache:go-offline
+            mvn ${MVN_ARGS} \
+              -Dorg.slf4j.simpleLogger.showThreadName=true \
+              -Dsurefire.reportNameSuffix=${{ matrix.platform }} \
+              -pl crac \
+              -am \
+              -amd \
+              -Pexamples,tests,spotbugs,javadoc \
+              verify
   gate:
     runs-on: ubuntu-22.04
-    needs: [ prime-build, copyright, checkstyle, shellcheck, neo4j, langchain4j, hashicorp_vault, oci_v3 ]
+    needs: [ prime-build, copyright, checkstyle, shellcheck, neo4j, langchain4j, hashicorp_vault, oci_v3, eureka, crac ]
     steps:
       - shell: bash
         run: |

--- a/crac/bom/pom.xml
+++ b/crac/bom/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.extensions</groupId>
+        <artifactId>helidon-extensions-parent</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../parent/pom.xml</relativePath>
+    </parent>
+
+    <groupId>io.helidon.extensions.crac</groupId>
+    <artifactId>helidon-extensions-crac-bom</artifactId>
+    <version>27.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>Helidon Extensions Crac BOM POM</name>
+
+    <properties>
+        <crac.extension.version>27.0.0-SNAPSHOT</crac.extension.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.helidon.extensions.crac</groupId>
+                <artifactId>helidon-extensions-crac</artifactId>
+                <version>${crac.extension.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/crac/docs/README.md
+++ b/crac/docs/README.md
@@ -1,0 +1,3 @@
+# Overview
+
+Crac extension

--- a/crac/examples/pom.xml
+++ b/crac/examples/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.extensions.crac</groupId>
+        <artifactId>helidon-extensions-crac-project</artifactId>
+        <version>27.0.0-SNAPSHOT</version>
+    </parent>
+    <packaging>pom</packaging>
+
+    <groupId>io.helidon.extensions.crac.examples</groupId>
+    <artifactId>helidon-extensions-crac-examples-project</artifactId>
+    <name>Helidon Extensions Crac Examples</name>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.sources.skip>true</maven.sources.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
+
+    <modules>
+    </modules>
+</project>

--- a/crac/modules/crac/pom.xml
+++ b/crac/modules/crac/pom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>io.helidon.extensions.crac</groupId>
+        <artifactId>helidon-extensions-crac-modules-project</artifactId>
+        <version>27.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>helidon-extensions-crac</artifactId>
+    <name>Helidon Extensions CRaC</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-resumable</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.crac</groupId>
+            <artifactId>crac</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common.features</groupId>
+            <artifactId>helidon-common-features-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+    </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.common.features</groupId>
+                            <artifactId>helidon-common-features-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.common.features</groupId>
+                        <artifactId>helidon-common-features-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/crac/modules/crac/src/main/java/io/helidon/extensions/crac/CracResumableResource.java
+++ b/crac/modules/crac/src/main/java/io/helidon/extensions/crac/CracResumableResource.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.crac;
+
+import io.helidon.common.resumable.Resumable;
+
+import org.crac.Context;
+import org.crac.Resource;
+
+import static java.lang.System.Logger.Level.TRACE;
+
+class CracResumableResource implements Resource {
+
+    private static final System.Logger LOGGER = System.getLogger(CracResumableResource.class.getName());
+
+    private final Resumable resumable;
+
+    CracResumableResource(Resumable resumable) {
+        this.resumable = resumable;
+    }
+
+    @Override
+    public void beforeCheckpoint(Context<? extends Resource> context) throws Exception {
+        if (LOGGER.isLoggable(TRACE)) {
+            LOGGER.log(TRACE, "Suspending resumable {0} as CRaC resource.", resumable.getClass().getName());
+        }
+        resumable.suspend();
+    }
+
+    @Override
+    public void afterRestore(Context<? extends Resource> context) throws Exception {
+        if (LOGGER.isLoggable(TRACE)) {
+            LOGGER.log(TRACE, "Resuming resumable {0} as CRaC resource.", resumable.getClass().getName());
+        }
+        resumable.resume();
+    }
+}

--- a/crac/modules/crac/src/main/java/io/helidon/extensions/crac/CracSupport.java
+++ b/crac/modules/crac/src/main/java/io/helidon/extensions/crac/CracSupport.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.crac;
+
+import java.util.Map;
+import java.util.WeakHashMap;
+
+import io.helidon.common.resumable.Resumable;
+import io.helidon.common.resumable.ResumableSupport;
+
+import org.crac.Resource;
+import org.crac.management.CRaCMXBean;
+
+import static java.lang.System.Logger.Level.TRACE;
+
+/**
+ * Resumable implementation with CRaC.
+ */
+public class CracSupport implements ResumableSupport {
+
+    private static final System.Logger LOGGER = System.getLogger(CracSupport.class.getName());
+    private static final Map<Resumable, Resource> REFERENCES = new WeakHashMap<>();
+
+    /**
+     * Constructor required by Java {@link java.util.ServiceLoader}.
+     */
+    public CracSupport() {
+    }
+
+    @Override
+    public void register(Resumable resumable) {
+        // CRaC API keeps resources as weak refs, we don't want our wrappers being GCed
+        CracResumableResource resumableResource = new CracResumableResource(resumable);
+        REFERENCES.put(resumable, resumableResource);
+        org.crac.Core.getGlobalContext().register(resumableResource);
+
+        if (LOGGER.isLoggable(TRACE)) {
+            LOGGER.log(TRACE, "Registered resumable {0} as CRaC resource.", resumable.getClass().getName());
+        }
+    }
+
+    @Override
+    public void checkpointResume() {
+        try {
+            org.crac.Core.checkpointRestore();
+        } catch (org.crac.RestoreException | org.crac.CheckpointException e) {
+            if (LOGGER.isLoggable(TRACE)) {
+                LOGGER.log(TRACE, "CRaC checkpoint restore failed", e);
+            }
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public long uptimeSinceResume() {
+        return CRaCMXBean.getCRaCMXBean().getUptimeSinceRestore();
+    }
+
+    @Override
+    public long resumeTime() {
+        return CRaCMXBean.getCRaCMXBean().getRestoreTime();
+    }
+}

--- a/crac/modules/crac/src/main/java/io/helidon/extensions/crac/package-info.java
+++ b/crac/modules/crac/src/main/java/io/helidon/extensions/crac/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Helidon abstraction over CRaC API, replaces no-op implementation when this module is present on classpath.
+ */
+package io.helidon.extensions.crac;

--- a/crac/modules/crac/src/main/java/module-info.java
+++ b/crac/modules/crac/src/main/java/module-info.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2025, 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.helidon.common.features.api.Features;
+import io.helidon.common.features.api.HelidonFlavor;
+
+/**
+ * Helidon abstraction over CRaC API, replaces no-op implementation when this module is present on classpath.
+ */
+@Features.Preview
+@Features.Name("CRaC")
+@Features.Description("Coordinated Restore at Checkpoint")
+@Features.Flavor({HelidonFlavor.MP, HelidonFlavor.SE})
+@Features.Path("CRaC")
+@Features.Since("4.2.0")
+module io.helidon.extensions.crac {
+    requires static io.helidon.common.features.api; // @Feature
+
+    requires transitive org.crac;
+
+    requires io.helidon.common.resumable;
+
+    provides io.helidon.common.resumable.ResumableSupport with io.helidon.extensions.crac.CracSupport;
+
+    exports io.helidon.extensions.crac;
+}

--- a/crac/modules/pom.xml
+++ b/crac/modules/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://maven.apache.org/POM/4.0.0"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.extensions.crac</groupId>
+        <artifactId>helidon-extensions-crac-project</artifactId>
+        <version>27.0.0-SNAPSHOT</version>
+    </parent>
+    <packaging>pom</packaging>
+
+    <artifactId>helidon-extensions-crac-modules-project</artifactId>
+    <name>Helidon Extensions Crac Modules Project</name>
+
+
+    <modules>
+        <module>crac</module>
+    </modules>
+
+</project>

--- a/crac/pom.xml
+++ b/crac/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.extensions</groupId>
+        <artifactId>helidon-extensions-project</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <groupId>io.helidon.extensions.crac</groupId>
+    <artifactId>helidon-extensions-crac-project</artifactId>
+    <version>27.0.0-SNAPSHOT</version>
+
+    <packaging>pom</packaging>
+
+    <name>Helidon Extensions Crac Project</name>
+
+    <modules>
+        <module>bom</module>
+        <module>modules</module>
+    </modules>
+
+    <properties>
+        <!--
+        When changing Helidon base version:
+        - change it here to version manage Helidon dependencies
+        - change it in all example POM files in parent section, as that cannot use a property
+        -->
+        <helidon.version>27.0.0-SNAPSHOT</helidon.version>
+        <version.lib.crac>1.5.0</version.lib.crac>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.crac</groupId>
+                <artifactId>crac</artifactId>
+                <version>${version.lib.crac}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.extensions.crac</groupId>
+                <artifactId>helidon-extensions-crac-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon</groupId>
+                <artifactId>helidon-dependencies</artifactId>
+                <version>${helidon.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <profiles>
+        <profile>
+            <id>tests</id>
+            <modules>
+                <module>tests</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>examples</id>
+            <modules>
+                <module>examples</module>
+            </modules>
+        </profile>
+    </profiles>
+</project>

--- a/crac/tests/pom.xml
+++ b/crac/tests/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.extensions.crac</groupId>
+        <artifactId>helidon-extensions-crac-project</artifactId>
+        <version>27.0.0-SNAPSHOT</version>
+    </parent>
+    <packaging>pom</packaging>
+
+    <groupId>io.helidon.extensions.crac.tests</groupId>
+    <artifactId>helidon-extensions-crac-tests-project</artifactId>
+    <name>Helidon Extensions Crac Tests Project</name>
+
+    <properties>
+        <spotbugs.skip>true</spotbugs.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.sources.skip>true</maven.sources.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <dependency-check.skip>true</dependency-check.skip>
+    </properties>
+
+    <modules>
+    </modules>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <module>oci-v3</module>
         <module>langchain4j</module>
         <module>eureka</module>
+        <module>crac</module>
     </modules>
 
     <organization>


### PR DESCRIPTION
### Description

Part of #8 

Migration of CRaC from Helidon core repository.
Test cannot be migrated as it uses MicroProfile.