### PR TITLE
11131 Support streaming models for Lc4j agents

### DIFF
--- a/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/AgentCodegen.java
+++ b/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/AgentCodegen.java
@@ -17,6 +17,9 @@
 package io.helidon.extensions.langchain4j.codegen;
 
 import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.stream.Stream;
 
 import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.CodegenUtil;
@@ -33,20 +36,35 @@ import io.helidon.common.types.ElementKind;
 import io.helidon.common.types.TypeInfo;
 import io.helidon.common.types.TypeName;
 import io.helidon.common.types.TypeNames;
+import io.helidon.common.types.TypedElementInfo;
 import io.helidon.service.codegen.ServiceCodegenTypes;
 
 import static io.helidon.common.types.AccessModifier.PACKAGE_PRIVATE;
 import static io.helidon.common.types.AccessModifier.PRIVATE;
 import static io.helidon.common.types.TypeNames.CLASS_WILDCARD;
+import static io.helidon.common.types.TypeNames.PRIMITIVE_BOOLEAN;
 import static io.helidon.common.types.TypeNames.STRING;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AGENTS_CONFIG;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AGENT_METADATA;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AI_AGENT;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AI_CHAT_MODEL;
+import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AI_STREAMING_CHAT_MODEL;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.CONFIG;
+import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_A2A_CLIENT_AGENT;
+import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_AGENTIC_AGENT;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_AGENTIC_SERVICES;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_CHAT_MODEL;
+import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_CONDITIONAL_AGENT;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_DECLARATIVE_AGENT_CREATION_CONTEXT;
+import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_HUMAN_IN_THE_LOOP;
+import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_LOOP_AGENT;
+import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_MCP_CLIENT_AGENT;
+import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_PARALLEL_AGENT;
+import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_PARALLEL_MAPPER_AGENT;
+import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_PLANNER_AGENT;
+import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_SEQUENCE_AGENT;
+import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_STREAMING_CHAT_MODEL;
+import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_SUPERVISOR_AGENT;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_NAMED;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_ANNOTATION_SINGLETON;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_QUALIFIER;
@@ -54,47 +72,113 @@ import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_REGISTRY;
 
 class AgentCodegen implements CodegenExtension {
     private static final TypeName GENERATOR = TypeName.create(AgentCodegen.class);
+    private static final Set<TypeName> AGENT_METHOD_ANNOTATIONS = Set.of(
+            LC_AGENTIC_AGENT,
+            LC_SEQUENCE_AGENT,
+            LC_CONDITIONAL_AGENT,
+            LC_LOOP_AGENT,
+            LC_PARALLEL_AGENT,
+            LC_PARALLEL_MAPPER_AGENT,
+            LC_PLANNER_AGENT,
+            LC_SUPERVISOR_AGENT,
+            LC_HUMAN_IN_THE_LOOP,
+            LC_A2A_CLIENT_AGENT,
+            LC_MCP_CLIENT_AGENT
+    );
+    private static final String CHAT_MODEL_CONFIG_KEY = "chat-model";
+    private static final String STREAMING_CHAT_MODEL_CONFIG_KEY = "streaming-chat-model";
+
     static final String AGENTS_CONFIG_KEY = "langchain4j.agents";
 
     @Override
     public void process(RoundContext roundCtx) {
         Collection<TypeInfo> types = roundCtx.annotatedTypes(AI_AGENT);
+        Set<TypeName> chatModelRequiredTypes = chatModelRequiredTypes(types);
 
-        // First round to get annotation metadata of all known agents
+        validateAgentTypes(types);
+        generateAgentSuppliers(roundCtx, types, chatModelRequiredTypes);
+    }
+
+    private void validateAgentTypes(Collection<TypeInfo> types) {
         for (TypeInfo type : types) {
-            // for each annotated interface, generate Iface__AiServices and Iface__Service
-            // the type MUST be an interface
             if (type.kind() != ElementKind.INTERFACE) {
                 throw new CodegenException("Type annotated with " + AI_AGENT.fqName() + " must be an interface.",
                                            type.originatingElementValue());
             }
-
-        }
-        // Second round to generate agent producers
-        for (TypeInfo type : types) {
-            process(roundCtx, type);
+            if (type.hasAnnotation(AI_CHAT_MODEL) && type.hasAnnotation(AI_STREAMING_CHAT_MODEL)) {
+                throw new CodegenException("Type annotated with " + AI_AGENT.fqName()
+                                                   + " cannot use both @Ai.ChatModel and @Ai.StreamingChatModel.",
+                                           type.originatingElementValue());
+            }
+            type.elementInfo()
+                    .stream()
+                    .filter(it -> it.kind() == ElementKind.METHOD)
+                    .forEach(method -> validateAgentMethod(type, method));
         }
     }
 
-    private void process(RoundContext roundCtx, TypeInfo agentInterface) {
-        TypeName agentInterfaceType = agentInterface.typeName();
-        TypeName generatedType = generatedTypeName(agentInterfaceType, "AiAgent");
+    private void validateAgentMethod(TypeInfo type, TypedElementInfo method) {
+        if (isAgentMethod(method) && isStringStream(method.typeName())) {
+            throw new CodegenException("Agent method "
+                                               + type.typeName().fqName()
+                                               + "#"
+                                               + method.elementName()
+                                               + " must return dev.langchain4j.service.TokenStream instead of Stream<String>.",
+                                       type.originatingElementValue());
+        }
+    }
+
+    private void generateAgentSuppliers(RoundContext roundCtx,
+                                        Collection<TypeInfo> types,
+                                        Set<TypeName> chatModelRequiredTypes) {
+        for (TypeInfo type : types) {
+            generateAgentSupplier(roundCtx, type, chatModelRequiredTypes);
+        }
+    }
+
+    private void generateAgentSupplier(RoundContext roundCtx,
+                                       TypeInfo agentInterface,
+                                       Set<TypeName> chatModelRequiredTypes) {
+        AgentInfo agent = agentInfo(agentInterface);
         AgentMetadataSupplierBuilder.build(agentInterface, roundCtx);
 
         var classModel = ClassModel.builder()
-                .type(generatedType)
+                .type(agent.generatedType())
                 .copyright(CodegenUtil.copyright(GENERATOR,
-                                                 agentInterfaceType,
-                                                 generatedType))
+                                                 agent.agentInterfaceType(),
+                                                 agent.generatedType()))
                 .addAnnotation(CodegenUtil.generatedAnnotation(GENERATOR,
-                                                               agentInterfaceType,
-                                                               generatedType,
+                                                               agent.agentInterfaceType(),
+                                                               agent.generatedType(),
                                                                "1",
                                                                ""))
                 .accessModifier(AccessModifier.PACKAGE_PRIVATE)
-                .addInterface(supplierType(agentInterfaceType))
+                .addInterface(supplierType(agent.agentInterfaceType()))
                 .addAnnotation(Annotation.create(SERVICE_ANNOTATION_SINGLETON));
 
+        addStateFields(classModel);
+        addConstructor(classModel, agentInterface);
+        classModel.addMethod(method -> addGetMethod(method, agent));
+        classModel.addMethod(method -> addRequiresChatModelMethod(method, chatModelRequiredTypes));
+        classModel.addMethod(this::addValidateChatModelSupportMethod);
+        classModel.addMethod(method -> addConfigureSubAgentsMethod(method, agent));
+
+        roundCtx.addGeneratedType(agent.generatedType(),
+                                  classModel,
+                                  agent.agentInterfaceType(),
+                                  agentInterface.originatingElementValue());
+    }
+
+    private AgentInfo agentInfo(TypeInfo agentInterface) {
+        TypeName agentInterfaceType = agentInterface.typeName();
+        return new AgentInfo(agentInterface.typeName(),
+                             generatedTypeName(agentInterfaceType, "AiAgent"),
+                             agentInterface.annotation(AI_AGENT).stringValue().orElseThrow(),
+                             agentInterface.hasAnnotation(AI_CHAT_MODEL),
+                             agentInterface.hasAnnotation(AI_STREAMING_CHAT_MODEL));
+    }
+
+    private void addStateFields(ClassModel.Builder classModel) {
         classModel.addField(aiServices -> aiServices
                 .name("agenticConfig")
                 .type(CONFIG)
@@ -116,52 +200,149 @@ class AgentCodegen implements CodegenExtension {
                 .accessModifier(PRIVATE)
         );
 
-        // constructor (parameters depend on annotations on interface)
+        classModel.addField(aiServices -> aiServices
+                .name("streamingChatModel")
+                .type(LC_STREAMING_CHAT_MODEL)
+                .isFinal(true)
+                .accessModifier(PRIVATE)
+        );
+    }
+
+    private void addConstructor(ClassModel.Builder classModel, TypeInfo agentInterface) {
         classModel.addConstructor(ctr -> ctr
                 .accessModifier(AccessModifier.PACKAGE_PRIVATE)
                 .addAnnotation(Annotation.create(ServiceCodegenTypes.SERVICE_ANNOTATION_INJECT))
+                .addParameter(Parameter.builder()
+                                      .type(CONFIG)
+                                      .name("config")
+                                      .build())
+                .addParameter(Parameter.builder()
+                                      .type(SERVICE_REGISTRY)
+                                      .name("registry")
+                                      .build())
+                .addContent("this.agenticConfig = config.get(")
+                .addContentLiteral(AGENTS_CONFIG_KEY)
+                .addContentLine(");")
+                .addContentLine("this.registry = registry;")
                 .update(it -> {
                     aiAgentsParameter(it,
                                       true,
                                       agentInterface,
                                       AI_CHAT_MODEL,
                                       LC_CHAT_MODEL,
+                                      "chatModel",
                                       "chatModel");
+                    aiAgentsParameter(it,
+                                      true,
+                                      agentInterface,
+                                      AI_STREAMING_CHAT_MODEL,
+                                      LC_STREAMING_CHAT_MODEL,
+                                      "streamingChatModel",
+                                      "streamingChatModel");
                 })
         );
+    }
 
-        // and the get method (implementation of supplier)
-        classModel.addMethod(get -> get
-                .accessModifier(AccessModifier.PUBLIC)
+    private void addGetMethod(Method.Builder method, AgentInfo agent) {
+        method.accessModifier(AccessModifier.PUBLIC)
                 .addAnnotation(Annotations.OVERRIDE)
-                .returnType(agentInterfaceType)
+                .returnType(agent.agentInterfaceType())
                 .name("get")
                 .addContent("var topAgentConfig = this.agenticConfig.get(")
-                .addContentLiteral(agentInterface.annotation(AI_AGENT).stringValue().orElseThrow())
+                .addContentLiteral(agent.agentName())
                 .addContentLine(");")
-                .addContent("var configuredModel = topAgentConfig")
+                .addContent("boolean chatModelConfigured = topAgentConfig.get(")
+                .addContentLiteral(CHAT_MODEL_CONFIG_KEY)
+                .addContentLine(").exists();")
+                .addContent("boolean streamingChatModelConfigured = topAgentConfig.get(")
+                .addContentLiteral(STREAMING_CHAT_MODEL_CONFIG_KEY)
+                .addContentLine(").exists();")
+                .addContentLine("if (chatModelConfigured && streamingChatModelConfigured) {")
+                .increaseContentPadding()
+                .addContent("throw new ")
+                .addContent(IllegalStateException.class)
+                .addContent("(")
+                .addContentLiteral("Both chat-model and streaming-chat-model are configured for agent "
+                                           + agent.agentName()
+                                           + ".")
+                .addContentLine(");")
+                .decreaseContentPadding()
+                .addContentLine("}")
+                .addContent("var configuredChatModel = topAgentConfig")
                 .addContent(".get(")
-                .addContentLiteral("chat-model")
+                .addContentLiteral(CHAT_MODEL_CONFIG_KEY)
                 .addContentLine(")")
                 .increaseContentPadding()
                 .addContentLine(".asString()")
-                .addContent(".map(n -> registry.getNamed(ChatModel.class, n))")
+                .addContent(".map(n -> registry.getNamed(")
+                .addContent(LC_CHAT_MODEL)
+                .addContentLine(".class, n))")
                 .addContentLine(".orElse(chatModel);")
                 .decreaseContentPadding()
-                .addContent("return ")
+                .addContent("var configuredStreamingChatModel = topAgentConfig")
+                .addContent(".get(")
+                .addContentLiteral(STREAMING_CHAT_MODEL_CONFIG_KEY)
+                .addContentLine(")")
+                .increaseContentPadding()
+                .addContentLine(".asString()")
+                .addContent(".map(n -> registry.getNamed(")
+                .addContent(LC_STREAMING_CHAT_MODEL)
+                .addContentLine(".class, n))")
+                .addContentLine(".orElse(streamingChatModel);")
+                .decreaseContentPadding()
+                .addContentLine("if (chatModelConfigured) {")
+                .increaseContentPadding()
+                .addContentLine("configuredStreamingChatModel = null;")
+                .decreaseContentPadding()
+                .addContentLine("}")
+                .addContentLine("if (streamingChatModelConfigured) {")
+                .increaseContentPadding()
+                .addContentLine("configuredChatModel = null;")
+                .decreaseContentPadding()
+                .addContentLine("}")
+                .update(it -> addRootModelSelection(it, agent))
+                .addContent("validateChatModelSupport(")
+                .addContent(agent.agentInterfaceType())
+                .addContent(".class, ")
+                .addContentLiteral(agent.agentName())
+                .addContentLine(", configuredChatModel, configuredStreamingChatModel);")
+                .addContentLine("var rootChatModel = configuredChatModel;")
+                .addContentLine("if (configuredStreamingChatModel != null && rootChatModel == null) {")
+                .increaseContentPadding()
+                .addContent("rootChatModel = new ")
+                .addContent(LC_CHAT_MODEL)
+                .addContentLine("() { };")
+                .decreaseContentPadding()
+                .addContentLine("}");
+        method.addContent("return ")
                 .addContent(LC_AGENTIC_SERVICES)
                 .addContent(".createAgenticSystem(")
-                .addContent(agentInterfaceType)
-                .addContent(".class, ")
-                .addContent("configuredModel, ")
-                .addContent("this")
-                .addContentLine("::configureSubAgents);")
-                .addContentLine("")
-        );
+                .addContent(agent.agentInterfaceType())
+                .addContent(".class, rootChatModel, this")
+                .addContentLine("::configureSubAgents);");
+        method.addContentLine();
+    }
 
-        classModel.addMethod(this::addConfigureSubAgentsMethod);
-
-        roundCtx.addGeneratedType(generatedType, classModel, agentInterfaceType, agentInterface.originatingElementValue());
+    private void addRootModelSelection(Method.Builder method, AgentInfo agent) {
+        if (agent.hasChatModelAnnotation()) {
+            method.addContentLine("if (!streamingChatModelConfigured) {")
+                    .increaseContentPadding()
+                    .addContentLine("configuredStreamingChatModel = null;")
+                    .decreaseContentPadding()
+                    .addContentLine("}");
+        } else if (agent.hasStreamingChatModelAnnotation()) {
+            method.addContentLine("if (!chatModelConfigured) {")
+                    .increaseContentPadding()
+                    .addContentLine("configuredChatModel = null;")
+                    .decreaseContentPadding()
+                    .addContentLine("}");
+        } else {
+            method.addContentLine("if (configuredChatModel != null && configuredStreamingChatModel != null) {")
+                    .increaseContentPadding()
+                    .addContentLine("configuredStreamingChatModel = null;")
+                    .decreaseContentPadding()
+                    .addContentLine("}");
+        }
     }
 
     private void aiAgentsParameter(Constructor.Builder ctr,
@@ -169,57 +350,42 @@ class AgentCodegen implements CodegenExtension {
                                    TypeInfo aiInterface,
                                    TypeName aiModelAnnotation,
                                    TypeName lcModelType,
-                                   String aiServicesMethodName) {
-
-        ctr.addParameter(Parameter.builder()
-                                 .type(CONFIG)
-                                 .name("config")
-                                 .build());
-
-        ctr.addParameter(Parameter.builder()
-                                 .type(SERVICE_REGISTRY)
-                                 .name("registry")
-                                 .build());
-
-        ctr.addContent("this.agenticConfig = config.get(")
-                .addContentLiteral(AGENTS_CONFIG_KEY)
-                .addContentLine(");");
-        ctr.addContentLine("this.registry = registry;");
-
-        // if annotated, we have a named value (and that is mandatory)
+                                   String parameterName,
+                                   String fieldName) {
         String modelName = aiInterface.findAnnotation(aiModelAnnotation)
                 .flatMap(Annotation::stringValue)
                 .orElse(null);
 
         if (modelName == null) {
-            // there is no annotation, use only auto-discovered model (if present)
             if (!autoDiscovery) {
-                // no autodiscovery, this model will not be configured
                 return;
             }
             ctr.addParameter(parameter -> parameter
-                    .name(aiServicesMethodName)
+                    .name(parameterName)
                     .type(optionalType(lcModelType)));
-            ctr
-                    .addContent("this.chatModel = chatModel.orElse(null);");
+            ctr.addContent("this.")
+                    .addContent(fieldName)
+                    .addContent(" = ")
+                    .addContent(parameterName)
+                    .addContentLine(".orElse(null);");
         } else {
-            // there is no annotation, use only auto-discovered model (if present)
             if (!autoDiscovery) {
-                // no autodiscovery, this model will not be configured
                 return;
             }
             ctr.addParameter(parameter -> parameter
-                    .name(aiServicesMethodName)
+                    .name(parameterName)
                     .type(optionalType(lcModelType))
                     .addAnnotation(namedAnnotation(modelName)));
-            ctr
-                    .addContent("this.chatModel = chatModel.orElse(null);");
+            ctr.addContent("this.")
+                    .addContent(fieldName)
+                    .addContent(" = ")
+                    .addContent(parameterName)
+                    .addContentLine(".orElse(null);");
         }
     }
 
-    private void addConfigureSubAgentsMethod(Method.Builder mb) {
-        mb
-                .accessModifier(PACKAGE_PRIVATE)
+    private void addConfigureSubAgentsMethod(Method.Builder mb, AgentInfo rootAgent) {
+        mb.accessModifier(PACKAGE_PRIVATE)
                 .addParameter(Parameter.builder()
                                       .name("ctx")
                                       .type(LC_DECLARATIVE_AGENT_CREATION_CONTEXT)
@@ -242,20 +408,223 @@ class AgentCodegen implements CodegenExtension {
                 .addContent("+ cls +")
                 .addContentLiteral(" has no build time metadata available!")
                 .addContentLine("));")
-
                 .decreaseContentPadding()
                 .addContent(STRING)
                 .addContentLine(" agentName = metadata.agentName();")
+                .addContentLine("var agentConfig = agenticConfig.get(agentName);")
                 .addContent("var agentsConfigBuilder = ")
                 .addContent(AGENTS_CONFIG)
                 .addContent(".builder(metadata.buildTimeConfig());")
-                .decreaseContentPadding()
                 .addContentLine()
                 .addContentLine()
                 .addContentLine("// Override annotation setup with config")
-                .addContentLine("agentsConfigBuilder.config(agenticConfig.get(agentName));")
+                .addContentLine("agentsConfigBuilder.config(agentConfig);")
                 .addContentLine("var agentsConfig = agentsConfigBuilder.build();")
-                .addContentLine("agentsConfig.configure(ctx, registry);");
+                .addContent("var runtimeChatModel = agentConfig.get(")
+                .addContentLiteral(CHAT_MODEL_CONFIG_KEY)
+                .addContentLine(").asString()")
+                .increaseContentPadding()
+                .addContent(".map(n -> registry.getNamed(")
+                .addContent(LC_CHAT_MODEL)
+                .addContentLine(".class, n));")
+                .decreaseContentPadding()
+                .addContent("var runtimeStreamingChatModel = agentConfig.get(")
+                .addContentLiteral(STREAMING_CHAT_MODEL_CONFIG_KEY)
+                .addContentLine(").asString()")
+                .increaseContentPadding()
+                .addContent(".map(n -> registry.getNamed(")
+                .addContent(LC_STREAMING_CHAT_MODEL)
+                .addContentLine(".class, n));")
+                .decreaseContentPadding()
+                .addContent("var configuredAgentChatModel = agentsConfig.chatModel()")
+                .increaseContentPadding()
+                .addContent(".map(n -> registry.getNamed(")
+                .addContent(LC_CHAT_MODEL)
+                .addContentLine(".class, n))")
+                .addContentLine(".orElse(null);")
+                .decreaseContentPadding()
+                .addContent("var configuredAgentStreamingChatModel = agentsConfig.streamingChatModel()")
+                .increaseContentPadding()
+                .addContent(".map(n -> registry.getNamed(")
+                .addContent(LC_STREAMING_CHAT_MODEL)
+                .addContentLine(".class, n))")
+                .addContentLine(".orElse(null);")
+                .decreaseContentPadding()
+                .addContentLine("var effectiveChatModel = configuredAgentChatModel;")
+                .addContentLine("var effectiveStreamingChatModel = configuredAgentStreamingChatModel;")
+                .addContentLine("if (runtimeChatModel.isPresent() && runtimeStreamingChatModel.isPresent()) {")
+                .increaseContentPadding()
+                .addContent("throw new ")
+                .addContent(IllegalStateException.class)
+                .addContent("(")
+                .addContentLiteral("Both chat-model and streaming-chat-model are configured for agent ")
+                .addContent(" + agentName + ")
+                .addContentLiteral(".")
+                .addContentLine(");")
+                .decreaseContentPadding()
+                .addContentLine("}")
+                .addContentLine("agentsConfig.configure(ctx, registry);")
+                .addContentLine("if (runtimeChatModel.isPresent()) {")
+                .increaseContentPadding()
+                .addContentLine("effectiveChatModel = runtimeChatModel.get();")
+                .addContentLine("effectiveStreamingChatModel = null;")
+                .addContentLine("ctx.agentBuilder().streamingChatModel(null);")
+                .addContentLine("ctx.agentBuilder().chatModel(runtimeChatModel.get());")
+                .decreaseContentPadding()
+                .addContentLine("} else if (runtimeStreamingChatModel.isPresent()) {")
+                .increaseContentPadding()
+                .addContentLine("effectiveChatModel = null;")
+                .addContentLine("effectiveStreamingChatModel = runtimeStreamingChatModel.get();")
+                .addContentLine("ctx.agentBuilder().chatModel(null);")
+                .addContentLine("ctx.agentBuilder().streamingChatModel(runtimeStreamingChatModel.get());")
+                .decreaseContentPadding()
+                .addContentLine("} else if (configuredAgentStreamingChatModel != null && configuredAgentChatModel == null) {")
+                .increaseContentPadding()
+                .addContentLine("effectiveChatModel = null;")
+                .addContentLine("ctx.agentBuilder().chatModel(null);")
+                .decreaseContentPadding()
+                .addContentLine("} else if (configuredAgentChatModel == null && configuredAgentStreamingChatModel == null) {")
+                .increaseContentPadding()
+                .addContent("var topAgentConfig = this.agenticConfig.get(")
+                .addContentLiteral(rootAgent.agentName())
+                .addContentLine(");")
+                .addContent("boolean rootChatModelConfigured = topAgentConfig.get(")
+                .addContentLiteral(CHAT_MODEL_CONFIG_KEY)
+                .addContentLine(").exists();")
+                .addContent("boolean rootStreamingChatModelConfigured = topAgentConfig.get(")
+                .addContentLiteral(STREAMING_CHAT_MODEL_CONFIG_KEY)
+                .addContentLine(").exists();")
+                .addContent("var rootStreamingChatModel = topAgentConfig.get(")
+                .addContentLiteral(STREAMING_CHAT_MODEL_CONFIG_KEY)
+                .addContentLine(").asString()")
+                .increaseContentPadding()
+                .addContent(".map(n -> registry.getNamed(")
+                .addContent(LC_STREAMING_CHAT_MODEL)
+                .addContentLine(".class, n))")
+                .addContentLine(".orElse(null);")
+                .update(it -> {
+                    if (rootAgent.hasStreamingChatModelAnnotation()) {
+                        it.addContentLine("if (!rootStreamingChatModelConfigured) {")
+                                .increaseContentPadding()
+                                .addContentLine("rootStreamingChatModel = streamingChatModel;")
+                                .decreaseContentPadding()
+                                .addContentLine("}");
+                    } else if (!rootAgent.hasChatModelAnnotation()) {
+                        it.addContentLine("if (!rootStreamingChatModelConfigured && chatModel == null) {")
+                                .increaseContentPadding()
+                                .addContentLine("rootStreamingChatModel = streamingChatModel;")
+                                .decreaseContentPadding()
+                                .addContentLine("}");
+                    }
+                })
+                .decreaseContentPadding()
+                .addContentLine("if (!rootChatModelConfigured && rootStreamingChatModel != null) {")
+                .increaseContentPadding()
+                .addContentLine("effectiveChatModel = null;")
+                .addContentLine("effectiveStreamingChatModel = rootStreamingChatModel;")
+                .addContentLine("ctx.agentBuilder().chatModel(null);")
+                .addContentLine("ctx.agentBuilder().streamingChatModel(rootStreamingChatModel);")
+                .decreaseContentPadding()
+                .addContentLine("}")
+                .decreaseContentPadding()
+                .addContentLine("}")
+                .addContentLine("validateChatModelSupport(cls, agentName, effectiveChatModel, effectiveStreamingChatModel);");
+    }
+
+    private void addRequiresChatModelMethod(Method.Builder method, Set<TypeName> chatModelRequiredTypes) {
+        method.accessModifier(PRIVATE)
+                .returnType(PRIMITIVE_BOOLEAN)
+                .name("requiresChatModel")
+                .addParameter(CLASS_WILDCARD, "cls");
+
+        if (chatModelRequiredTypes.isEmpty()) {
+            method.addContentLine("return false;");
+            return;
+        }
+
+        chatModelRequiredTypes.forEach(typeName -> method
+                .addContent("if (cls == ")
+                .addContent(typeName)
+                .addContentLine(".class) {")
+                .increaseContentPadding()
+                .addContentLine("return true;")
+                .decreaseContentPadding()
+                .addContentLine("}"));
+        method.addContentLine("return false;");
+    }
+
+    private void addValidateChatModelSupportMethod(Method.Builder method) {
+        method.accessModifier(PRIVATE)
+                .name("validateChatModelSupport")
+                .addParameter(CLASS_WILDCARD, "cls")
+                .addParameter(STRING, "agentName")
+                .addParameter(LC_CHAT_MODEL, "configuredChatModel")
+                .addParameter(LC_STREAMING_CHAT_MODEL, "configuredStreamingChatModel")
+                .addContentLine("if (configuredChatModel == null")
+                .addContentLine("        && configuredStreamingChatModel != null")
+                .addContentLine("        && requiresChatModel(cls)) {")
+                .increaseContentPadding()
+                .addContent("throw new ")
+                .addContent(IllegalStateException.class)
+                .addContent("(")
+                .addContentLiteral("Agent ")
+                .addContent(" + agentName + ")
+                .addContentLiteral(" requires chat-model; streaming-chat-model only is not supported for "
+                                           + "supervisor agents or agents using summarizedContext.")
+                .addContentLine(");")
+                .decreaseContentPadding()
+                .addContentLine("}");
+    }
+
+    private Set<TypeName> chatModelRequiredTypes(Collection<TypeInfo> types) {
+        Set<TypeName> result = new LinkedHashSet<>();
+        for (TypeInfo type : types) {
+            if (requiresChatModel(type)) {
+                result.add(type.typeName());
+            }
+        }
+        return result;
+    }
+
+    private boolean requiresChatModel(TypeInfo agentInterface) {
+        if (agentInterface.elementInfo().stream()
+                .filter(it -> it.kind() == ElementKind.METHOD)
+                .anyMatch(this::requiresChatModel)) {
+            return true;
+        }
+
+        return agentInterface.interfaceTypeInfo().stream()
+                .anyMatch(this::requiresChatModel);
+    }
+
+    private boolean requiresChatModel(TypedElementInfo methodInfo) {
+        return methodInfo.annotations().stream()
+                .anyMatch(this::requiresChatModel);
+    }
+
+    private boolean requiresChatModel(Annotation annotation) {
+        if (LC_SUPERVISOR_AGENT.equals(annotation.typeName())) {
+            return true;
+        }
+
+        return LC_AGENTIC_AGENT.equals(annotation.typeName())
+                && annotation.stringValues("summarizedContext")
+                        .stream()
+                        .flatMap(Collection::stream)
+                        .findAny()
+                        .isPresent();
+    }
+
+    private boolean isAgentMethod(TypedElementInfo methodInfo) {
+        return methodInfo.annotations().stream()
+                .map(Annotation::typeName)
+                .anyMatch(AGENT_METHOD_ANNOTATIONS::contains);
+    }
+
+    private boolean isStringStream(TypeName typeName) {
+        return TypeName.create(Stream.class).equals(typeName.genericTypeName())
+                && typeName.typeArguments().size() == 1
+                && STRING.equals(typeName.typeArguments().getFirst());
     }
 
     private TypeName generatedTypeName(TypeName aiInterfaceType, String suffix) {
@@ -279,5 +648,12 @@ class AgentCodegen implements CodegenExtension {
 
     private Annotation namedAnnotation(String modelName) {
         return Annotation.create(SERVICE_ANNOTATION_NAMED, modelName);
+    }
+
+    private record AgentInfo(TypeName agentInterfaceType,
+                             TypeName generatedType,
+                             String agentName,
+                             boolean hasChatModelAnnotation,
+                             boolean hasStreamingChatModelAnnotation) {
     }
 }

--- a/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/AgentMetadataSupplierBuilder.java
+++ b/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/AgentMetadataSupplierBuilder.java
@@ -49,6 +49,7 @@ import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AI_CHAT_M
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AI_CONTENT_RETRIEVER;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AI_MCP_CLIENTS;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AI_RETRIEVER_AUGMENTOR;
+import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AI_STREAMING_CHAT_MODEL;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AI_TOOLS;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AI_TOOL_PROVIDER;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.SVC_SERVICES_FACTORY;
@@ -65,6 +66,7 @@ class AgentMetadataSupplierBuilder {
         var m = new LinkedHashMap<TypeName, AnnotationMapper>();
         m.put(AI_AGENT, new AnnotationMapper("name", MapperType.STRING_VALUE));
         m.put(AI_CHAT_MODEL, new AnnotationMapper("chatModel", MapperType.STRING_VALUE));
+        m.put(AI_STREAMING_CHAT_MODEL, new AnnotationMapper("streamingChatModel", MapperType.STRING_VALUE));
         m.put(AI_CHAT_MEMORY, new AnnotationMapper("chatMemory", MapperType.STRING_VALUE));
         m.put(AI_CHAT_MEMORY_PROVIDER, new AnnotationMapper("chatMemoryProvider", MapperType.STRING_VALUE));
         m.put(AI_CONTENT_RETRIEVER, new AnnotationMapper("contentRetriever", MapperType.STRING_VALUE));

--- a/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/LangchainTypes.java
+++ b/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/LangchainTypes.java
@@ -71,6 +71,17 @@ final class LangchainTypes {
     static final TypeName LC_MCP_TOOL_PROVIDER = TypeName.create("dev.langchain4j.mcp.McpToolProvider");
     static final TypeName LC_MCP_CLIENT = TypeName.create("dev.langchain4j.mcp.client.McpClient");
     static final TypeName LC_AGENTIC_SERVICES = TypeName.create("dev.langchain4j.agentic.AgenticServices");
+    static final TypeName LC_AGENTIC_AGENT = TypeName.create("dev.langchain4j.agentic.Agent");
+    static final TypeName LC_SEQUENCE_AGENT = TypeName.create("dev.langchain4j.agentic.declarative.SequenceAgent");
+    static final TypeName LC_CONDITIONAL_AGENT = TypeName.create("dev.langchain4j.agentic.declarative.ConditionalAgent");
+    static final TypeName LC_LOOP_AGENT = TypeName.create("dev.langchain4j.agentic.declarative.LoopAgent");
+    static final TypeName LC_PARALLEL_AGENT = TypeName.create("dev.langchain4j.agentic.declarative.ParallelAgent");
+    static final TypeName LC_PARALLEL_MAPPER_AGENT = TypeName.create("dev.langchain4j.agentic.declarative.ParallelMapperAgent");
+    static final TypeName LC_PLANNER_AGENT = TypeName.create("dev.langchain4j.agentic.declarative.PlannerAgent");
+    static final TypeName LC_SUPERVISOR_AGENT = TypeName.create("dev.langchain4j.agentic.declarative.SupervisorAgent");
+    static final TypeName LC_HUMAN_IN_THE_LOOP = TypeName.create("dev.langchain4j.agentic.declarative.HumanInTheLoop");
+    static final TypeName LC_A2A_CLIENT_AGENT = TypeName.create("dev.langchain4j.agentic.declarative.A2AClientAgent");
+    static final TypeName LC_MCP_CLIENT_AGENT = TypeName.create("dev.langchain4j.agentic.declarative.McpClientAgent");
     static final TypeName LC_DECLARATIVE_AGENT_CREATION_CONTEXT = TypeName.create(
             "dev.langchain4j.agentic.AgenticServices.DeclarativeAgentCreationContext");
 

--- a/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/AgentsConfigBlueprint.java
+++ b/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/AgentsConfigBlueprint.java
@@ -25,6 +25,7 @@ import io.helidon.service.registry.ServiceRegistry;
 
 import dev.langchain4j.guardrail.InputGuardrail;
 import dev.langchain4j.guardrail.OutputGuardrail;
+import dev.langchain4j.model.chat.StreamingChatModel;
 
 /**
  * Configuration for a single LangChain4j agent.
@@ -105,6 +106,16 @@ interface AgentsConfigBlueprint {
      */
     @Option.Configured
     Optional<String> chatModel();
+
+    /**
+     * Name of the {@link StreamingChatModel} service to use for this agent.
+     * <p>
+     * The value is resolved from the {@link ServiceRegistry}.
+     *
+     * @return configured name of the streaming chat model service, or empty if not configured
+     */
+    @Option.Configured
+    Optional<String> streamingChatModel();
 
     /**
      * Name of the {@link dev.langchain4j.memory.ChatMemory} service to use for this agent.

--- a/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/AgentsConfigSupport.java
+++ b/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/AgentsConfigSupport.java
@@ -29,6 +29,7 @@ import dev.langchain4j.mcp.client.McpClient;
 import dev.langchain4j.memory.ChatMemory;
 import dev.langchain4j.memory.chat.ChatMemoryProvider;
 import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
 import dev.langchain4j.rag.RetrievalAugmentor;
 import dev.langchain4j.rag.content.retriever.ContentRetriever;
 import dev.langchain4j.service.tool.ToolProvider;
@@ -42,6 +43,7 @@ class AgentsConfigSupport {
      * Configures LangChain4j {@link dev.langchain4j.agentic.agent.AgentBuilder} from {@link AgentsConfig}.
      * <p>
      * This method resolves any configured service references (such as {@link dev.langchain4j.model.chat.ChatModel},
+     * {@link dev.langchain4j.model.chat.StreamingChatModel},
      * {@link dev.langchain4j.memory.ChatMemory}, {@link dev.langchain4j.memory.chat.ChatMemoryProvider},
      * {@link dev.langchain4j.rag.content.retriever.ContentRetriever},
      * {@link dev.langchain4j.rag.RetrievalAugmentor},
@@ -64,6 +66,8 @@ class AgentsConfigSupport {
 
         agentsConfig.chatModel().map(s -> serviceRegistry.getNamed(ChatModel.class, s))
                 .ifPresent(agentBuilder::chatModel);
+        agentsConfig.streamingChatModel().map(s -> serviceRegistry.getNamed(StreamingChatModel.class, s))
+                .ifPresent(agentBuilder::streamingChatModel);
 
         agentsConfig.name().ifPresent(agentBuilder::name);
         agentsConfig.description().ifPresent(agentBuilder::description);

--- a/langchain4j/modules/providers/mock/src/test/java/io/helidon/extensions/langchain4j/providers/mock/MockStreamingTest.java
+++ b/langchain4j/modules/providers/mock/src/test/java/io/helidon/extensions/langchain4j/providers/mock/MockStreamingTest.java
@@ -16,8 +16,8 @@
 
 package io.helidon.extensions.langchain4j.providers.mock;
 
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Config;
@@ -27,6 +27,7 @@ import io.helidon.service.registry.Services;
 import io.helidon.testing.junit5.Testing;
 
 import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.service.TokenStream;
 import dev.langchain4j.service.SystemMessage;
 import org.junit.jupiter.api.Test;
 
@@ -66,9 +67,9 @@ public class MockStreamingTest {
                     return "Custom manually added response!";
                 }
             });
-            assertThat(aiService.chat("Custom rule match").collect(Collectors.joining()),
+            assertThat(join(aiService.chat("Custom rule match")),
                        is("Custom manually added response!"));
-            assertThat(aiService.chat("Custom rule match").toList(),
+            assertThat(tokens(aiService.chat("Custom rule match")),
                        contains("Custom manually added response!".splitWithDelimiters("\\s", 0)));
         } finally {
             model.resetRules();
@@ -80,7 +81,20 @@ public class MockStreamingTest {
     public interface HelidonSupportService {
 
         @SystemMessage("You are a Helidon expert!")
-        Stream<String> chat(String prompt);
+        TokenStream chat(String prompt);
     }
 
+    private static String join(TokenStream tokenStream) {
+        return String.join("", tokens(tokenStream));
+    }
+
+    private static List<String> tokens(TokenStream tokenStream) {
+        CompletableFuture<List<String>> response = new CompletableFuture<>();
+        List<String> tokens = new java.util.concurrent.CopyOnWriteArrayList<>();
+        tokenStream.onPartialResponse(tokens::add)
+                .onCompleteResponse(ignored -> response.complete(List.copyOf(tokens)))
+                .onError(response::completeExceptionally)
+                .start();
+        return response.join();
+    }
 }

--- a/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/ConfigDrivenStreamingExpert.java
+++ b/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/ConfigDrivenStreamingExpert.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.tests.agentic;
+
+import io.helidon.extensions.langchain4j.Ai;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+
+@Ai.Agent("config-driven-streaming-expert")
+public interface ConfigDrivenStreamingExpert {
+
+    @UserMessage("""
+            You are a config-driven streaming Helidon expert.
+            Reply with a short answer about Helidon.
+            The user request is {{request}}.
+            """)
+    @Agent(value = "A config-driven streaming Helidon expert", outputKey = "response")
+    TokenStream askExpert(@V("request") String request);
+}

--- a/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonChainedSequenceAgent.java
+++ b/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonChainedSequenceAgent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.tests.agentic;
+
+import io.helidon.extensions.langchain4j.Ai;
+
+import dev.langchain4j.agentic.declarative.SequenceAgent;
+import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.service.V;
+
+@Ai.Agent("streaming-helidon-chained-sequence-agent")
+@Ai.StreamingChatModel("streaming-mock-model")
+public interface StreamingHelidonChainedSequenceAgent {
+
+    @SequenceAgent(outputKey = "response", subAgents = {
+            StreamingHelidonDraftExpert.class,
+            StreamingHelidonResponseExpert.class
+    })
+    TokenStream askExpert(@V("request") String request);
+}

--- a/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonDraftExpert.java
+++ b/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonDraftExpert.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.tests.agentic;
+
+import io.helidon.extensions.langchain4j.Ai;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+
+@Ai.Agent("streaming-helidon-draft-expert")
+@Ai.StreamingChatModel("streaming-mock-model")
+public interface StreamingHelidonDraftExpert {
+
+    @UserMessage("""
+            Create a short streaming Helidon draft for the request.
+            Return only the draft and nothing else.
+            The user request is {{request}}.
+            """)
+    @Agent(value = "A streaming Helidon draft expert", outputKey = "draft")
+    TokenStream createDraft(@V("request") String request);
+}

--- a/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonExpert.java
+++ b/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonExpert.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.tests.agentic;
+
+import io.helidon.extensions.langchain4j.Ai;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+
+@Ai.Agent("streaming-helidon-expert")
+@Ai.StreamingChatModel("streaming-mock-model")
+public interface StreamingHelidonExpert {
+
+    @UserMessage("""
+            You are a streaming Helidon expert.
+            Reply with a short answer about Helidon.
+            The user request is {{request}}.
+            """)
+    @Agent(value = "A streaming Helidon expert", outputKey = "response")
+    TokenStream askExpert(@V("request") String request);
+}

--- a/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonResponseExpert.java
+++ b/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonResponseExpert.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.tests.agentic;
+
+import io.helidon.extensions.langchain4j.Ai;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+
+@Ai.Agent("streaming-helidon-response-expert")
+@Ai.StreamingChatModel("streaming-mock-model")
+public interface StreamingHelidonResponseExpert {
+
+    @UserMessage("""
+            Transform the streaming draft into the final Helidon response.
+            Return only the final response and nothing else.
+            The original request is {{request}}.
+            The draft is "{{draft}}".
+            """)
+    @Agent(value = "A streaming Helidon response expert", outputKey = "response")
+    TokenStream createResponse(@V("draft") String draft, @V("request") String request);
+}

--- a/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonSequenceAgent.java
+++ b/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonSequenceAgent.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.tests.agentic;
+
+import io.helidon.extensions.langchain4j.Ai;
+
+import dev.langchain4j.agentic.declarative.SequenceAgent;
+import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.service.V;
+
+@Ai.Agent("streaming-helidon-sequence-agent")
+@Ai.StreamingChatModel("streaming-mock-model")
+public interface StreamingHelidonSequenceAgent {
+
+    @SequenceAgent(outputKey = "response", subAgents = {
+            StreamingHelidonSubExpert.class
+    })
+    TokenStream askExpert(@V("request") String request);
+}

--- a/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonSubExpert.java
+++ b/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonSubExpert.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.tests.agentic;
+
+import io.helidon.extensions.langchain4j.Ai;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+
+@Ai.Agent("streaming-helidon-sub-expert")
+public interface StreamingHelidonSubExpert {
+
+    @UserMessage("""
+            You are a streaming Helidon sub-expert.
+            Reply with a short answer about Helidon.
+            The user request is {{request}}.
+            """)
+    @Agent(value = "A streaming Helidon sub-expert", outputKey = "response")
+    TokenStream askExpert(@V("request") String request);
+}

--- a/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonSummarizedContextExpert.java
+++ b/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonSummarizedContextExpert.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.tests.agentic;
+
+import io.helidon.extensions.langchain4j.Ai;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+
+@Ai.Agent("streaming-helidon-summarized-context-expert")
+@Ai.StreamingChatModel("streaming-mock-model")
+public interface StreamingHelidonSummarizedContextExpert {
+
+    @UserMessage("""
+            Use the summarized Helidon context to answer {{request}}.
+            """)
+    @Agent(value = "A streaming Helidon summarized-context expert",
+           outputKey = "response",
+           summarizedContext = {"draft-source"})
+    TokenStream askExpert(@V("request") String request);
+}

--- a/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonSummarizedContextSequenceAgent.java
+++ b/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonSummarizedContextSequenceAgent.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.tests.agentic;
+
+import io.helidon.extensions.langchain4j.Ai;
+
+import dev.langchain4j.agentic.declarative.SequenceAgent;
+import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.service.V;
+
+@Ai.Agent("streaming-helidon-summarized-context-sequence-agent")
+@Ai.StreamingChatModel("streaming-mock-model")
+public interface StreamingHelidonSummarizedContextSequenceAgent {
+
+    @SequenceAgent(outputKey = "response", subAgents = {
+            StreamingHelidonSummarySourceExpert.class,
+            StreamingHelidonSummarizedContextExpert.class
+    })
+    TokenStream askExpert(@V("request") String request);
+}

--- a/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonSummarySourceExpert.java
+++ b/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonSummarySourceExpert.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.tests.agentic;
+
+import io.helidon.extensions.langchain4j.Ai;
+
+import dev.langchain4j.agentic.Agent;
+import dev.langchain4j.service.TokenStream;
+import dev.langchain4j.service.UserMessage;
+import dev.langchain4j.service.V;
+
+@Ai.Agent("streaming-helidon-summary-source")
+@Ai.StreamingChatModel("streaming-mock-model")
+public interface StreamingHelidonSummarySourceExpert {
+
+    @UserMessage("""
+            Create a short streaming Helidon summary for {{request}}.
+            """)
+    @Agent(name = "draft-source", value = "A streaming Helidon summary source", outputKey = "draft")
+    TokenStream createDraft(@V("request") String request);
+}

--- a/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonSupervisorAgent.java
+++ b/langchain4j/tests/agentic/src/main/java/io/helidon/extensions/langchain4j/tests/agentic/StreamingHelidonSupervisorAgent.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.tests.agentic;
+
+import io.helidon.extensions.langchain4j.Ai;
+
+import dev.langchain4j.agentic.declarative.SupervisorAgent;
+import dev.langchain4j.service.V;
+
+@Ai.Agent("streaming-helidon-supervisor-agent")
+@Ai.StreamingChatModel("streaming-mock-model")
+public interface StreamingHelidonSupervisorAgent {
+
+    @SupervisorAgent(outputKey = "response", subAgents = {
+            StreamingHelidonSubExpert.class
+    })
+    String askExpert(@V("request") String request);
+}

--- a/langchain4j/tests/agentic/src/test/java/io/helidon/extensions/langchain4j/tests/agentic/AgentTest.java
+++ b/langchain4j/tests/agentic/src/test/java/io/helidon/extensions/langchain4j/tests/agentic/AgentTest.java
@@ -18,6 +18,7 @@ package io.helidon.extensions.langchain4j.tests.agentic;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.stream.Stream;
 
 import io.helidon.extensions.langchain4j.providers.mock.MockChatModel;
@@ -36,6 +37,7 @@ import dev.langchain4j.guardrail.GuardrailException;
 import dev.langchain4j.model.chat.request.ChatRequest;
 import dev.langchain4j.model.chat.response.ChatResponse;
 import dev.langchain4j.model.output.FinishReason;
+import dev.langchain4j.service.TokenStream;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 
@@ -138,5 +140,64 @@ public class AgentTest {
         assertTrue(guardrailRootCause.isPresent());
         assertThat(guardrailRootCause.get().getMessage(),
                    containsString("Inappropriate Helidon question! Prompt containing: reactive"));
+    }
+
+    @Test
+    void streamingAnnotatedAgentTest() {
+        var streamingHelidonExpert = Services.get(StreamingHelidonExpert.class);
+        var response = collect(streamingHelidonExpert.askExpert("streaming simple test"));
+        assertThat(response, is("Simple streaming response!"));
+    }
+
+    @Test
+    void streamingSequenceAgentTest() {
+        var streamingHelidonExpert = Services.get(StreamingHelidonSequenceAgent.class);
+        var response = collect(streamingHelidonExpert.askExpert("streaming sequence test"));
+        assertThat(response, is("Sequence streaming response!"));
+    }
+
+    @Test
+    void streamingSequenceOutputHandoffTest() {
+        var streamingHelidonExpert = Services.get(StreamingHelidonChainedSequenceAgent.class);
+        var response = collect(streamingHelidonExpert.askExpert("streaming chained handoff test"));
+        assertThat(response, is("Chained streaming response!"));
+    }
+
+    @Test
+    void streamingConfigDrivenAgentTest() {
+        var streamingHelidonExpert = Services.get(ConfigDrivenStreamingExpert.class);
+        var response = collect(streamingHelidonExpert.askExpert("streaming config test"));
+        assertThat(response, is("Config streaming response!"));
+    }
+
+    @Test
+    void streamingSupervisorRequiresChatModelTest() {
+        assertIllegalStateException(() -> Services.get(StreamingHelidonSupervisorAgent.class));
+    }
+
+    @Test
+    void streamingSummarizedContextSubAgentRequiresChatModelTest() {
+        assertIllegalStateException(() -> Services.get(StreamingHelidonSummarizedContextSequenceAgent.class));
+    }
+
+    void assertIllegalStateException(Executable executable) {
+        Throwable ex = assertThrows(Throwable.class, executable);
+        var illegalStateRootCause = Stream.iterate(ex, Objects::nonNull, Throwable::getCause)
+                .filter(e -> e instanceof IllegalStateException)
+                .findFirst()
+                .map(IllegalStateException.class::cast);
+        assertTrue(illegalStateRootCause.isPresent());
+        assertThat(illegalStateRootCause.get().getMessage(),
+                   containsString("requires chat-model"));
+    }
+
+    private static String collect(TokenStream tokenStream) {
+        CompletableFuture<String> response = new CompletableFuture<>();
+        StringBuilder builder = new StringBuilder();
+        tokenStream.onPartialResponse(builder::append)
+                .onCompleteResponse(ignored -> response.complete(builder.toString()))
+                .onError(response::completeExceptionally)
+                .start();
+        return response.join();
     }
 }

--- a/langchain4j/tests/agentic/src/test/resources/application.yaml
+++ b/langchain4j/tests/agentic/src/test/resources/application.yaml
@@ -20,6 +20,8 @@ app:
 
 langchain4j:
   agents:
+    config-driven-streaming-expert:
+      streaming-chat-model: streaming-mock-model
     flavor-classifier:
       chat-model: test-mock-model
     helidon-se-expert:
@@ -50,3 +52,16 @@ langchain4j:
           response: please retry me res
         - pattern: (?si).*imperative.*
           response: I am SE expert!
+    streaming-mock-model:
+      provider: helidon-mock
+      rules:
+        - pattern: (?si).*streaming simple test.*
+          response: Simple streaming response!
+        - pattern: (?si).*streaming sequence test.*
+          response: Sequence streaming response!
+        - pattern: (?si).*Create a short streaming Helidon draft.*streaming chained handoff test.*
+          response: intermediate streaming draft
+        - pattern: (?si).*Transform the streaming draft into the final Helidon response.*intermediate streaming draft.*
+          response: Chained streaming response!
+        - pattern: (?si).*streaming config test.*
+          response: Config streaming response!


### PR DESCRIPTION
Resolves helidon-io/helidon#11131

Summary:
- add `@Ai.StreamingChatModel` handling for `@Ai.Agent`, including config-driven selection for root and sub-agents
- expose `TokenStream` as the public agent streaming API and remove the generated internal-agent and proxy bridge
- add agentic streaming coverage for direct agents, sequences, chained handoff, config-driven agents, and streaming-only validation cases

Testing:
- `mvn -Ptests -pl tests/agentic -am test -Dtest=AgentTest -Dsurefire.failIfNoSpecifiedTests=false`
- `mvn -pl modules/providers/mock -am test -Dtest=MockStreamingTest -Dsurefire.failIfNoSpecifiedTests=false`
- `mvn checkstyle:checkstyle-aggregate -Dcheckstyle.output.format=plain -Dcheckstyle.output.file=/tmp/langchain4j-checkstyle.txt`
- `mvn -N -Dhelidon.enforcer.output.file=/tmp/langchain4j-copyright.txt -Dhelidon.enforcer.rules=copyright -Dhelidon.enforcer.failOnError=false -Pcopyright validate`
