### PR TITLE
Fix helidon-config-metadata group id references

### DIFF
--- a/extensions/eureka/modules/eureka-discovery/pom.xml
+++ b/extensions/eureka/modules/eureka-discovery/pom.xml
@@ -54,7 +54,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/eureka/modules/eureka/pom.xml
+++ b/extensions/eureka/modules/eureka/pom.xml
@@ -50,7 +50,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/gson/modules/gson-media/pom.xml
+++ b/extensions/gson/modules/gson-media/pom.xml
@@ -33,7 +33,7 @@
 
     <dependencies>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/hashicorp-vault/modules/vault/pom.xml
+++ b/extensions/hashicorp-vault/modules/vault/pom.xml
@@ -65,7 +65,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/langchain4j/modules/langchain4j/pom.xml
+++ b/extensions/langchain4j/modules/langchain4j/pom.xml
@@ -47,7 +47,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/langchain4j/modules/providers/cohere/pom.xml
+++ b/extensions/langchain4j/modules/providers/cohere/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/langchain4j/modules/providers/coherence/pom.xml
+++ b/extensions/langchain4j/modules/providers/coherence/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/langchain4j/modules/providers/google-gemini/pom.xml
+++ b/extensions/langchain4j/modules/providers/google-gemini/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/langchain4j/modules/providers/jlama/pom.xml
+++ b/extensions/langchain4j/modules/providers/jlama/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/langchain4j/modules/providers/lc4j-in-process/pom.xml
+++ b/extensions/langchain4j/modules/providers/lc4j-in-process/pom.xml
@@ -48,7 +48,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/langchain4j/modules/providers/mock/pom.xml
+++ b/extensions/langchain4j/modules/providers/mock/pom.xml
@@ -36,7 +36,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/langchain4j/modules/providers/ollama/pom.xml
+++ b/extensions/langchain4j/modules/providers/ollama/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/langchain4j/modules/providers/open-ai/pom.xml
+++ b/extensions/langchain4j/modules/providers/open-ai/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/langchain4j/modules/providers/oracle-genai/pom.xml
+++ b/extensions/langchain4j/modules/providers/oracle-genai/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/langchain4j/modules/providers/oracle/pom.xml
+++ b/extensions/langchain4j/modules/providers/oracle/pom.xml
@@ -35,7 +35,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/neo4j/modules/neo4j/pom.xml
+++ b/extensions/neo4j/modules/neo4j/pom.xml
@@ -51,7 +51,7 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/oci-v3/modules/metrics/metrics/pom.xml
+++ b/extensions/oci-v3/modules/metrics/metrics/pom.xml
@@ -46,7 +46,7 @@
             <artifactId>oci-java-sdk-monitoring</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/oci-v3/modules/oci/pom.xml
+++ b/extensions/oci-v3/modules/oci/pom.xml
@@ -41,7 +41,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/oci-v3/modules/tls-certificates/pom.xml
+++ b/extensions/oci-v3/modules/tls-certificates/pom.xml
@@ -64,7 +64,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>

--- a/extensions/openapi-ui/modules/openapi-ui/pom.xml
+++ b/extensions/openapi-ui/modules/openapi-ui/pom.xml
@@ -54,7 +54,7 @@
             <artifactId>helidon-config</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.helidon.config</groupId>
+            <groupId>io.helidon.config.metadata</groupId>
             <artifactId>helidon-config-metadata</artifactId>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
Resolves #59

Updates the affected extension module POMs to use `io.helidon.config.metadata:helidon-config-metadata`, matching the Helidon 27 BOM after the artifact group relocation.
