### PR TITLE
Use build cache for checkstyle validation

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -81,6 +81,7 @@ jobs:
           ref: ${{ inputs.ref }}
       - uses: ./.github/actions/common
         with:
+          build-cache: read-only
           run: etc/scripts/checkstyle.sh
   shellcheck:
     timeout-minutes: 5


### PR DESCRIPTION
The `checkstyle` job currently restores only the generic Maven cache, while the module validation jobs also restore the per-run build cache populated by `prime-build`.

Restore the build cache for `checkstyle` as well so it resolves the same primed Helidon snapshot artifacts as the other validation jobs.
