### PR TITLE
  Add OpenAPI composed-schema model generation and docs

### DIFF
--- a/extensions/openapi-generator/docs/ARCHITECTURE.md
+++ b/extensions/openapi-generator/docs/ARCHITECTURE.md
@@ -122,6 +122,12 @@ imports that are not appropriate for the Helidon-generated output, such as Swagg
 annotation shorthands and Jackson-specific nullable wrappers that are not used by the
 templates.
 
+This stage also detects composed schemas:
+
+- `allOf` continues through the normal model path and is rendered as a merged POJO
+- `oneOf` and `anyOf` are marked for wrapper-style rendering using generated vendor
+  extensions derived from upstream `CodegenComposedSchemas`
+
 ### `fromOperation`
 
 Operation processing enriches each `CodegenOperation` with Helidon-specific vendor
@@ -192,6 +198,8 @@ Current templates:
 - `api.mustache` emits the endpoint stub implementation.
 - `restClient.mustache` extends the shared API contract to reuse HTTP annotations.
 - `model.mustache` generates model classes rather than records.
+- `model.mustache` renders `oneOf` and `anyOf` schemas as wrapper models with generated
+  Helidon `@Json.Converter` implementations and typed variant accessors.
 - `api.mustache` does not emit `@RestServer.Listener`, because the default listener is
   already implied.
 
@@ -208,6 +216,9 @@ Per tag:
 Per schema:
 
 - `{Model}.java`
+  For plain schemas and `allOf`, this is a standard POJO.
+  For `oneOf` and `anyOf`, this is a wrapper model around `JsonValue` with variant-aware
+  matching and serialization support.
 
 Project-level support:
 
@@ -247,6 +258,7 @@ Representative tests:
 - `PetstoreGenerationIT`
 - `FeaturesGenerationIT`
 - `FeaturesAvoidOptionalListParamsIT`
+- `ComposedSchemaGenerationIT`
 - `FormGenerationIT`
 - `ValidationGenerationIT`
 - `ValidationPrivateFieldIT`

--- a/extensions/openapi-generator/docs/README.md
+++ b/extensions/openapi-generator/docs/README.md
@@ -174,7 +174,7 @@ Per schema:
 
 | File | Description |
 |------|-------------|
-| `{Model}.java` | Helidon JSON model type with generated validation and enum support |
+| `{Model}.java` | Helidon JSON model type with generated validation, enum support, and composed-schema handling |
 
 Supporting files:
 
@@ -190,6 +190,18 @@ Supporting files:
 | `src/main/resources/META-INF/openapi.yaml` | Copied spec, if `serverOpenApi=true` |
 
 ## OpenAPI Mapping Notes
+
+### Composed Schemas
+
+The generator supports OpenAPI composed schemas:
+
+- `allOf` generates a single POJO with merged properties and combined required fields
+- `oneOf` generates a wrapper model with generated typed accessors, factory methods, and exact-one validation
+- `anyOf` generates a wrapper model with generated typed accessors, factory methods, and at-least-one validation
+
+For `oneOf` and `anyOf`, the generated model stores the raw JSON payload and uses a generated
+Helidon `@Json.Converter` to preserve composed-schema semantics during serialization and
+deserialization. This avoids flattening distinct variants into a single permissive POJO.
 
 ### Parameters
 
@@ -226,6 +238,7 @@ and covers:
 
 - petstore-style generation
 - feature coverage and validation
+- composed-schema support (`oneOf`, `anyOf`, `allOf`)
 - form and multipart handling
 - security
 - observability options

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -26,14 +26,19 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
+import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.ComposedSchema;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.servers.Server;
+import org.openapitools.codegen.CodegenComposedSchemas;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenOperation;
 import org.openapitools.codegen.CodegenParameter;
@@ -93,6 +98,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
     private boolean metricsEnabled = false;
     private boolean avoidOptionalListParams = false;
     private List<SecurityRequirement> globalSecurityRequirements = List.of();
+    private OpenAPI currentOpenAPI;
 
     /**
      * Creates a new generator with default options and template mappings.
@@ -327,6 +333,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
     @Override
     public void preprocessOpenAPI(io.swagger.v3.oas.models.OpenAPI openAPI) {
         super.preprocessOpenAPI(openAPI);
+        currentOpenAPI = openAPI;
         globalSecurityRequirements = openAPI.getSecurity() == null
                 ? List.of()
                 : new ArrayList<>(openAPI.getSecurity());
@@ -377,6 +384,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         model.imports.remove("JsonInclude");
         model.imports.remove("JsonProperty");
         model.imports.remove("JsonNullable");   // openApiNullable wrapper — not used in our template
+        applyComposedModelMetadata(model);
         return model;
     }
 
@@ -756,6 +764,9 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             ModelsMap modelsMap = entry.getValue();
             for (ModelMap modelContainer : modelsMap.getModels()) {
                 var model = modelContainer.getModel();
+                if (Boolean.TRUE.equals(model.vendorExtensions.get("x-is-composed-wrapper"))) {
+                    continue;
+                }
                 boolean modelHasValidation = false;
 
                 for (CodegenProperty prop : model.vars) {
@@ -1095,5 +1106,352 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         } catch (ArithmeticException | NumberFormatException ignored) {
             return null;
         }
+    }
+
+    private void applyComposedModelMetadata(CodegenModel model) {
+        CodegenComposedSchemas composedSchemas = model.getComposedSchemas();
+        if (composedSchemas == null) {
+            return;
+        }
+
+        String composedKind;
+        List<CodegenProperty> variants;
+        if (composedSchemas.getOneOf() != null && !composedSchemas.getOneOf().isEmpty()) {
+            composedKind = "oneOf";
+            variants = composedSchemas.getOneOf();
+        } else if (composedSchemas.getAnyOf() != null && !composedSchemas.getAnyOf().isEmpty()) {
+            composedKind = "anyOf";
+            variants = composedSchemas.getAnyOf();
+        } else {
+            return;
+        }
+
+        List<Map<String, Object>> composedVariants = new ArrayList<>();
+        Set<String> usedSuffixes = new LinkedHashSet<>();
+        for (int i = 0; i < variants.size(); i++) {
+            CodegenProperty variant = variants.get(i);
+            composedVariants.add(buildComposedVariantMetadata(model, variant, i, usedSuffixes));
+        }
+        markLast(composedVariants);
+
+        model.vendorExtensions.put("x-is-composed-wrapper", Boolean.TRUE);
+        model.vendorExtensions.put("x-composed-kind", composedKind);
+        model.vendorExtensions.put("x-is-oneof-wrapper", "oneOf".equals(composedKind));
+        model.vendorExtensions.put("x-is-anyof-wrapper", "anyOf".equals(composedKind));
+        model.vendorExtensions.put("x-composed-variants", composedVariants);
+    }
+
+    private Map<String, Object> buildComposedVariantMetadata(CodegenModel model,
+                                                             CodegenProperty variant,
+                                                             int index,
+                                                             Set<String> usedSuffixes) {
+        Map<String, Object> result = new HashMap<>();
+        String rawTypeName = variant.complexType != null && !variant.complexType.isBlank()
+                ? variant.complexType
+                : variant.dataType;
+        String methodSuffix = uniqueVariantMethodSuffix(rawTypeName, index, usedSuffixes);
+        String schemaName = schemaNameForVariant(variant);
+        String typeConstantName = "TYPE_" + methodSuffix.toUpperCase();
+        SchemaMatchInfo matchInfo = schemaMatchInfo(variant, schemaName);
+
+        result.put("dataType", variant.dataType);
+        result.put("methodSuffix", methodSuffix);
+        result.put("typeConstantName", typeConstantName);
+        result.put("matcherMethodName", "matches" + methodSuffix);
+        result.put("factoryMethodName", "of" + methodSuffix);
+        result.put("predicateMethodName", "is" + methodSuffix);
+        result.put("accessorMethodName", "as" + methodSuffix);
+        result.put("displayName", rawTypeName);
+        result.put("jsonType", matchInfo.jsonType());
+        result.put("integralNumber", matchInfo.integralNumber());
+        result.put("nullable", matchInfo.nullable());
+        result.put("usesComposedMatcher", matchInfo.usesComposedMatcher());
+        result.put("isObjectVariant", "OBJECT".equals(matchInfo.jsonType()) && !matchInfo.usesComposedMatcher());
+        result.put("explicitAdditionalPropertiesFalse", matchInfo.explicitAdditionalPropertiesFalse());
+        String discriminatorProperty = discriminatorProperty(model);
+        List<String> discriminatorAliases = discriminatorAliases(model, schemaName);
+        result.put("discriminatorProperty", discriminatorProperty);
+        result.put("hasDiscriminatorProperty", discriminatorProperty != null);
+        result.put("discriminatorAliases", toTemplateStrings(discriminatorAliases));
+        result.put("hasDiscriminatorAliases", !discriminatorAliases.isEmpty());
+        result.put("requiredProperties", toTemplateStrings(matchInfo.requiredProperties()));
+        result.put("hasRequiredProperties", !matchInfo.requiredProperties().isEmpty());
+        result.put("knownProperties", toTemplateStrings(matchInfo.knownProperties()));
+        result.put("hasKnownProperties", !matchInfo.knownProperties().isEmpty());
+        return result;
+    }
+
+    private List<Map<String, String>> toTemplateStrings(List<String> values) {
+        List<Map<String, String>> result = new ArrayList<>();
+        for (int i = 0; i < values.size(); i++) {
+            Map<String, String> entry = new HashMap<>();
+            entry.put("value", values.get(i));
+            entry.put("-last", String.valueOf(i == values.size() - 1));
+            result.add(entry);
+        }
+        return result;
+    }
+
+    private void markLast(List<Map<String, Object>> entries) {
+        for (int i = 0; i < entries.size(); i++) {
+            entries.get(i).put("-last", i == entries.size() - 1);
+        }
+    }
+
+    private String uniqueVariantMethodSuffix(String rawTypeName, int index, Set<String> usedSuffixes) {
+        String candidate = camelize(sanitizeName(rawTypeName == null ? "" : rawTypeName));
+        if (candidate == null || candidate.isBlank()) {
+            candidate = "Variant" + (index + 1);
+        }
+
+        String unique = candidate;
+        int suffix = 2;
+        while (!usedSuffixes.add(unique)) {
+            unique = candidate + suffix;
+            suffix++;
+        }
+        return unique;
+    }
+
+    private String schemaNameForVariant(CodegenProperty variant) {
+        if (variant.getRef() != null && !variant.getRef().isBlank()) {
+            return variant.getRef().substring(variant.getRef().lastIndexOf('/') + 1);
+        }
+        if (variant.complexType != null && !variant.complexType.isBlank()
+                && currentOpenAPI != null
+                && currentOpenAPI.getComponents() != null
+                && currentOpenAPI.getComponents().getSchemas() != null
+                && currentOpenAPI.getComponents().getSchemas().containsKey(variant.complexType)) {
+            return variant.complexType;
+        }
+        return null;
+    }
+
+    private SchemaMatchInfo schemaMatchInfo(CodegenProperty variant, String schemaName) {
+        if (schemaName != null) {
+            Schema schema = resolveSchemaByName(schemaName);
+            if (schema != null) {
+                return schemaMatchInfo(schemaName, schema, new LinkedHashSet<>());
+            }
+        }
+
+        if (variant.isArray) {
+            return new SchemaMatchInfo("ARRAY", false, false, false,
+                    null, List.of(), List.of());
+        }
+        if (variant.isBoolean) {
+            return new SchemaMatchInfo("BOOLEAN", false, false, false,
+                    null, List.of(), List.of());
+        }
+        if (variant.isInteger || variant.isLong || variant.isShort || variant.isUnboundedInteger) {
+            return new SchemaMatchInfo("NUMBER", true, false, false,
+                    null, List.of(), List.of());
+        }
+        if (variant.isNumber || variant.isFloat || variant.isDouble || variant.isDecimal) {
+            return new SchemaMatchInfo("NUMBER", false, false, false,
+                    null, List.of(), List.of());
+        }
+        if (variant.isString || variant.isDate || variant.isDateTime || variant.isUuid || variant.isUri) {
+            return new SchemaMatchInfo("STRING", false, false, false,
+                    null, List.of(), List.of());
+        }
+        if (variant.isMap || variant.isFreeFormObject) {
+            return new SchemaMatchInfo("OBJECT", false, false, false,
+                    null, List.of(), List.of());
+        }
+        return new SchemaMatchInfo("UNKNOWN", false, false, false,
+                null, List.of(), List.of());
+    }
+
+    private SchemaMatchInfo schemaMatchInfo(String schemaName, Schema schema, Set<String> seenSchemas) {
+        Schema resolvedSchema = dereferenceSchema(schema, seenSchemas);
+        if (resolvedSchema == null) {
+            return new SchemaMatchInfo("UNKNOWN", false, false, false,
+                    null, List.of(), List.of());
+        }
+
+        boolean nullable = Boolean.TRUE.equals(resolvedSchema.getNullable());
+        if (isUnionSchema(resolvedSchema)) {
+            return new SchemaMatchInfo("UNKNOWN", false, nullable, true,
+                    null, List.of(), List.of());
+        }
+
+        if (isObjectSchema(resolvedSchema)) {
+            ObjectShape objectShape = objectShape(resolvedSchema, new LinkedHashSet<>(seenSchemas));
+            return new SchemaMatchInfo("OBJECT",
+                    false,
+                    nullable,
+                    false,
+                    null,
+                    List.of(),
+                    new ArrayList<>(objectShape.requiredProperties()),
+                    new ArrayList<>(objectShape.knownProperties()),
+                    objectShape.explicitAdditionalPropertiesFalse());
+        }
+
+        String type = resolvedSchema.getType();
+        if ("array".equals(type)) {
+            return new SchemaMatchInfo("ARRAY", false, nullable, false,
+                    null, List.of(), List.of());
+        }
+        if ("boolean".equals(type)) {
+            return new SchemaMatchInfo("BOOLEAN", false, nullable, false,
+                    null, List.of(), List.of());
+        }
+        if ("integer".equals(type)) {
+            return new SchemaMatchInfo("NUMBER", true, nullable, false,
+                    null, List.of(), List.of());
+        }
+        if ("number".equals(type)) {
+            return new SchemaMatchInfo("NUMBER", false, nullable, false,
+                    null, List.of(), List.of());
+        }
+        if ("string".equals(type)) {
+            return new SchemaMatchInfo("STRING", false, nullable, false,
+                    null, List.of(), List.of());
+        }
+
+        return new SchemaMatchInfo("UNKNOWN", false, nullable, false,
+                null, List.of(), List.of());
+    }
+
+    private Schema dereferenceSchema(Schema schema, Set<String> seenSchemas) {
+        if (schema == null || currentOpenAPI == null || currentOpenAPI.getComponents() == null
+                || currentOpenAPI.getComponents().getSchemas() == null) {
+            return schema;
+        }
+
+        if (schema.get$ref() == null || schema.get$ref().isBlank()) {
+            return schema;
+        }
+
+        String schemaName = schema.get$ref().substring(schema.get$ref().lastIndexOf('/') + 1);
+        if (!seenSchemas.add(schemaName)) {
+            return schema;
+        }
+
+        return currentOpenAPI.getComponents().getSchemas().getOrDefault(schemaName, schema);
+    }
+
+    private Schema resolveSchemaByName(String schemaName) {
+        if (currentOpenAPI == null || currentOpenAPI.getComponents() == null
+                || currentOpenAPI.getComponents().getSchemas() == null) {
+            return null;
+        }
+        return currentOpenAPI.getComponents().getSchemas().get(schemaName);
+    }
+
+    private boolean isUnionSchema(Schema schema) {
+        if (!(schema instanceof ComposedSchema composedSchema)) {
+            return false;
+        }
+        return (composedSchema.getOneOf() != null && !composedSchema.getOneOf().isEmpty())
+                || (composedSchema.getAnyOf() != null && !composedSchema.getAnyOf().isEmpty());
+    }
+
+    private boolean isObjectSchema(Schema schema) {
+        if (schema == null) {
+            return false;
+        }
+        if ("object".equals(schema.getType())) {
+            return true;
+        }
+        if (schema.getProperties() != null && !schema.getProperties().isEmpty()) {
+            return true;
+        }
+        if (schema instanceof ComposedSchema composedSchema
+                && composedSchema.getAllOf() != null
+                && !composedSchema.getAllOf().isEmpty()) {
+            return true;
+        }
+        return schema.getAdditionalProperties() != null;
+    }
+
+    private ObjectShape objectShape(Schema schema, Set<String> seenSchemas) {
+        Schema resolvedSchema = dereferenceSchema(schema, seenSchemas);
+        if (resolvedSchema == null) {
+            return new ObjectShape(Set.of(), Set.of(), false);
+        }
+
+        Set<String> requiredProperties = new LinkedHashSet<>();
+        Set<String> knownProperties = new LinkedHashSet<>();
+        boolean explicitAdditionalPropertiesFalse = Boolean.FALSE.equals(resolvedSchema.getAdditionalProperties());
+
+        if (resolvedSchema.getRequired() != null) {
+            requiredProperties.addAll(resolvedSchema.getRequired());
+        }
+        if (resolvedSchema.getProperties() != null) {
+            knownProperties.addAll(resolvedSchema.getProperties().keySet());
+        }
+
+        if (resolvedSchema instanceof ComposedSchema composedSchema
+                && composedSchema.getAllOf() != null) {
+            for (Schema nestedSchema : composedSchema.getAllOf()) {
+                ObjectShape nestedShape = objectShape(nestedSchema, new LinkedHashSet<>(seenSchemas));
+                requiredProperties.addAll(nestedShape.requiredProperties());
+                knownProperties.addAll(nestedShape.knownProperties());
+                explicitAdditionalPropertiesFalse =
+                        explicitAdditionalPropertiesFalse || nestedShape.explicitAdditionalPropertiesFalse();
+            }
+        }
+
+        return new ObjectShape(requiredProperties, knownProperties, explicitAdditionalPropertiesFalse);
+    }
+
+    private String discriminatorProperty(CodegenModel model) {
+        if (model.discriminator == null) {
+            return null;
+        }
+        if (model.discriminator.getPropertyBaseName() != null && !model.discriminator.getPropertyBaseName().isBlank()) {
+            return model.discriminator.getPropertyBaseName();
+        }
+        return model.discriminator.getPropertyName();
+    }
+
+    private List<String> discriminatorAliases(CodegenModel model, String schemaName) {
+        if (model.discriminator == null || schemaName == null) {
+            return List.of();
+        }
+
+        Set<String> aliases = new LinkedHashSet<>();
+        Map<String, String> mapping = model.discriminator.getMapping();
+        if (mapping != null) {
+            String schemaRef = "#/components/schemas/" + schemaName;
+            mapping.forEach((alias, target) -> {
+                if (schemaName.equals(target) || schemaRef.equals(target)) {
+                    aliases.add(alias);
+                }
+            });
+        }
+        if (aliases.isEmpty()) {
+            aliases.add(schemaName);
+        }
+        return new ArrayList<>(aliases);
+    }
+
+    private record SchemaMatchInfo(String jsonType,
+                                   boolean integralNumber,
+                                   boolean nullable,
+                                   boolean usesComposedMatcher,
+                                   String discriminatorProperty,
+                                   List<String> discriminatorAliases,
+                                   List<String> requiredProperties,
+                                   List<String> knownProperties,
+                                   boolean explicitAdditionalPropertiesFalse) {
+        private SchemaMatchInfo(String jsonType,
+                                boolean integralNumber,
+                                boolean nullable,
+                                boolean usesComposedMatcher,
+                                String discriminatorProperty,
+                                List<String> requiredProperties,
+                                List<String> knownProperties) {
+            this(jsonType, integralNumber, nullable, usesComposedMatcher,
+                    discriminatorProperty, List.of(), requiredProperties, knownProperties, false);
+        }
+    }
+
+    private record ObjectShape(Set<String> requiredProperties,
+                               Set<String> knownProperties,
+                               boolean explicitAdditionalPropertiesFalse) {
     }
 }

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
@@ -22,6 +22,258 @@ import io.helidon.json.binding.Json;
 import {{import}};
 {{/imports}}
 {{#model}}
+{{#vendorExtensions.x-is-composed-wrapper}}
+import java.util.Objects;
+import java.util.Optional;
+
+import io.helidon.common.GenericType;
+import io.helidon.json.JsonGenerator;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonParser;
+import io.helidon.json.JsonValue;
+import io.helidon.json.JsonValueType;
+import io.helidon.json.binding.JsonBinding;
+import io.helidon.json.binding.JsonConverter;
+
+/**
+ * {{description}}{{^description}}{{classname}} {{vendorExtensions.x-composed-kind}} wrapper.{{/description}}
+ *
+ * <p>This generated model preserves {{vendorExtensions.x-composed-kind}} semantics by storing
+ * the raw JSON value and exposing typed accessors for each supported variant.</p>
+ */
+@Json.Converter({{classname}}.{{classname}}JsonConverter.class)
+{{#isDeprecated}}@Deprecated
+{{/isDeprecated}}public final class {{classname}} {
+
+    private static final JsonBinding JSON_BINDING = JsonBinding.create();
+    private static final GenericType<{{classname}}> SELF_TYPE = new GenericType<{{classname}}>() { };
+{{#vendorExtensions.x-composed-variants}}
+    private static final GenericType<{{{dataType}}}> {{typeConstantName}} = new GenericType<{{{dataType}}}>() { };
+{{/vendorExtensions.x-composed-variants}}
+
+    private final JsonValue value;
+
+    private {{classname}}(JsonValue value) {
+        this.value = Objects.requireNonNull(value, "value");
+    }
+
+    /**
+     * Creates a validated wrapper from a raw JSON value.
+     *
+     * @param value JSON value
+     * @return typed wrapper
+     */
+    public static {{classname}} fromJsonValue(JsonValue value) {
+        validateJsonValue(value, "jsonValue");
+        return new {{classname}}(value);
+    }
+
+    /**
+     * Returns the raw JSON payload.
+     *
+     * @return raw JSON value
+     */
+    public JsonValue jsonValue() {
+        return value;
+    }
+
+{{#vendorExtensions.x-composed-variants}}
+    /**
+     * Creates a {{classname}} wrapper from a {{displayName}} value.
+     *
+     * @param value variant value
+     * @return typed wrapper
+     */
+    public static {{classname}} {{factoryMethodName}}({{{dataType}}} value) {
+        return new {{classname}}(toJsonValue(Objects.requireNonNull(value, "{{displayName}} value"), {{typeConstantName}}));
+    }
+
+    /**
+     * Returns whether the payload matches {{displayName}}.
+     *
+     * @return {@code true} if the payload matches {{displayName}}
+     */
+    public boolean {{predicateMethodName}}() {
+        return {{matcherMethodName}}(value);
+    }
+
+    /**
+     * Attempts to deserialize the payload as {{displayName}}.
+     *
+     * @return optional {{displayName}} view of the payload
+     */
+    public Optional<{{{dataType}}}> {{accessorMethodName}}() {
+        return {{predicateMethodName}}()
+                ? Optional.ofNullable(JSON_BINDING.deserialize(value, {{typeConstantName}}))
+                : Optional.empty();
+    }
+
+{{/vendorExtensions.x-composed-variants}}
+    /**
+     * Returns whether the JSON value matches this composed schema.
+     *
+     * @param jsonValue JSON value to validate
+     * @return {@code true} if the value matches this schema
+     */
+    public static boolean matchesJsonValue(JsonValue jsonValue) {
+        int matches = variantMatchCount(jsonValue);
+{{#vendorExtensions.x-is-oneof-wrapper}}
+        return matches == 1;
+{{/vendorExtensions.x-is-oneof-wrapper}}
+{{#vendorExtensions.x-is-anyof-wrapper}}
+        return matches >= 1;
+{{/vendorExtensions.x-is-anyof-wrapper}}
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof {{classname}} other)) {
+            return false;
+        }
+        return value.equals(other.value);
+    }
+
+    @Override
+    public String toString() {
+        return value.toString();
+    }
+
+    private static void validateJsonValue(JsonValue jsonValue, String sourceName) {
+        int matches = variantMatchCount(jsonValue);
+{{#vendorExtensions.x-is-oneof-wrapper}}
+        if (matches != 1) {
+            throw new IllegalArgumentException(sourceName
+                    + " must match exactly one of [{{#vendorExtensions.x-composed-variants}}{{displayName}}{{^-last}}, {{/-last}}{{/vendorExtensions.x-composed-variants}}], but matched "
+                    + matches);
+        }
+{{/vendorExtensions.x-is-oneof-wrapper}}
+{{#vendorExtensions.x-is-anyof-wrapper}}
+        if (matches < 1) {
+            throw new IllegalArgumentException(sourceName
+                    + " must match at least one of [{{#vendorExtensions.x-composed-variants}}{{displayName}}{{^-last}}, {{/-last}}{{/vendorExtensions.x-composed-variants}}]");
+        }
+{{/vendorExtensions.x-is-anyof-wrapper}}
+    }
+
+    private static int variantMatchCount(JsonValue jsonValue) {
+        int matches = 0;
+{{#vendorExtensions.x-composed-variants}}
+        if ({{matcherMethodName}}(jsonValue)) {
+            matches++;
+        }
+{{/vendorExtensions.x-composed-variants}}
+        return matches;
+    }
+
+{{#vendorExtensions.x-composed-variants}}
+    private static boolean {{matcherMethodName}}(JsonValue jsonValue) {
+        if (jsonValue == null) {
+            return false;
+        }
+        if (jsonValue.type() == JsonValueType.NULL) {
+            return {{nullable}};
+        }
+{{#usesComposedMatcher}}
+        if (!{{{dataType}}}.matchesJsonValue(jsonValue)) {
+            return false;
+        }
+{{/usesComposedMatcher}}
+{{#isObjectVariant}}
+        if (!matchesObjectShape(
+                jsonValue,
+                {{#hasDiscriminatorProperty}}"{{discriminatorProperty}}"{{/hasDiscriminatorProperty}}{{^hasDiscriminatorProperty}}null{{/hasDiscriminatorProperty}},
+                {{#hasDiscriminatorAliases}}java.util.Set.of({{#discriminatorAliases}}"{{value}}"{{^-last}}, {{/-last}}{{/discriminatorAliases}}){{/hasDiscriminatorAliases}}{{^hasDiscriminatorAliases}}java.util.Set.of(){{/hasDiscriminatorAliases}},
+                {{#hasRequiredProperties}}java.util.Set.of({{#requiredProperties}}"{{value}}"{{^-last}}, {{/-last}}{{/requiredProperties}}){{/hasRequiredProperties}}{{^hasRequiredProperties}}java.util.Set.of(){{/hasRequiredProperties}},
+                {{#hasKnownProperties}}java.util.Set.of({{#knownProperties}}"{{value}}"{{^-last}}, {{/-last}}{{/knownProperties}}){{/hasKnownProperties}}{{^hasKnownProperties}}java.util.Set.of(){{/hasKnownProperties}},
+                {{explicitAdditionalPropertiesFalse}})) {
+            return false;
+        }
+{{/isObjectVariant}}
+{{^usesComposedMatcher}}{{^isObjectVariant}}
+        if (!matchesJsonType(jsonValue, JsonValueType.{{jsonType}}, {{integralNumber}})) {
+            return false;
+        }
+{{/isObjectVariant}}{{/usesComposedMatcher}}
+        try {
+            JSON_BINDING.deserialize(jsonValue, {{typeConstantName}});
+            return true;
+        } catch (RuntimeException ignored) {
+            return false;
+        }
+    }
+
+{{/vendorExtensions.x-composed-variants}}
+    private static boolean matchesJsonType(JsonValue jsonValue, JsonValueType expectedType, boolean integralNumber) {
+        if (jsonValue == null || jsonValue.type() != expectedType) {
+            return false;
+        }
+        return !integralNumber || jsonValue.asNumber().bigDecimalValue().stripTrailingZeros().scale() <= 0;
+    }
+
+    private static boolean matchesObjectShape(JsonValue jsonValue,
+                                              String discriminatorProperty,
+                                              java.util.Set<String> discriminatorValues,
+                                              java.util.Set<String> requiredProperties,
+                                              java.util.Set<String> knownProperties,
+                                              boolean explicitAdditionalPropertiesFalse) {
+        if (jsonValue == null || jsonValue.type() != JsonValueType.OBJECT) {
+            return false;
+        }
+
+        JsonObject object = jsonValue.asObject();
+        if (discriminatorProperty != null) {
+            String discriminatorValue = object.stringValue(discriminatorProperty, null);
+            if (discriminatorValue == null || !discriminatorValues.contains(discriminatorValue)) {
+                return false;
+            }
+        }
+        if (!object.keysAsStrings().containsAll(requiredProperties)) {
+            return false;
+        }
+        return !explicitAdditionalPropertiesFalse || knownProperties.containsAll(object.keysAsStrings());
+    }
+
+    private static <T> JsonValue toJsonValue(T value, GenericType<T> type) {
+        return JsonParser.create(JSON_BINDING.serialize(value, type)).readJsonValue();
+    }
+
+    /**
+     * Helidon JSON converter for {{classname}}.
+     */
+    public static final class {{classname}}JsonConverter implements JsonConverter<{{classname}}> {
+
+        @Override
+        public GenericType<{{classname}}> type() {
+            return SELF_TYPE;
+        }
+
+        @Override
+        public {{classname}} deserialize(JsonParser parser) {
+            JsonValue jsonValue = parser.readJsonValue();
+            validateJsonValue(jsonValue, "JSON payload");
+            return new {{classname}}(jsonValue);
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, {{classname}} value, boolean serializeNulls) {
+            if (value == null || value.value == null) {
+                generator.writeNull();
+                return;
+            }
+            value.value.toJson(generator);
+        }
+    }
+}
+{{/vendorExtensions.x-is-composed-wrapper}}
+{{^vendorExtensions.x-is-composed-wrapper}}
 
 /**
  * {{description}}{{^description}}{{classname}} model.{{/description}}
@@ -60,5 +312,6 @@ import {{import}};
 
 {{/isEnum}}{{/vars}}
 }
+{{/vendorExtensions.x-is-composed-wrapper}}
 {{/model}}
 {{/models}}

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/ComposedSchemaGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/ComposedSchemaGenerationIT.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.openapi.generator;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.config.CodegenConfigurator;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Characterization tests for composed schemas.
+ *
+ * <p>The generator preserves {@code oneOf} and {@code anyOf} as wrapper models
+ * with custom JSON converters and typed accessors, while {@code allOf} is
+ * merged into a single POJO with combined properties.</p>
+ */
+class ComposedSchemaGenerationIT {
+
+    @TempDir
+    static Path outputRoot;
+
+    private static Path oneOfOutputDir;
+    private static Path anyOfOutputDir;
+    private static Path allOfOutputDir;
+
+    @BeforeAll
+    static void generate() throws Exception {
+        oneOfOutputDir = generateProject("oneof-composed.yaml", "oneof");
+        anyOfOutputDir = generateProject("anyof-composed.yaml", "anyof");
+        allOfOutputDir = generateProject("allof-composed.yaml", "allof");
+    }
+
+    @Test
+    void oneOfGeneratesWrapperWithVariantFactoriesAndAccessors() throws IOException {
+        String content = read(modelFile(oneOfOutputDir, "PetUnion.java"));
+        assertThat(content, containsString("@Json.Converter(PetUnion.PetUnionJsonConverter.class)"));
+        assertThat(content, containsString("public final class PetUnion"));
+        assertThat(content, containsString("private final JsonValue value;"));
+        assertThat(content, containsString("public static PetUnion ofCat(Cat value)"));
+        assertThat(content, containsString("public Optional<Cat> asCat()"));
+        assertThat(content, containsString("public static boolean matchesJsonValue(JsonValue jsonValue)"));
+    }
+
+    @Test
+    void oneOfDoesNotFlattenVariantPropertiesIntoWrapperFields() throws IOException {
+        String content = read(modelFile(oneOfOutputDir, "PetUnion.java"));
+        assertThat(content, org.hamcrest.CoreMatchers.not(containsString("private String name;")));
+        assertThat(content, org.hamcrest.CoreMatchers.not(containsString("private Integer lives;")));
+        assertThat(content, org.hamcrest.CoreMatchers.not(containsString("private String breed;")));
+    }
+
+    @Test
+    void anyOfGeneratesWrapperWithVariantFactoriesAndAccessors() throws IOException {
+        String content = read(modelFile(anyOfOutputDir, "FlexiblePet.java"));
+        assertThat(content, containsString("@Json.Converter(FlexiblePet.FlexiblePetJsonConverter.class)"));
+        assertThat(content, containsString("public final class FlexiblePet"));
+        assertThat(content, containsString("private final JsonValue value;"));
+        assertThat(content, containsString("public static FlexiblePet ofCatBits(CatBits value)"));
+        assertThat(content, containsString("public Optional<DogBits> asDogBits()"));
+        assertThat(content, containsString("return matches >= 1;"));
+    }
+
+    @Test
+    void allOfGeneratesSinglePojoWithCombinedProperties() throws IOException {
+        String content = read(modelFile(allOfOutputDir, "CombinedPet.java"));
+        assertThat(content, containsString("class CombinedPet"));
+        assertThat(content, containsString("@Json.Required"));
+        assertThat(content, containsString("private String name;"));
+        assertThat(content, containsString("private String breed;"));
+    }
+
+    @Test
+    void oneOfGeneratedProjectBuildsWithMaven() throws Exception {
+        GeneratedProjectBuildSupport.assertMavenPackageSucceeds(oneOfOutputDir);
+    }
+
+    @Test
+    void anyOfGeneratedProjectBuildsWithMaven() throws Exception {
+        GeneratedProjectBuildSupport.assertMavenPackageSucceeds(anyOfOutputDir);
+    }
+
+    @Test
+    void allOfGeneratedProjectBuildsWithMaven() throws Exception {
+        GeneratedProjectBuildSupport.assertMavenPackageSucceeds(allOfOutputDir);
+    }
+
+    private static Path generateProject(String resourceName, String directoryName) throws Exception {
+        URL resource = ComposedSchemaGenerationIT.class.getClassLoader().getResource(resourceName);
+        String specPath = Paths.get(resource.toURI()).toAbsolutePath().toString();
+        Path outputDir = outputRoot.resolve(directoryName);
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("helidon-declarative")
+                .setInputSpec(specPath)
+                .setOutputDir(outputDir.toString())
+                .addAdditionalProperty("apiPackage", "io.helidon.example.api")
+                .addAdditionalProperty("modelPackage", "io.helidon.example.model")
+                .addAdditionalProperty("invokerPackage", "io.helidon.example");
+
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+        return outputDir;
+    }
+
+    private Path modelFile(Path outputDir, String name) {
+        return outputDir.resolve("src/main/java/io/helidon/example/model/" + name);
+    }
+
+    private String read(Path path) throws IOException {
+        return Files.readString(path).replace("\r\n", "\n");
+    }
+}

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/allof-composed.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/allof-composed.yaml
@@ -1,0 +1,52 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+openapi: 3.0.3
+info:
+  title: allOf composed schema check
+  version: 1.0.0
+servers:
+  - url: http://localhost:8080/api
+paths:
+  /pets/combined:
+    get:
+      operationId: getCombinedPet
+      tags:
+        - pets
+      responses:
+        '200':
+          description: allOf response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CombinedPet'
+components:
+  schemas:
+    PetBase:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+    PetExtra:
+      type: object
+      properties:
+        breed:
+          type: string
+    CombinedPet:
+      allOf:
+        - $ref: '#/components/schemas/PetBase'
+        - $ref: '#/components/schemas/PetExtra'

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/anyof-composed.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/anyof-composed.yaml
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+openapi: 3.0.3
+info:
+  title: anyOf composed schema check
+  version: 1.0.0
+servers:
+  - url: http://localhost:8080/api
+paths:
+  /pets/flexible:
+    get:
+      operationId: getFlexiblePet
+      tags:
+        - pets
+      responses:
+        '200':
+          description: anyOf response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FlexiblePet'
+components:
+  schemas:
+    CatBits:
+      type: object
+      properties:
+        lives:
+          type: integer
+    DogBits:
+      type: object
+      properties:
+        breed:
+          type: string
+    FlexiblePet:
+      anyOf:
+        - $ref: '#/components/schemas/CatBits'
+        - $ref: '#/components/schemas/DogBits'

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/oneof-composed.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/oneof-composed.yaml
@@ -1,0 +1,58 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+openapi: 3.0.3
+info:
+  title: oneOf composed schema check
+  version: 1.0.0
+servers:
+  - url: http://localhost:8080/api
+paths:
+  /pets/union:
+    get:
+      operationId: getPetUnion
+      tags:
+        - pets
+      responses:
+        '200':
+          description: oneOf response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PetUnion'
+components:
+  schemas:
+    Cat:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        lives:
+          type: integer
+    Dog:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        breed:
+          type: string
+    PetUnion:
+      oneOf:
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'


### PR DESCRIPTION
### Description

Issue #37. Add composed-schema model generation and docs. Implement support for OpenAPI composed schemas in the Helidon generator:

  - render oneOf and anyOf as wrapper models with generated Json converters
  - preserve exact-one and at-least-one validation semantics
  - keep allOf as merged POJO generation
  - add integration coverage for oneOf/anyOf/allOf
  - document composed-schema support in README and architecture docs

### Documentation

Updated in PR.
