### PR TITLE
Add Gson extension examples

### DIFF
--- a/extensions/gson/examples/pom.xml
+++ b/extensions/gson/examples/pom.xml
@@ -39,5 +39,7 @@
     </properties>
 
     <modules>
+        <module>se-imperative</module>
+        <module>se-declarative</module>
     </modules>
 </project>

--- a/extensions/gson/examples/se-declarative/README.md
+++ b/extensions/gson/examples/se-declarative/README.md
@@ -1,0 +1,94 @@
+Gson Media Support SE Declarative Example
+---
+
+This example shows how to use `helidon-extensions-gson-media` with a Helidon SE WebServer built using declarative APIs.
+The server reads JSON request entities into Java objects and sends Java objects back as JSON using Gson.
+
+Unlike the imperative sample, this declarative version does not manually configure media support.
+Because `helidon-extensions-gson-media` is on the classpath, Gson media support is discovered automatically.
+
+The example also includes a small `gson.properties` section in `application.yaml`.
+It enables `serialize-nulls`, so the `punctuation` field is rendered even when the application has not set a value yet.
+
+# Running as jar
+
+Build this application:
+
+```shell
+mvn clean package
+```
+
+Run from the command line:
+
+```shell
+java -jar target/helidon-extensions-gson-examples-se-declarative.jar
+```
+
+Expected output should be similar to the following:
+
+```text
+2026.04.24 12:00:00.000 INFO Logging at runtime configured using classpath: /logging.properties
+2026.04.24 12:00:00.250 INFO [0x12345678] http://0.0.0.0:8080 bound for socket '@default'
+Server started on: http://localhost:8080/hello
+```
+
+# Configuration
+
+The example uses this Gson configuration:
+
+```yaml
+gson:
+  properties:
+    serialize-nulls: true
+```
+
+# Exercising the application
+
+Request the default greeting:
+
+```shell
+curl -i -H "Accept: application/json" http://localhost:8080/hello
+```
+
+Expected response:
+
+```text
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"greeting":"Hello","name":"World","punctuation":null}
+```
+
+Update the greeting using a JSON request body:
+
+```shell
+curl -i -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  http://localhost:8080/hello \
+  -d '{"greeting":"Ahoj","punctuation":"!"}'
+```
+
+Expected response:
+
+```text
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"greeting":"Ahoj","name":"World","punctuation":"!"}
+```
+
+Request a named greeting:
+
+```shell
+curl -i -H "Accept: application/json" http://localhost:8080/hello/Reader
+```
+
+Expected response:
+
+```text
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"greeting":"Ahoj","name":"Reader","punctuation":"!"}
+```

--- a/extensions/gson/examples/se-declarative/pom.xml
+++ b/extensions/gson/examples/se-declarative/pom.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-se</artifactId>
+        <version>27.0.0-SNAPSHOT</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>io.helidon.extensions.gson.examples</groupId>
+    <artifactId>helidon-extensions-gson-examples-se-declarative</artifactId>
+    <version>27.0.0-SNAPSHOT</version>
+    <name>Helidon Extensions Gson Example SE Declarative</name>
+    <description>Example for Helidon SE WebServer with Gson media support using declarative APIs.</description>
+
+    <properties>
+        <mainClass>io.helidon.extensions.gson.examples.declarative.Main</mainClass>
+        <helidon.extension.gson.version>27.0.0-SNAPSHOT</helidon.extension.gson.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.extensions.gson</groupId>
+            <artifactId>helidon-extensions-gson-media</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.helidon.extensions.gson</groupId>
+                <artifactId>helidon-extensions-gson-bom</artifactId>
+                <version>${helidon.extension.gson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-Ahelidon.api.incubating=ignore</arg>
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.bundles</groupId>
+                            <artifactId>helidon-bundles-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.helidon.service</groupId>
+                <artifactId>helidon-service-maven-plugin</artifactId>
+                <version>${helidon.version}</version>
+                <executions>
+                    <execution>
+                        <id>create-application</id>
+                        <goals>
+                            <goal>create-application</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/gson/examples/se-declarative/src/main/java/io/helidon/extensions/gson/examples/declarative/GreetingDto.java
+++ b/extensions/gson/examples/se-declarative/src/main/java/io/helidon/extensions/gson/examples/declarative/GreetingDto.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.gson.examples.declarative;
+
+public class GreetingDto {
+    private String greeting;
+    private String name;
+    private String punctuation;
+
+    GreetingDto() {
+    }
+
+    GreetingDto(String greeting, String name, String punctuation) {
+        this.greeting = greeting;
+        this.name = name;
+        this.punctuation = punctuation;
+    }
+
+    public String getGreeting() {
+        return greeting;
+    }
+
+    public void setGreeting(String greeting) {
+        this.greeting = greeting;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getPunctuation() {
+        return punctuation;
+    }
+
+    public void setPunctuation(String punctuation) {
+        this.punctuation = punctuation;
+    }
+}

--- a/extensions/gson/examples/se-declarative/src/main/java/io/helidon/extensions/gson/examples/declarative/GreetingEndpoint.java
+++ b/extensions/gson/examples/se-declarative/src/main/java/io/helidon/extensions/gson/examples/declarative/GreetingEndpoint.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.gson.examples.declarative;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.common.Default;
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.config.Configuration;
+import io.helidon.http.Http;
+import io.helidon.service.registry.Service;
+import io.helidon.webserver.http.RestServer;
+
+@RestServer.Endpoint
+@Http.Path("/hello")
+@Service.Singleton
+class GreetingEndpoint {
+    private final AtomicReference<String> greeting = new AtomicReference<>();
+    private final AtomicReference<String> punctuation = new AtomicReference<>();
+
+    @Service.Inject
+    GreetingEndpoint(@Default.Value("Hello") @Configuration.Value("app.greeting") String greeting) {
+        this.greeting.set(greeting);
+    }
+
+    @Http.GET
+    @Http.Produces(MediaTypes.APPLICATION_JSON_VALUE)
+    GreetingDto hello() {
+        return currentGreeting("World");
+    }
+
+    @Http.GET
+    @Http.Path("/{name}")
+    @Http.Produces(MediaTypes.APPLICATION_JSON_VALUE)
+    GreetingDto hello(@Http.PathParam("name") String name) {
+        return currentGreeting(name);
+    }
+
+    @Http.POST
+    @Http.Consumes(MediaTypes.APPLICATION_JSON_VALUE)
+    @Http.Produces(MediaTypes.APPLICATION_JSON_VALUE)
+    GreetingDto updateGreeting(@Http.Entity GreetingUpdate update) {
+        if (update.getGreeting() != null) {
+            greeting.set(update.getGreeting());
+        }
+        punctuation.set(update.getPunctuation());
+        return currentGreeting("World");
+    }
+
+    private GreetingDto currentGreeting(String name) {
+        return new GreetingDto(greeting.get(), name, punctuation.get());
+    }
+}

--- a/extensions/gson/examples/se-declarative/src/main/java/io/helidon/extensions/gson/examples/declarative/GreetingUpdate.java
+++ b/extensions/gson/examples/se-declarative/src/main/java/io/helidon/extensions/gson/examples/declarative/GreetingUpdate.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.gson.examples.declarative;
+
+class GreetingUpdate {
+    private String greeting;
+    private String punctuation;
+
+    GreetingUpdate() {
+    }
+
+    String getGreeting() {
+        return greeting;
+    }
+
+    public void setGreeting(String greeting) {
+        this.greeting = greeting;
+    }
+
+    String getPunctuation() {
+        return punctuation;
+    }
+
+    public void setPunctuation(String punctuation) {
+        this.punctuation = punctuation;
+    }
+}

--- a/extensions/gson/examples/se-declarative/src/main/java/io/helidon/extensions/gson/examples/declarative/Main.java
+++ b/extensions/gson/examples/se-declarative/src/main/java/io/helidon/extensions/gson/examples/declarative/Main.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.gson.examples.declarative;
+
+import io.helidon.logging.common.LogConfig;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.service.registry.Services;
+import io.helidon.webserver.WebServer;
+
+@Service.GenerateBinding
+public class Main {
+    static {
+        LogConfig.initClass();
+    }
+
+    private Main() {
+    }
+
+    public static void main(String[] args) {
+        LogConfig.configureRuntime();
+        ServiceRegistryManager.start(ApplicationBinding.create());
+
+        WebServer webServer = Services.get(WebServer.class);
+        System.out.println("Server started on: http://localhost:" + webServer.port() + "/hello");
+    }
+}

--- a/extensions/gson/examples/se-declarative/src/main/java/io/helidon/extensions/gson/examples/declarative/package-info.java
+++ b/extensions/gson/examples/se-declarative/src/main/java/io/helidon/extensions/gson/examples/declarative/package-info.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Declarative examples for Gson extension for Helidon.
+ *
+ * @see io.helidon.extensions.gson.examples.declarative.Main
+ */
+package io.helidon.extensions.gson.examples.declarative;

--- a/extensions/gson/examples/se-declarative/src/main/resources/application.yaml
+++ b/extensions/gson/examples/se-declarative/src/main/resources/application.yaml
@@ -1,0 +1,29 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+app:
+  greeting: "Hello"
+
+server:
+  port: 8080
+  host: 0.0.0.0
+
+gson:
+  properties:
+    serialize-nulls: true
+
+declarative:
+  ignore-incubating: true

--- a/extensions/gson/examples/se-declarative/src/main/resources/logging.properties
+++ b/extensions/gson/examples/se-declarative/src/main/resources/logging.properties
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
+.level=INFO
+io.helidon.level=INFO

--- a/extensions/gson/examples/se-declarative/src/test/java/io/helidon/extensions/gson/examples/declarative/MainTest.java
+++ b/extensions/gson/examples/se-declarative/src/test/java/io/helidon/extensions/gson/examples/declarative/MainTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.gson.examples.declarative;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.http.Status;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webserver.testing.junit5.ServerTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class MainTest {
+    private final Http1Client client;
+
+    MainTest(Http1Client client) {
+        this.client = client;
+    }
+
+    @Test
+    void testHelloWorld() {
+        var response = client.get("/hello")
+                .accept(MediaTypes.APPLICATION_JSON)
+                .request(GreetingDto.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        GreetingDto entity = response.entity();
+        assertThat(entity.getGreeting(), is("Hello"));
+        assertThat(entity.getName(), is("World"));
+        assertThat(entity.getPunctuation(), is((String) null));
+    }
+
+    @Test
+    void testHelloNamed() {
+        var response = client.get("/hello/Reader")
+                .accept(MediaTypes.APPLICATION_JSON)
+                .request(GreetingDto.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        GreetingDto entity = response.entity();
+        assertThat(entity.getGreeting(), is("Hello"));
+        assertThat(entity.getName(), is("Reader"));
+        assertThat(entity.getPunctuation(), is((String) null));
+    }
+
+    @Test
+    void testUpdateGreeting() {
+        var response = client.post("/hello")
+                .contentType(MediaTypes.APPLICATION_JSON)
+                .accept(MediaTypes.APPLICATION_JSON)
+                .submit("{\"greeting\":\"Ahoj\",\"punctuation\":\"!\"}", GreetingDto.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        GreetingDto entity = response.entity();
+        assertThat(entity.getGreeting(), is("Ahoj"));
+        assertThat(entity.getName(), is("World"));
+        assertThat(entity.getPunctuation(), is("!"));
+
+        try {
+            GreetingDto updated = client.get("/hello/Reader")
+                    .accept(MediaTypes.APPLICATION_JSON)
+                    .requestEntity(GreetingDto.class);
+            assertThat(updated.getGreeting(), is("Ahoj"));
+            assertThat(updated.getName(), is("Reader"));
+            assertThat(updated.getPunctuation(), is("!"));
+        } finally {
+            client.post("/hello")
+                    .contentType(MediaTypes.APPLICATION_JSON)
+                    .accept(MediaTypes.APPLICATION_JSON)
+                    .submit("{\"greeting\":\"Hello\"}")
+                    .close();
+        }
+    }
+}

--- a/extensions/gson/examples/se-imperative/README.md
+++ b/extensions/gson/examples/se-imperative/README.md
@@ -1,0 +1,91 @@
+Gson Media Support SE Example
+---
+
+This example shows how to use `helidon-extensions-gson-media` with a Helidon SE WebServer built using imperative APIs.
+The server reads JSON request entities into Java objects and sends Java objects back as JSON using Gson.
+
+The example also includes a small `gson.properties` section in `application.yaml`.
+It enables `serialize-nulls`, so the `punctuation` field is rendered even when the application has not set a value yet.
+
+# Running as jar
+
+Build this application:
+
+```shell
+mvn clean package
+```
+
+Run from the command line:
+
+```shell
+java -jar target/helidon-extensions-gson-examples-se-imperative.jar
+```
+
+Expected output should be similar to the following:
+
+```text
+2026.04.24 12:00:00.000 INFO Logging at runtime configured using classpath: /logging.properties
+2026.04.24 12:00:00.250 INFO [0x12345678] http://0.0.0.0:8080 bound for socket '@default'
+Server started on: http://localhost:8080/hello
+```
+
+# Configuration
+
+The example uses this Gson configuration:
+
+```yaml
+gson:
+  properties:
+    serialize-nulls: true
+```
+
+# Exercising the application
+
+Request the default greeting:
+
+```shell
+curl -i -H "Accept: application/json" http://localhost:8080/hello
+```
+
+Expected response:
+
+```text
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"greeting":"Hello","name":"World","punctuation":null}
+```
+
+Update the greeting using a JSON request body:
+
+```shell
+curl -i -X POST \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json" \
+  http://localhost:8080/hello \
+  -d '{"greeting":"Ahoj","punctuation":"!"}'
+```
+
+Expected response:
+
+```text
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"greeting":"Ahoj","name":"World","punctuation":"!"}
+```
+
+Request a named greeting:
+
+```shell
+curl -i -H "Accept: application/json" http://localhost:8080/hello/Reader
+```
+
+Expected response:
+
+```text
+HTTP/1.1 200 OK
+Content-Type: application/json
+
+{"greeting":"Ahoj","name":"Reader","punctuation":"!"}
+```

--- a/extensions/gson/examples/se-imperative/pom.xml
+++ b/extensions/gson/examples/se-imperative/pom.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-se</artifactId>
+        <version>27.0.0-SNAPSHOT</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>io.helidon.extensions.gson.examples</groupId>
+    <artifactId>helidon-extensions-gson-examples-se-imperative</artifactId>
+    <version>27.0.0-SNAPSHOT</version>
+    <name>Helidon Extensions Gson Example SE (Imperative)</name>
+    <description>Example for Helidon SE WebServer with Gson media support using programmatic APIs.</description>
+
+    <properties>
+        <mainClass>io.helidon.extensions.gson.examples.imperative.Main</mainClass>
+        <helidon.extension.gson.version>27.0.0-SNAPSHOT</helidon.extension.gson.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.extensions.gson</groupId>
+            <artifactId>helidon-extensions-gson-media</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.helidon.extensions.gson</groupId>
+                <artifactId>helidon-extensions-gson-bom</artifactId>
+                <version>${helidon.extension.gson.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/gson/examples/se-imperative/src/main/java/io/helidon/extensions/gson/examples/imperative/GreetingResponse.java
+++ b/extensions/gson/examples/se-imperative/src/main/java/io/helidon/extensions/gson/examples/imperative/GreetingResponse.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.gson.examples.imperative;
+
+final class GreetingResponse {
+    private final String greeting;
+    private final String name;
+    private final String punctuation;
+
+    GreetingResponse(String greeting, String name, String punctuation) {
+        this.greeting = greeting;
+        this.name = name;
+        this.punctuation = punctuation;
+    }
+
+    public String getGreeting() {
+        return greeting;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPunctuation() {
+        return punctuation;
+    }
+}

--- a/extensions/gson/examples/se-imperative/src/main/java/io/helidon/extensions/gson/examples/imperative/GreetingService.java
+++ b/extensions/gson/examples/se-imperative/src/main/java/io/helidon/extensions/gson/examples/imperative/GreetingService.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.gson.examples.imperative;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.helidon.config.Config;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.HttpService;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+
+final class GreetingService implements HttpService {
+    private final AtomicReference<String> greeting;
+    private final AtomicReference<String> punctuation;
+
+    private GreetingService(String greeting, String punctuation) {
+        this.greeting = new AtomicReference<>(greeting);
+        this.punctuation = new AtomicReference<>(punctuation);
+    }
+
+    static GreetingService create(Config config) {
+        return new GreetingService(config.get("app.greeting")
+                                           .asString()
+                                           .orElse("Hello"),
+                                   config.get("app.punctuation")
+                                           .asString()
+                                           .orElse(null));
+    }
+
+    @Override
+    public void routing(HttpRules rules) {
+        rules.get("/", this::helloWorld)
+                .get("/{name}", this::helloName)
+                .post("/", this::updateGreeting);
+    }
+
+    private void helloWorld(ServerRequest request, ServerResponse response) {
+        response.send(currentGreeting("World"));
+    }
+
+    private void helloName(ServerRequest request, ServerResponse response) {
+        response.send(currentGreeting(request.path().pathParameters().get("name")));
+    }
+
+    private void updateGreeting(ServerRequest request, ServerResponse response) {
+        GreetingUpdate update = request.content().as(GreetingUpdate.class);
+
+        if (update.getGreeting() != null) {
+            greeting.set(update.getGreeting());
+        }
+        punctuation.set(update.getPunctuation());
+
+        response.send(currentGreeting("World"));
+    }
+
+    private GreetingResponse currentGreeting(String name) {
+        return new GreetingResponse(greeting.get(), name, punctuation.get());
+    }
+}

--- a/extensions/gson/examples/se-imperative/src/main/java/io/helidon/extensions/gson/examples/imperative/GreetingUpdate.java
+++ b/extensions/gson/examples/se-imperative/src/main/java/io/helidon/extensions/gson/examples/imperative/GreetingUpdate.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.gson.examples.imperative;
+
+final class GreetingUpdate {
+    private String greeting;
+    private String punctuation;
+
+    String getGreeting() {
+        return greeting;
+    }
+
+    public void setGreeting(String greeting) {
+        this.greeting = greeting;
+    }
+
+    String getPunctuation() {
+        return punctuation;
+    }
+
+    public void setPunctuation(String punctuation) {
+        this.punctuation = punctuation;
+    }
+}

--- a/extensions/gson/examples/se-imperative/src/main/java/io/helidon/extensions/gson/examples/imperative/Main.java
+++ b/extensions/gson/examples/se-imperative/src/main/java/io/helidon/extensions/gson/examples/imperative/Main.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.gson.examples.imperative;
+
+import io.helidon.config.Config;
+import io.helidon.extensions.gson.media.GsonSupport;
+import io.helidon.logging.common.LogConfig;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+
+public class Main {
+    private Main() {
+    }
+
+    public static void main(String[] args) {
+        LogConfig.configureRuntime();
+
+        Config config = Config.create();
+        WebServer server = startServer(config);
+
+        System.out.println("Server started on: http://localhost:" + server.port() + "/hello");
+    }
+
+    static WebServer startServer(Config config) {
+        WebServerConfig.Builder server = WebServer.builder()
+                .config(config.get("server"));
+
+        configureServer(server, config);
+        return server.build().start();
+    }
+
+    static void configureServer(WebServerConfig.Builder server, Config config) {
+        server.mediaContext(context -> {
+            context.mediaSupportsDiscoverServices(false);
+            context.addMediaSupport(GsonSupport.create(config.get("gson")));
+        });
+        server.routing(routing -> routing.register("/hello", GreetingService.create(config)));
+    }
+}

--- a/extensions/gson/examples/se-imperative/src/main/resources/application.yaml
+++ b/extensions/gson/examples/se-imperative/src/main/resources/application.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+app:
+  greeting: "Hello"
+
+server:
+  port: 8080
+  host: 0.0.0.0
+
+gson:
+  properties:
+    serialize-nulls: true

--- a/extensions/gson/examples/se-imperative/src/main/resources/logging.properties
+++ b/extensions/gson/examples/se-imperative/src/main/resources/logging.properties
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+handlers=io.helidon.logging.jul.HelidonConsoleHandler
+java.util.logging.SimpleFormatter.format=%1$tY.%1$tm.%1$td %1$tH:%1$tM:%1$tS.%1$tL %4$s %5$s%6$s%n
+.level=INFO
+io.helidon.level=INFO

--- a/extensions/gson/examples/se-imperative/src/test/java/io/helidon/extensions/gson/examples/imperative/MainTest.java
+++ b/extensions/gson/examples/se-imperative/src/test/java/io/helidon/extensions/gson/examples/imperative/MainTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.gson.examples.imperative;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.config.Config;
+import io.helidon.http.Status;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class MainTest {
+    private static final String RESET_GREETING = "{\"greeting\":\"Hello\"}";
+    private static final String UPDATED_GREETING = "{\"greeting\":\"Ahoj\",\"punctuation\":\"!\"}";
+
+    private final Http1Client client;
+
+    MainTest(Http1Client client) {
+        this.client = client;
+    }
+
+    @SetUpServer
+    static void configureServer(WebServerConfig.Builder server) {
+        Main.configureServer(server, Config.create());
+    }
+
+    @Test
+    void testHelloWorld() {
+        var response = client.get("/hello")
+                .accept(MediaTypes.APPLICATION_JSON)
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("{\"greeting\":\"Hello\",\"name\":\"World\",\"punctuation\":null}"));
+    }
+
+    @Test
+    void testHelloNamed() {
+        var response = client.get("/hello/Reader")
+                .accept(MediaTypes.APPLICATION_JSON)
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is("{\"greeting\":\"Hello\",\"name\":\"Reader\",\"punctuation\":null}"));
+    }
+
+    @Test
+    void testUpdateGreeting() {
+        try {
+            var updateResponse = client.post("/hello")
+                    .contentType(MediaTypes.APPLICATION_JSON)
+                    .accept(MediaTypes.APPLICATION_JSON)
+                    .submit(UPDATED_GREETING, String.class);
+
+            assertThat(updateResponse.status(), is(Status.OK_200));
+            assertThat(updateResponse.entity(), is("{\"greeting\":\"Ahoj\",\"name\":\"World\",\"punctuation\":\"!\"}"));
+
+            var helloResponse = client.get("/hello/Reader")
+                    .accept(MediaTypes.APPLICATION_JSON)
+                    .request(String.class);
+
+            assertThat(helloResponse.status(), is(Status.OK_200));
+            assertThat(helloResponse.entity(), is("{\"greeting\":\"Ahoj\",\"name\":\"Reader\",\"punctuation\":\"!\"}"));
+        } finally {
+            client.post("/hello")
+                    .contentType(MediaTypes.APPLICATION_JSON)
+                    .accept(MediaTypes.APPLICATION_JSON)
+                    .submit(RESET_GREETING)
+                    .close();
+        }
+    }
+}


### PR DESCRIPTION
Resolves #57

Add matching SE imperative and declarative Gson examples under `extensions/gson/examples`.
The examples show Gson request and response mapping, `serialize-nulls` configuration, and runnable README instructions with focused tests.
