### PR TITLE
openapi-generator: Remove @Validated from declarative HTTP endpoint

### DIFF
--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/api-interface.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/api-interface.mustache
@@ -18,6 +18,7 @@ package {{package}};
 
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.Http;
+import io.helidon.service.registry.Service;
 import io.helidon.webserver.http.RestServer;
 {{#imports}}
 import {{import}};
@@ -47,9 +48,8 @@ import io.helidon.security.abac.role.RoleValidator;
  * {@code @Http.GET}, etc.) that are shared between the server endpoint and the
  * declarative REST client.</p>
  */
-@SuppressWarnings("deprecation")
-{{#hasParamValidation}}@Validation.Validated
-{{/hasParamValidation}}@Http.Path("{{helidonBasePath}}")
+@Http.Path("{{helidonBasePath}}")
+@Service.Singleton
 public interface {{classname}}Api {
 
 {{#operation}}

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/api.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/api.mustache
@@ -56,7 +56,6 @@ import io.helidon.security.SecurityContext;
  * <p>{@code @RestServer.Endpoint} — processed at build time by the Helidon annotation
  * processor to register HTTP routing without runtime reflection.</p>
  */
-@SuppressWarnings("deprecation")
 @RestServer.Endpoint
 @Service.Singleton
 {{#corsEnabled}}@Cors.Defaults

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/FeaturesGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/FeaturesGenerationIT.java
@@ -200,12 +200,6 @@ class FeaturesGenerationIT {
     }
 
     @Test
-    void apiInterfaceHasValidatedAnnotationWhenParamValidationIsPresent() throws IOException {
-        assertThat(read(apiFile("ThingsApi.java")),
-                   containsString("@Validation.Validated"));
-    }
-
-    @Test
     void apiInterfaceIntParamHasExclusiveMinMaxValidation() throws IOException {
         String content = read(apiFile("ThingsApi.java"));
         assertThat(content, containsString("@Validation.Integer.Min(11)"));


### PR DESCRIPTION
### Description

Remove `@Validated` from declarative HTTP endpoint
Add Service.Singleton to pass validation codegen
Update FeaturesGenerationIT to pass with the removal of Validated.

### Documentation

None.
