### PR TITLE
Update release.sh to strip the -SNAPSHOT qualifier only 

### DIFF
--- a/etc/scripts/release.sh
+++ b/etc/scripts/release.sh
@@ -451,7 +451,7 @@ create_tag() {
   read -r _ _ version < <(gav "${WS_DIR}/extensions/${extension}/pom.xml")
 
   # Strip qualifier
-  version="${version%%-*}"
+  version=${version%-SNAPSHOT}
 
   git_branch="release/${extension}/${version}"
   tag_name="${extension}/${version}"


### PR DESCRIPTION
### Description

Update release.sh to strip the -SNAPSHOT qualifier only  so to allow qualified release versions (E.g. -M1 -RC1 etc.)

### Documentation

None.