### PR TITLE
Add Helidon-style builders to generated OpenAPI models

### DIFF
--- a/extensions/openapi-generator/docs/ARCHITECTURE.md
+++ b/extensions/openapi-generator/docs/ARCHITECTURE.md
@@ -148,7 +148,14 @@ Notable behavior:
 - required properties are marked for JSON-required rendering
 - default values are converted into Java literals
 - validation annotations are derived from OpenAPI constraints
-- model validation annotations are emitted on getter methods rather than private fields
+- model validation annotations are emitted on prefixless accessor methods rather
+  than private fields
+- model classes expose prefixless accessors and mutators, such as `id()` and
+  `id(value)`, instead of JavaBean-style `getId()` and `setId(...)`
+- model classes expose builders backed by `io.helidon.common.Builder` through a
+  generated `BuilderBase<B, T>` class; `allOf` subtype builder bases extend the
+  parent model builder base so inherited and local properties can be set in one
+  fluent chain
 - composed schemas are normalized into template-friendly flags:
   - `allOf` prefers Java inheritance when there is a single referenced parent
   - `oneOf` and `anyOf` generate model interfaces annotated with a generated
@@ -201,7 +208,9 @@ Current templates:
 - `api-interface.mustache` defines the shared annotated contract.
 - `api.mustache` emits the endpoint stub implementation.
 - `restClient.mustache` extends the shared API contract to reuse HTTP annotations.
-- `model.mustache` generates model classes rather than records.
+- `model.mustache` generates mutable JSON entity model classes rather than
+  records. Models use prefixless property methods and Helidon-style builders
+  instead of JavaBean getters and setters.
 - `api.mustache` does not emit `@RestServer.Listener`, because the default listener is
   already implied.
 
@@ -218,6 +227,11 @@ Per tag:
 Per schema:
 
 - `{Model}.java`
+  - `@Json.Entity` model class
+  - prefixless accessor and mutator methods for schema properties
+  - `@Json.BuilderInfo` and a generated `Builder` / `BuilderBase<B, T>`
+    implementing `io.helidon.common.Builder`
+  - generated nested enums when needed
 
 ## Verification
 

--- a/extensions/openapi-generator/docs/README.md
+++ b/extensions/openapi-generator/docs/README.md
@@ -185,7 +185,7 @@ Per schema:
 
 | File | Description |
 |------|-------------|
-| `{Model}.java` | Helidon JSON model type with generated validation and enum support |
+| `{Model}.java` | Helidon JSON model type with generated builders, validation, and enum support |
 
 Supporting files:
 
@@ -226,6 +226,37 @@ For union schemas, generated converters use the OpenAPI discriminator when one i
 present. Without a discriminator, they fall back to structural matching based on
 the member models' required and declared properties.
 
+### Model API
+
+Generated object schemas are mutable Helidon JSON entities with prefixless
+property accessors and mutators. A schema property named `id` produces `id()`
+and `id(value)` methods instead of JavaBean-style `getId()` and `setId(...)`.
+
+Each generated model also has a Helidon-style builder:
+
+```java
+Pet pet = Pet.builder()
+        .id(1L)
+        .name("Fluffy")
+        .tag("cat")
+        .build();
+
+Long id = pet.id();
+pet.name("Mochi");
+```
+
+Builders implement `io.helidon.common.Builder` through a generated
+`BuilderBase<B, T>` class. For `allOf` inheritance, child builders extend the
+parent model's builder base so fluent chains can set both inherited and local
+properties:
+
+```java
+Extended extended = Extended.builder()
+        .id("extended-1")
+        .name("extended-name")
+        .build();
+```
+
 ### Parameters
 
 | OpenAPI | Generated |
@@ -250,8 +281,9 @@ The generator currently emits Helidon validation annotations for:
 - collection size
 - `multipleOf` for integer, long, and number constraints
 
-For model classes, validation annotations are emitted on accessor methods rather than
-private fields so generated projects compile cleanly with the current validation API.
+For model classes, validation annotations are emitted on prefixless accessor
+methods rather than private fields so generated projects compile cleanly with the
+current validation API.
 
 ## Testing
 

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/composed-schemas/src/test/java/io/helidon/example/model/ComposedJsonBindingTest.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/composed-schemas/src/test/java/io/helidon/example/model/ComposedJsonBindingTest.java
@@ -31,8 +31,8 @@ class ComposedJsonBindingTest {
     @Test
     void oneOfDiscriminatorRoundTrip() {
         Cat cat = new Cat();
-        cat.setKind("cat&special");
-        cat.setWhiskers(7);
+        cat.kind("cat&special");
+        cat.whiskers(7);
 
         String json = jsonBinding.serialize((Pet) cat, Pet.class);
         assertThat(json, containsString("\"kind\":\"cat&special\""));
@@ -40,20 +40,20 @@ class ComposedJsonBindingTest {
 
         Pet pet = jsonBinding.deserialize("{\"kind\":\"cat&special\",\"whiskers\":7}", Pet.class);
         assertThat(pet, instanceOf(Cat.class));
-        assertThat(((Cat) pet).getWhiskers(), is(7));
+        assertThat(((Cat) pet).whiskers(), is(7));
     }
 
     @Test
     void anyOfStructuralRoundTrip() {
         EmailContact emailContact = new EmailContact();
-        emailContact.setEmail("user@example.com");
+        emailContact.email("user@example.com");
 
         String json = jsonBinding.serialize((Contact) emailContact, Contact.class);
         assertThat(json, containsString("\"email\":\"user@example.com\""));
 
         Contact contact = jsonBinding.deserialize("{\"email\":\"user@example.com\"}", Contact.class);
         assertThat(contact, instanceOf(EmailContact.class));
-        assertThat(((EmailContact) contact).getEmail(), is("user@example.com"));
+        assertThat(((EmailContact) contact).email(), is("user@example.com"));
     }
 
     @Test

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -1616,7 +1616,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         if (property == null) {
             return null;
         }
-        return property.setter;
+        return property.name;
     }
 
     private String discriminatorValueExpression(CodegenModel parentModel,

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
@@ -366,7 +366,8 @@ final class {{classname}}JsonBindingFactory implements JsonBindingFactory<{{clas
 {{/vendorExtensions.x-polymorphic-subtypes}}{{/vendorExtensions.x-has-polymorphic-subtypes}}
 {{#isDeprecated}}@Deprecated
 {{/isDeprecated}}{{#vendorExtensions.x-has-validations}}@Validation.Validated
-{{/vendorExtensions.x-has-validations}}public class {{classname}}{{#vendorExtensions.x-extends-model}} extends {{vendorExtensions.x-extends-model}}{{/vendorExtensions.x-extends-model}}{{#vendorExtensions.x-has-implements-models}} implements {{#vendorExtensions.x-implements-models}}{{name}}{{^last}}, {{/last}}{{/vendorExtensions.x-implements-models}}{{/vendorExtensions.x-has-implements-models}} {
+{{/vendorExtensions.x-has-validations}}@Json.BuilderInfo({{classname}}.Builder.class)
+public class {{classname}}{{#vendorExtensions.x-extends-model}} extends {{vendorExtensions.x-extends-model}}{{/vendorExtensions.x-extends-model}}{{#vendorExtensions.x-has-implements-models}} implements {{#vendorExtensions.x-implements-models}}{{name}}{{^last}}, {{/last}}{{/vendorExtensions.x-implements-models}}{{/vendorExtensions.x-has-implements-models}} {
 
 {{#vendorExtensions.x-render-vars}}
     {{#description}}/** {{description}} */
@@ -382,15 +383,190 @@ final class {{classname}}JsonBindingFactory implements JsonBindingFactory<{{clas
 
 {{#vendorExtensions.x-render-vars}}
 {{#vendorExtensions.x-validation-annotations}}    {{{annotation}}}
-{{/vendorExtensions.x-validation-annotations}}    public {{{datatypeWithEnum}}} {{getter}}() {
+{{/vendorExtensions.x-validation-annotations}}    public {{{datatypeWithEnum}}} {{name}}() {
         return {{name}};
     }
 
-    public void {{setter}}({{{datatypeWithEnum}}} {{name}}) {
+    public void {{name}}({{{datatypeWithEnum}}} {{name}}) {
         this.{{name}} = {{name}};
     }
 
 {{/vendorExtensions.x-render-vars}}
+{{^vendorExtensions.x-extends-model}}
+    /**
+     * Create a builder for {@link {{classname}}}.
+     *
+     * @return new builder
+     */
+    @Json.Ignore
+    public static BuilderBase<?, ? extends {{classname}}> builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link {{classname}}}.
+     */
+    public static class Builder extends BuilderBase<Builder, {{classname}}> {
+
+        /**
+         * Create a new builder.
+         */
+        public Builder() {
+            super(new {{classname}}());
+        }
+
+{{#vendorExtensions.x-render-vars}}
+        /**
+         * Set {{name}}.
+         *
+         * @param {{name}} {{name}} value
+         * @return updated builder
+         */
+        public Builder {{name}}({{{datatypeWithEnum}}} {{name}}) {
+            return super.{{name}}({{name}});
+        }
+
+{{/vendorExtensions.x-render-vars}}
+        /**
+         * Build the instance.
+         *
+         * @return configured instance
+         */
+        @Override
+        public {{classname}} build() {
+            return super.build();
+        }
+    }
+
+    /**
+     * Base builder for {@link {{classname}}}.
+     *
+     * @param <B> concrete builder type
+     * @param <T> concrete built type
+     */
+    public static class BuilderBase<B extends BuilderBase<B, T>, T extends {{classname}}>
+            implements io.helidon.common.Builder<B, T> {
+        protected final T instance;
+
+        /**
+         * Create a new builder.
+         *
+         * @param instance instance to build
+         */
+        protected BuilderBase(T instance) {
+            this.instance = instance;
+        }
+
+{{#vendorExtensions.x-render-vars}}
+        /**
+         * Set {{name}}.
+         *
+         * @param {{name}} {{name}} value
+         * @return updated builder
+         */
+        public B {{name}}({{{datatypeWithEnum}}} {{name}}) {
+            instance.{{name}}({{name}});
+            return self();
+        }
+
+{{/vendorExtensions.x-render-vars}}
+        /**
+         * Build the instance.
+         *
+         * @return configured instance
+         */
+        @Override
+        public T build() {
+            return instance;
+        }
+
+        @SuppressWarnings("unchecked")
+        protected B self() {
+            return (B) this;
+        }
+    }
+
+{{/vendorExtensions.x-extends-model}}{{#vendorExtensions.x-extends-model}}
+    /**
+     * Create a builder for {@link {{classname}}}.
+     *
+     * @return new builder
+     */
+    @Json.Ignore
+    public static BuilderBase<?, ? extends {{classname}}> builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for {@link {{classname}}}.
+     */
+    public static class Builder extends BuilderBase<Builder, {{classname}}> {
+
+        /**
+         * Create a new builder.
+         */
+        public Builder() {
+            super(new {{classname}}());
+        }
+
+{{#vendorExtensions.x-render-vars}}
+        /**
+         * Set {{name}}.
+         *
+         * @param {{name}} {{name}} value
+         * @return updated builder
+         */
+        public Builder {{name}}({{{datatypeWithEnum}}} {{name}}) {
+            (({{classname}}) instance).{{name}}({{name}});
+            return this;
+        }
+
+{{/vendorExtensions.x-render-vars}}
+        /**
+         * Build the instance.
+         *
+         * @return configured instance
+         */
+        @Override
+        public {{classname}} build() {
+            return ({{classname}}) instance;
+        }
+    }
+
+    /**
+     * Base builder for {@link {{classname}}}.
+     *
+     * @param <B> concrete builder type
+     * @param <T> concrete built type
+     */
+    public static class BuilderBase<B extends BuilderBase<B, T>, T extends {{classname}}>
+            extends {{vendorExtensions.x-extends-model}}.BuilderBase<B, T> {
+
+        /**
+         * Create a new builder.
+         *
+         * @param instance instance to build
+         */
+        protected BuilderBase(T instance) {
+            super(instance);
+        }
+
+{{#vendorExtensions.x-render-vars}}
+        /**
+         * Set {{name}}.
+         *
+         * @param {{name}} {{name}} value
+         * @return updated builder
+         */
+        public B {{name}}({{{datatypeWithEnum}}} {{name}}) {
+            instance.{{name}}({{name}});
+            return self();
+        }
+
+{{/vendorExtensions.x-render-vars}}
+    }
+
+{{/vendorExtensions.x-extends-model}}
 {{#vendorExtensions.x-render-vars}}{{#isEnum}}
     public enum {{datatypeWithEnum}} {
         {{#allowableValues}}{{#enumVars}}{{name}}{{^-last}},

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/ComposedSchemasGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/ComposedSchemasGenerationIT.java
@@ -72,6 +72,16 @@ class ComposedSchemasGenerationIT {
     }
 
     @Test
+    void allOfModelBuilderExtendsParentBuilder() throws IOException {
+        String content = read(modelFile("Extended.java"));
+        assertThat(content, containsString("public static BuilderBase<?, ? extends Extended> builder()"));
+        assertThat(content, containsString("public static class Builder extends BuilderBase<Builder, Extended>"));
+        assertThat(content, containsString("extends Base.BuilderBase<B, T>"));
+        assertThat(content, containsString("public Builder name(String name)"));
+        assertThat(content, containsString("public Extended build()"));
+    }
+
+    @Test
     void oneOfSchemaGeneratesInterface() throws IOException {
         String content = read(modelFile("Pet.java"));
         assertThat(content, containsString("public interface Pet"));
@@ -228,7 +238,7 @@ class ComposedSchemasGenerationIT {
                     @Test
                     void oneOfDiscriminatorRoundTrip() {
                         Cat cat = new Cat();
-                        cat.setWhiskers(7);
+                        cat.whiskers(7);
 
                         String json = jsonBinding.serialize((Pet) cat, Pet.class);
                         assertThat(json, containsString("\\\"kind\\\":\\\"cat&special\\\""));
@@ -236,20 +246,31 @@ class ComposedSchemasGenerationIT {
 
                         Pet pet = jsonBinding.deserialize("{\\\"kind\\\":\\\"cat&special\\\",\\\"whiskers\\\":7}", Pet.class);
                         assertThat(pet, instanceOf(Cat.class));
-                        assertThat(((Cat) pet).getWhiskers(), is(7));
+                        assertThat(((Cat) pet).whiskers(), is(7));
                     }
 
                     @Test
                     void anyOfStructuralRoundTrip() {
                         EmailContact emailContact = new EmailContact();
-                        emailContact.setEmail("user@example.com");
+                        emailContact.email("user@example.com");
 
                         String json = jsonBinding.serialize((Contact) emailContact, Contact.class);
                         assertThat(json, containsString("\\\"email\\\":\\\"user@example.com\\\""));
 
                         Contact contact = jsonBinding.deserialize("{\\\"email\\\":\\\"user@example.com\\\"}", Contact.class);
                         assertThat(contact, instanceOf(EmailContact.class));
-                        assertThat(((EmailContact) contact).getEmail(), is("user@example.com"));
+                        assertThat(((EmailContact) contact).email(), is("user@example.com"));
+                    }
+
+                    @Test
+                    void allOfBuilderCanSetParentAndChildProperties() {
+                        Extended extended = Extended.builder()
+                                .id("extended-1")
+                                .name("extended-name")
+                                .build();
+
+                        assertThat(extended.id(), is("extended-1"));
+                        assertThat(extended.name(), is("extended-name"));
                     }
 
                     @Test

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/DiscriminatorAllOfGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/DiscriminatorAllOfGenerationIT.java
@@ -77,7 +77,7 @@ class DiscriminatorAllOfGenerationIT {
     void discriminatorAllOfSubtypeInitializesInheritedDiscriminator() throws IOException {
         String content = read(modelFile("CreateChangeFreezeConditionShape.java"));
         assertThat(content, containsString("public CreateChangeFreezeConditionShape()"));
-        assertThat(content, containsString("setConditionShape(\"CHANGE_FREEZE\");"));
+        assertThat(content, containsString("conditionShape(\"CHANGE_FREEZE\");"));
     }
 
     private static File modelFile(String fileName) {

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/DiscriminatorEnumAllOfGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/DiscriminatorEnumAllOfGenerationIT.java
@@ -42,8 +42,8 @@ class DiscriminatorEnumAllOfGenerationIT {
         Path outputDir = generate("discriminator-enum-repro.yaml");
         String content = read(modelFile(outputDir, "RegionHealthCheckCategoryDetails.java"));
         assertThat(content, containsString("public RegionHealthCheckCategoryDetails()"));
-        assertThat(content, containsString("setCategory(MqlCheckDetails.CategoryEnum.REGION_HEALTH_CHECK);"));
-        assertThat(content, not(containsString("setCategory(\"REGION_HEALTH_CHECK\")")));
+        assertThat(content, containsString("category(MqlCheckDetails.CategoryEnum.REGION_HEALTH_CHECK);"));
+        assertThat(content, not(containsString("category(\"REGION_HEALTH_CHECK\")")));
     }
 
     @Test
@@ -51,7 +51,7 @@ class DiscriminatorEnumAllOfGenerationIT {
         Path outputDir = generate("discriminator-enum-repro.yaml");
         String content = read(modelFile(outputDir, "MqlCheckDetails.java"));
         assertThat(content, containsString("private CategoryEnum category;"));
-        assertThat(content, containsString("public void setCategory(CategoryEnum category)"));
+        assertThat(content, containsString("public void category(CategoryEnum category)"));
         assertThat(content, containsString("public enum CategoryEnum"));
     }
 
@@ -64,11 +64,11 @@ class DiscriminatorEnumAllOfGenerationIT {
         assertThat(parent, containsString("@Json.Subtype(alias = \"TIME_WINDOW_CONSTRAINTS\", value = TimeWindowConstraintsConditionShape.class)"));
 
         String changeFreeze = read(modelFile(outputDir, "ChangeFreezeConditionShape.java"));
-        assertThat(changeFreeze, containsString("setConditionShape(ConditionShapeDetails.ConditionShapeEnum.CHANGE_FREEZE);"));
+        assertThat(changeFreeze, containsString("conditionShape(ConditionShapeDetails.ConditionShapeEnum.CHANGE_FREEZE);"));
         assertThat(changeFreeze, not(containsString("CHANGE_FREEZE_CONDITION_SHAPE")));
 
         String timeWindow = read(modelFile(outputDir, "TimeWindowConstraintsConditionShape.java"));
-        assertThat(timeWindow, containsString("setConditionShape(ConditionShapeDetails.ConditionShapeEnum.TIME_WINDOW_CONSTRAINTS);"));
+        assertThat(timeWindow, containsString("conditionShape(ConditionShapeDetails.ConditionShapeEnum.TIME_WINDOW_CONSTRAINTS);"));
         assertThat(timeWindow, not(containsString("TIME_WINDOW_CONSTRAINTS_CONDITION_SHAPE")));
     }
 
@@ -81,11 +81,11 @@ class DiscriminatorEnumAllOfGenerationIT {
         assertThat(parent, containsString("@Json.Subtype(alias = \"STRING\", value = UserConfigStringValue.class)"));
 
         String stringValue = read(modelFile(outputDir, "UserConfigStringValue.java"));
-        assertThat(stringValue, containsString("setType(UserConfig.TypeEnum.STRING);"));
+        assertThat(stringValue, containsString("type(UserConfig.TypeEnum.STRING);"));
         assertThat(stringValue, not(containsString("USER_CONFIG_STRING_VALUE")));
 
         String instantValue = read(modelFile(outputDir, "UserConfigInstantValue.java"));
-        assertThat(instantValue, containsString("setType(UserConfig.TypeEnum.INSTANT);"));
+        assertThat(instantValue, containsString("type(UserConfig.TypeEnum.INSTANT);"));
         assertThat(instantValue, not(containsString("USER_CONFIG_INSTANT_VALUE")));
     }
 
@@ -97,7 +97,7 @@ class DiscriminatorEnumAllOfGenerationIT {
         assertThat(parent, containsString("AUTHOR_DEFINED_TIME_EXPIRY"));
 
         String explicitSubtype = read(modelFile(outputDir, "ConditionAuthorDefinedExpiringApprovalInvalidationTypeDetails.java"));
-        assertThat(explicitSubtype, containsString("setApprovalInvalidationType("
+        assertThat(explicitSubtype, containsString("approvalInvalidationType("
                 + "ApprovalInvalidationTypeDetails.ApprovalInvalidationTypeEnum.AUTHOR_DEFINED_TIME_EXPIRY);"));
         assertThat(explicitSubtype,
                 not(containsString("CONDITION_AUTHOR_DEFINED_EXPIRING_APPROVAL_INVALIDATION_TYPE_DETAILS")));
@@ -111,7 +111,7 @@ class DiscriminatorEnumAllOfGenerationIT {
         assertThat(parent, containsString("SERVICE_PHONEBOOK_SCOPE"));
 
         String subtype = read(modelFile(outputDir, "ServicePhoneBookScope.java"));
-        assertThat(subtype, containsString("setScopeType(ApplicableScope.ScopeTypeEnum.SERVICE_PHONEBOOK_SCOPE);"));
+        assertThat(subtype, containsString("scopeType(ApplicableScope.ScopeTypeEnum.SERVICE_PHONEBOOK_SCOPE);"));
         assertThat(subtype, not(containsString("SERVICE_PHONE_BOOK_SCOPE")));
     }
 
@@ -123,7 +123,7 @@ class DiscriminatorEnumAllOfGenerationIT {
         assertThat(parent, containsString("CM_PREREQUISITES_VIOLATION"));
 
         String subtype = read(modelFile(outputDir, "CmPreRequisiteViolationConditionShape.java"));
-        assertThat(subtype, containsString("setConditionShape("
+        assertThat(subtype, containsString("conditionShape("
                 + "ConditionShapeDetails.ConditionShapeEnum.CM_PREREQUISITES_VIOLATION);"));
         assertThat(subtype, not(containsString("CM_PRE_REQUISITE_VIOLATION_CONDITION_SHAPE")));
     }
@@ -136,7 +136,7 @@ class DiscriminatorEnumAllOfGenerationIT {
         assertThat(parent, containsString("AUTHOR_DEFINED_TIME_EXPIRY"));
 
         String subtype = read(modelFile(outputDir, "AuthorDefinedExpiryDetails.java"));
-        assertThat(subtype, containsString("setApprovalInvalidationType("
+        assertThat(subtype, containsString("approvalInvalidationType("
                 + "ApprovalInvalidationTypeDetails.ApprovalInvalidationTypeEnum.AUTHOR_DEFINED_TIME_EXPIRY);"));
         assertThat(subtype, not(containsString("AUTHOR_DEFINED_EXPIRY_DETAILS")));
     }
@@ -149,7 +149,7 @@ class DiscriminatorEnumAllOfGenerationIT {
         assertThat(parent, containsString("SERVICE_PHONEBOOK_SCOPE"));
 
         String subtype = read(modelFile(outputDir, "ServicePhoneBookScope.java"));
-        assertThat(subtype, containsString("setScopeType(ApplicableScope.ScopeTypeEnum.SERVICE_PHONEBOOK_SCOPE);"));
+        assertThat(subtype, containsString("scopeType(ApplicableScope.ScopeTypeEnum.SERVICE_PHONEBOOK_SCOPE);"));
         assertThat(subtype, not(containsString("SERVICE_PHONE_BOOK_SCOPE")));
     }
 
@@ -161,7 +161,7 @@ class DiscriminatorEnumAllOfGenerationIT {
         assertThat(parent, containsString("CM_PREREQUISITES_VIOLATION"));
 
         String subtype = read(modelFile(outputDir, "CmPreRequisiteViolationConditionShape.java"));
-        assertThat(subtype, containsString("setConditionShape("
+        assertThat(subtype, containsString("conditionShape("
                 + "ConditionShapeDetails.ConditionShapeEnum.CM_PREREQUISITES_VIOLATION);"));
         assertThat(subtype, not(containsString("CM_PRE_REQUISITE_VIOLATION_CONDITION_SHAPE")));
     }
@@ -177,7 +177,7 @@ class DiscriminatorEnumAllOfGenerationIT {
 
         String subtype = read(modelFile(outputDir, "AuthorDefinedExpiryDetails.java"));
         assertThat(subtype, containsString("public class AuthorDefinedExpiryDetails extends ApprovalInvalidationTypeDetails"));
-        assertThat(subtype, containsString("setApprovalInvalidationType("
+        assertThat(subtype, containsString("approvalInvalidationType("
                 + "ApprovalInvalidationTypeDetails.ApprovalInvalidationTypeEnum.AUTHOR_DEFINED_TIME_EXPIRY);"));
         assertThat(subtype, not(containsString("AUTHOR_DEFINED_EXPIRY_DETAILS")));
     }
@@ -193,7 +193,7 @@ class DiscriminatorEnumAllOfGenerationIT {
 
         String subtype = read(modelFile(outputDir, "ServicePhoneBookScope.java"));
         assertThat(subtype, containsString("public class ServicePhoneBookScope extends ApplicableScope"));
-        assertThat(subtype, containsString("setScopeType(ApplicableScope.ScopeTypeEnum.SERVICE_PHONEBOOK_SCOPE);"));
+        assertThat(subtype, containsString("scopeType(ApplicableScope.ScopeTypeEnum.SERVICE_PHONEBOOK_SCOPE);"));
         assertThat(subtype, not(containsString("SERVICE_PHONE_BOOK_SCOPE")));
     }
 
@@ -206,7 +206,7 @@ class DiscriminatorEnumAllOfGenerationIT {
         assertThat(parent, containsString("@Json.Subtype(alias = \"CM_PREREQUISITES_VIOLATION\", value = CmPreRequisiteViolationConditionShape.class)"));
 
         String subtype = read(modelFile(outputDir, "CmPreRequisiteViolationConditionShape.java"));
-        assertThat(subtype, containsString("setConditionShape("
+        assertThat(subtype, containsString("conditionShape("
                 + "ConditionShapeDetails.ConditionShapeEnum.CM_PREREQUISITES_VIOLATION);"));
         assertThat(subtype, not(containsString("CM_PRE_REQUISITE_VIOLATION_CONDITION_SHAPE")));
     }
@@ -220,7 +220,7 @@ class DiscriminatorEnumAllOfGenerationIT {
         assertThat(parent, containsString("@Json.Subtype(alias = \"SERVICE_PHONEBOOK_SCOPE\", value = ServicePhoneBookScope.class)"));
 
         String subtype = read(modelFile(outputDir, "ServicePhoneBookScope.java"));
-        assertThat(subtype, containsString("setScopeType(ApplicableScope.ScopeTypeEnum.SERVICE_PHONEBOOK_SCOPE);"));
+        assertThat(subtype, containsString("scopeType(ApplicableScope.ScopeTypeEnum.SERVICE_PHONEBOOK_SCOPE);"));
         assertThat(subtype, not(containsString("SERVICE_PHONE_BOOK_SCOPE")));
     }
 
@@ -233,7 +233,7 @@ class DiscriminatorEnumAllOfGenerationIT {
         assertThat(parent, containsString("@Json.Subtype(alias = \"AUTHOR_DEFINED_TIME_EXPIRY\", value = AuthorDefinedExpiryDetails.class)"));
 
         String subtype = read(modelFile(outputDir, "AuthorDefinedExpiryDetails.java"));
-        assertThat(subtype, containsString("setApprovalInvalidationType("
+        assertThat(subtype, containsString("approvalInvalidationType("
                 + "ApprovalInvalidationTypeDetails.ApprovalInvalidationTypeEnum.AUTHOR_DEFINED_TIME_EXPIRY);"));
         assertThat(subtype, not(containsString("AUTHOR_DEFINED_EXPIRY_DETAILS")));
     }
@@ -247,7 +247,7 @@ class DiscriminatorEnumAllOfGenerationIT {
         assertThat(parent, containsString("@Json.Subtype(alias = \"CM_PREREQUISITES_VIOLATION\", value = CmPreRequisiteViolationConditionShape.class)"));
 
         String subtype = read(modelFile(outputDir, "CmPreRequisiteViolationConditionShape.java"));
-        assertThat(subtype, containsString("setConditionShape("
+        assertThat(subtype, containsString("conditionShape("
                 + "ConditionShapeDetails.ConditionShapeEnum.CM_PREREQUISITES_VIOLATION);"));
         assertThat(subtype, not(containsString("CM_PRE_REQUISITE_VIOLATION_CONDITION_SHAPE")));
     }
@@ -263,7 +263,7 @@ class DiscriminatorEnumAllOfGenerationIT {
         assertThat(parent, containsString("@Json.Subtype(alias = \"CM_PREREQUISITES_VIOLATION\", value = CmPreRequisiteViolationConditionShape.class)"));
 
         String subtype = read(modelFile(outputDir, "CmPreRequisiteViolationConditionShape.java"));
-        assertThat(subtype, containsString("setConditionShape("
+        assertThat(subtype, containsString("conditionShape("
                 + "ConditionShapeDetails.ConditionShapeEnum.CM_PREREQUISITES_VIOLATION);"));
         assertThat(subtype, not(containsString("CM_PRE_REQUISITE_VIOLATION_CONDITION_SHAPE")));
     }
@@ -277,7 +277,7 @@ class DiscriminatorEnumAllOfGenerationIT {
         assertThat(parent, containsString("@Json.Subtype(alias = \"SERVICE_PHONEBOOK_SCOPE\", value = ServicePhoneBookScope.class)"));
 
         String subtype = read(modelFile(outputDir, "ServicePhoneBookScope.java"));
-        assertThat(subtype, containsString("setScopeType(ApplicableScope.ScopeTypeEnum.SERVICE_PHONEBOOK_SCOPE);"));
+        assertThat(subtype, containsString("scopeType(ApplicableScope.ScopeTypeEnum.SERVICE_PHONEBOOK_SCOPE);"));
         assertThat(subtype, not(containsString("SERVICE_PHONE_BOOK_SCOPE")));
     }
 
@@ -290,7 +290,7 @@ class DiscriminatorEnumAllOfGenerationIT {
         assertThat(parent, containsString("@Json.Subtype(alias = \"AUTHOR_DEFINED_TIME_EXPIRY\", value = ConditionAuthorDefinedExpiringApprovalInvalidationTypeDetails.class)"));
 
         String subtype = read(modelFile(outputDir, "ConditionAuthorDefinedExpiringApprovalInvalidationTypeDetails.java"));
-        assertThat(subtype, containsString("setApprovalInvalidationType("
+        assertThat(subtype, containsString("approvalInvalidationType("
                 + "ApprovalInvalidationTypeDetails.ApprovalInvalidationTypeEnum.AUTHOR_DEFINED_TIME_EXPIRY);"));
         assertThat(subtype, not(containsString("CONDITION_AUTHOR_DEFINED_EXPIRING_APPROVAL_INVALIDATION_TYPE_DETAILS")));
     }

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/PetstoreGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/PetstoreGenerationIT.java
@@ -278,12 +278,26 @@ class PetstoreGenerationIT {
     }
 
     @Test
-    void petModelHasGettersAndSetters() throws IOException {
+    void petModelHasPrefixlessAccessorsAndMutators() throws IOException {
         String content = read(modelFile("Pet.java"));
-        assertThat(content, containsString("getId()"));
-        assertThat(content, containsString("setId("));
-        assertThat(content, containsString("getName()"));
-        assertThat(content, containsString("setName("));
+        assertThat(content, containsString("id()"));
+        assertThat(content, containsString("id(Long id)"));
+        assertThat(content, containsString("name()"));
+        assertThat(content, containsString("name(String name)"));
+        assertThat(content, not(containsString("getId()")));
+        assertThat(content, not(containsString("setId(")));
+    }
+
+    @Test
+    void petModelHasBuilder() throws IOException {
+        String content = read(modelFile("Pet.java"));
+        assertThat(content, containsString("@Json.BuilderInfo(Pet.Builder.class)"));
+        assertThat(content, containsString("public static BuilderBase<?, ? extends Pet> builder()"));
+        assertThat(content, containsString("public static class Builder extends BuilderBase<Builder, Pet>"));
+        assertThat(content, containsString("implements io.helidon.common.Builder<B, T>"));
+        assertThat(content, containsString("public B id(Long id)"));
+        assertThat(content, containsString("public B name(String name)"));
+        assertThat(content, containsString("public T build()"));
     }
 
     @Test

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/ValidationPrivateFieldIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/ValidationPrivateFieldIT.java
@@ -82,7 +82,7 @@ class ValidationPrivateFieldIT {
         assertThat(read(modelFile("CreateGuardrailsOperationDetails.java")),
                    containsString("""
                            @Validation.String.Length(min = 1, value = 255)
-                               public String getCompartmentId() {
+                               public String compartmentId() {
                            """.stripIndent().trim()));
     }
 
@@ -91,7 +91,7 @@ class ValidationPrivateFieldIT {
         assertThat(read(modelFile("CreateGuardrailsOperationDetails.java")),
                    containsString("""
                            @Validation.String.Length(min = 1, value = 255)
-                               public String getName() {
+                               public String name() {
                            """.stripIndent().trim()));
     }
 


### PR DESCRIPTION

### Description

Add Helidon-style builders to generated OpenAPI models.

Generate prefixless model accessors and mutators that align with builder method names, and add Helidon common Builder support via generated Builder/BuilderBase types. Preserve allOf inheritance by chaining subtype builder bases to parent builder bases, and update discriminator initialization to use the prefixless mutators.

Update OpenAPI generator tests and docs to cover the new model API shape, builder inheritance, JSON binding behavior, and validation placement. See issue #79.


### Documentation

Included in PR.
