### PR TITLE
Make generated OpenAPI Java version configurable

### DIFF
--- a/extensions/openapi-generator/docs/ARCHITECTURE.md
+++ b/extensions/openapi-generator/docs/ARCHITECTURE.md
@@ -79,6 +79,7 @@ Its responsibilities are:
 Important option constants currently supported:
 
 - `helidonVersion`
+- `javaVersion`
 - `generateClient`
 - `generateErrorHandler`
 - `serverOpenApi`

--- a/extensions/openapi-generator/docs/README.md
+++ b/extensions/openapi-generator/docs/README.md
@@ -59,6 +59,9 @@ The module is packaged as a thin jar. Runtime dependencies are copied to
 In the examples below, `4.0.0-SNAPSHOT` is the version of this extension artifact.
 The separate `helidonVersion` option controls which Helidon version is written
 into generated Maven and Gradle projects, and its current default is `4.4.1`.
+The `javaVersion` option controls the generated Maven compiler source and target
+values and the generated Gradle Java toolchain version, and its current default is
+`21`.
 
 For CI-style verification of generated Maven projects in this module, enable
 the `it-tests` Maven profile:
@@ -91,6 +94,7 @@ Add the generator as a dependency of `openapi-generator-maven-plugin`:
                 <output>${project.build.directory}/generated-sources/openapi</output>
                 <configOptions>
                     <helidonVersion>4.4.1</helidonVersion>
+                    <javaVersion>21</javaVersion>
                     <apiPackage>com.example.api</apiPackage>
                     <modelPackage>com.example.model</modelPackage>
                     <invokerPackage>com.example</invokerPackage>
@@ -129,11 +133,12 @@ java -jar openapi-generator/modules/openapi-generator/target/helidon-extensions-
   -g helidon-declarative \
   -i /path/to/openapi.yaml \
   -o /path/to/output \
-  --additional-properties helidonVersion=4.4.1,apiPackage=com.example.api,modelPackage=com.example.model,invokerPackage=com.example
+  --additional-properties helidonVersion=4.4.1,javaVersion=21,apiPackage=com.example.api,modelPackage=com.example.model,invokerPackage=com.example
 ```
 
 Here again, the jar version (`4.0.0-SNAPSHOT`) is the generator version, while
-`helidonVersion=4.4.1` controls the generated project.
+`helidonVersion=4.4.1` controls the generated Helidon dependencies and
+`javaVersion=21` controls the generated project Java compilation level.
 
 Example with the optional-list flag enabled:
 
@@ -153,6 +158,7 @@ Set these under Maven `<configOptions>` or CLI `--additional-properties`.
 | Option | Default | Description |
 |--------|---------|-------------|
 | `helidonVersion` | `4.4.1` | Helidon version written into generated Maven and Gradle builds |
+| `javaVersion` | `21` | Java version written into generated Maven compiler source/target and Gradle toolchain builds |
 | `apiPackage` | `io.helidon.example.api` | Package for generated API, endpoint, client, and error classes |
 | `modelPackage` | `io.helidon.example.model` | Package for generated model classes |
 | `invokerPackage` | `io.helidon.example` | Package for generated `Main.java` |

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -80,6 +80,7 @@ import static org.openapitools.codegen.utils.StringUtils.camelize;
 public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
 
     static final String OPT_HELIDON_VERSION = "helidonVersion";
+    static final String OPT_JAVA_VERSION = "javaVersion";
     static final String OPT_GENERATE_CLIENT = "generateClient";
     static final String OPT_GENERATE_ERROR_HANDLER = "generateErrorHandler";
     static final String OPT_SERVER_OPENAPI = "serverOpenApi";
@@ -112,6 +113,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             "RESPONSES");
 
     private String helidonVersion = "4.4.1";
+    private String javaVersion = "21";
     private boolean generateClient = true;
     private boolean generateErrorHandler = true;
     private boolean serverOpenApi = true;
@@ -173,6 +175,9 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         addOption(OPT_HELIDON_VERSION,
                 "Helidon version written into the generated pom.xml",
                 helidonVersion);
+        addOption(OPT_JAVA_VERSION,
+                "Java version used as the generated Maven source/target and Gradle toolchain version",
+                javaVersion);
         addOption(OPT_GENERATE_CLIENT,
                 "Generate @RestClient.Endpoint interface per tag",
                 String.valueOf(generateClient));
@@ -232,6 +237,9 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         if (additionalProperties.containsKey(OPT_HELIDON_VERSION)) {
             helidonVersion = additionalProperties.get(OPT_HELIDON_VERSION).toString();
         }
+        if (additionalProperties.containsKey(OPT_JAVA_VERSION)) {
+            javaVersion = normalizeJavaVersion(additionalProperties.get(OPT_JAVA_VERSION));
+        }
         if (additionalProperties.containsKey(OPT_GENERATE_CLIENT)) {
             generateClient = Boolean.parseBoolean(
                     additionalProperties.get(OPT_GENERATE_CLIENT).toString());
@@ -275,6 +283,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
 
         // Expose options to all templates via additionalProperties
         additionalProperties.put("helidonVersion", helidonVersion);
+        additionalProperties.put("javaVersion", javaVersion);
         additionalProperties.put("generateClient", generateClient);
         additionalProperties.put("generateErrorHandler", generateErrorHandler);
         additionalProperties.put("serverOpenApi", serverOpenApi);
@@ -302,6 +311,14 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         // Main.java location depends on the (possibly user-supplied) invokerPackage
         String mainFolder = "src/main/java/" + invokerPackage.replace('.', '/');
         supportingFiles.add(new SupportingFile("Main.java.mustache", mainFolder, "Main.java"));
+    }
+
+    private static String normalizeJavaVersion(Object value) {
+        String text = String.valueOf(value).trim();
+        if (!text.matches("[1-9][0-9]*")) {
+            throw new IllegalArgumentException("javaVersion must be a positive integer, but was '" + text + "'");
+        }
+        return text;
     }
 
     // -------------------------------------------------------------------------

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/build.gradle.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/build.gradle.mustache
@@ -24,7 +24,7 @@ version = '{{artifactVersion}}'
 
 java {
     toolchain {
-        languageVersion = JavaLanguageVersion.of(21)
+        languageVersion = JavaLanguageVersion.of({{javaVersion}})
     }
 }
 

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/pom.xml.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/pom.xml.mustache
@@ -190,8 +190,8 @@ limitations under the License.
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
+                    <source>{{javaVersion}}</source>
+                    <target>{{javaVersion}}</target>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>io.helidon.bundles</groupId>

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/HelidonDeclarativeCodegenTest.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/HelidonDeclarativeCodegenTest.java
@@ -221,4 +221,23 @@ class HelidonDeclarativeCodegenTest {
         assertThat(codegen.modelPackage(), is("io.helidon.example.model"));
         assertThat(codegen.getInvokerPackage(), is("io.helidon.example"));
     }
+
+    @Test
+    void processOptsRejectsNonIntegerJavaVersion() {
+        codegen.additionalProperties().put("javaVersion", "1.8");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                          () -> codegen.processOpts());
+
+        assertThat(exception.getMessage(), containsString("javaVersion must be a positive integer"));
+    }
+
+    @Test
+    void processOptsExposesIntegerJavaVersion() {
+        codegen.additionalProperties().put("javaVersion", "17");
+
+        codegen.processOpts();
+
+        assertThat(codegen.additionalProperties().get("javaVersion"), is("17"));
+    }
 }

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/JavaVersionGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/JavaVersionGenerationIT.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.openapi.generator;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.config.CodegenConfigurator;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Integration test for generated-project Java version configuration.
+ */
+class JavaVersionGenerationIT {
+
+    @TempDir
+    static Path outputDir;
+
+    @BeforeAll
+    static void generate() throws Exception {
+        URL resource = JavaVersionGenerationIT.class
+                .getClassLoader()
+                .getResource("petstore.yaml");
+        String specPath = Paths.get(resource.toURI()).toAbsolutePath().toString();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("helidon-declarative")
+                .setInputSpec(specPath)
+                .setOutputDir(outputDir.toString())
+                .addAdditionalProperty("helidonVersion", "4.4.1")
+                .addAdditionalProperty("javaVersion", "25")
+                .addAdditionalProperty("apiPackage", "io.helidon.example.api")
+                .addAdditionalProperty("modelPackage", "io.helidon.example.model")
+                .addAdditionalProperty("invokerPackage", "io.helidon.example");
+
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+    }
+
+    @Test
+    void pomXmlUsesConfiguredJavaVersionAsSourceAndTarget() throws IOException {
+        String pom = read(outputDir.resolve("pom.xml"));
+
+        assertThat(pom, containsString("<source>25</source>"));
+        assertThat(pom, containsString("<target>25</target>"));
+    }
+
+    @Test
+    void buildGradleUsesConfiguredJavaVersionAsToolchainVersion() throws IOException {
+        assertThat(read(outputDir.resolve("build.gradle")),
+                   containsString("languageVersion = JavaLanguageVersion.of(25)"));
+    }
+
+    private static String read(Path file) throws IOException {
+        return Files.readString(file).replace("\r\n", "\n");
+    }
+}

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/PetstoreGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/PetstoreGenerationIT.java
@@ -355,6 +355,13 @@ class PetstoreGenerationIT {
     }
 
     @Test
+    void pomXmlDefaultsCompilerSourceAndTargetToJava21() throws IOException {
+        String pom = read(outputDir.resolve("pom.xml").toFile());
+        assertThat(pom, containsString("<source>21</source>"));
+        assertThat(pom, containsString("<target>21</target>"));
+    }
+
+    @Test
     void buildGradleContainsApplicationPlugin() throws IOException {
         assertThat(read(outputDir.resolve("build.gradle").toFile()),
                    containsString("id 'application'"));
@@ -376,6 +383,12 @@ class PetstoreGenerationIT {
     void buildGradleConfiguresMainClass() throws IOException {
         assertThat(read(outputDir.resolve("build.gradle").toFile()),
                    containsString("mainClass = 'io.helidon.example.Main'"));
+    }
+
+    @Test
+    void buildGradleDefaultsJavaToolchainToJava21() throws IOException {
+        assertThat(read(outputDir.resolve("build.gradle").toFile()),
+                   containsString("languageVersion = JavaLanguageVersion.of(21)"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add a javaVersion option to the Helidon declarative OpenAPI generator
- use javaVersion in generated Maven compiler source/target and Gradle Java toolchain files
- validate javaVersion as a positive integer and document the new option
- issue #84

## Testing
- mvn -pl extensions/openapi-generator/modules/openapi-generator test
- mvn clean install