### PR TITLE
Restore serializationLibrary support in OpenAPI generator

### DIFF
--- a/extensions/openapi-generator/docs/ARCHITECTURE.md
+++ b/extensions/openapi-generator/docs/ARCHITECTURE.md
@@ -148,6 +148,10 @@ Notable behavior:
 
 - required properties are marked for JSON-required rendering
 - default values are converted into Java literals
+- serialization library flags are exposed to templates for Helidon JSON, JSON-B,
+  or Jackson output
+- discriminator properties are identified so Jackson can use existing-property
+  polymorphism and JSON-B can avoid unsupported composed-schema generation
 - validation annotations are derived from OpenAPI constraints
 - model validation annotations are emitted on prefixless accessor methods rather
   than private fields
@@ -160,7 +164,12 @@ Notable behavior:
 - composed schemas are normalized into template-friendly flags:
   - `allOf` prefers Java inheritance when there is a single referenced parent
   - `oneOf` and `anyOf` generate model interfaces annotated with a generated
-    `@Json.Converter`
+    `@Json.Converter` for Helidon JSON output
+  - Jackson output supports discriminator-based `oneOf` and `anyOf` using
+    `@JsonTypeInfo` and `@JsonSubTypes`
+  - JSON-B output rejects composed `oneOf` and `anyOf` models because the
+    generated fluent model shape needs field visibility and JSON-B type info
+    cannot safely share the discriminator field
   - union member models implement the generated interface(s)
   - generated converters deserialize using discriminator aliases when present,
     then fall back to structural matching by declared properties
@@ -209,9 +218,11 @@ Current templates:
 - `api-interface.mustache` defines the shared annotated contract.
 - `api.mustache` emits the endpoint stub implementation.
 - `restClient.mustache` extends the shared API contract to reuse HTTP annotations.
-- `model.mustache` generates mutable JSON entity model classes rather than
-  records. Models use prefixless property methods and Helidon-style builders
-  instead of JavaBean getters and setters.
+- `model.mustache` generates mutable JSON model classes rather than records.
+  Models use prefixless property methods and Helidon-style builders instead of
+  JavaBean getters and setters. The selected serialization library controls
+  whether the model uses Helidon JSON binding annotations, JSON-B field
+  visibility, or Jackson property annotations.
 - `api.mustache` does not emit `@RestServer.Listener`, because the default listener is
   already implied.
 
@@ -228,9 +239,11 @@ Per tag:
 Per schema:
 
 - `{Model}.java`
-  - `@Json.Entity` model class
+  - JSON model class using the selected serialization library
   - prefixless accessor and mutator methods for schema properties
-  - `@Json.BuilderInfo` and a generated `Builder` / `BuilderBase<B, T>`
+  - `@Json.BuilderInfo` for Helidon JSON output, JSON-B field visibility for
+    JSON-B output, or Jackson property annotations for Jackson output
+  - a generated `Builder` / `BuilderBase<B, T>`
     implementing `io.helidon.common.Builder`
   - generated nested enums when needed
 
@@ -245,36 +258,45 @@ Module-local integration checks are Maven-only:
 ### Composed Schemas
 
 The generator supports OpenAPI composed schemas using Java shapes that fit the
-existing Helidon-oriented templates:
+selected JSON serialization library:
 
 - `allOf`
   - when exactly one referenced component schema participates, the generated model
     extends that parent and emits only locally owned properties
   - when that parent schema declares a discriminator, the base model is annotated
-    with generated Helidon polymorphism metadata and child models can initialize
-    inherited discriminator values from `x-discriminator-value`
+    with generated Helidon or Jackson polymorphism metadata and child models can
+    initialize inherited discriminator values from `x-discriminator-value`
   - otherwise the generator falls back to a flattened model containing the merged
     properties exposed by `openapi-generator`
 - `oneOf`
-  - the composed schema is generated as a Java interface with a generated
-    `@Json.Converter`
+  - for Helidon JSON output, the composed schema is generated as a Java interface
+    with a generated `@Json.Converter`
+  - for Jackson output, discriminator-based `oneOf` uses `@JsonTypeInfo` with
+    `JsonTypeInfo.As.EXISTING_PROPERTY` and `@JsonSubTypes`
   - each referenced member model implements that interface
   - generated deserialization requires exactly one matching subtype
   - when a discriminator is present, converter dispatch prefers discriminator aliases
   - primitive, array, map, and inline members are rejected with a clear
     unsupported-shape message instead of generating invalid Java
 - `anyOf`
-  - the composed schema is generated as a Java interface with a generated
-    `@Json.Converter`
+  - for Helidon JSON output, the composed schema is generated as a Java interface
+    with a generated `@Json.Converter`
+  - for Jackson output, discriminator-based `anyOf` uses `@JsonTypeInfo` with
+    `JsonTypeInfo.As.EXISTING_PROPERTY` and `@JsonSubTypes`
   - each referenced member model implements that interface
   - generated deserialization requires at least one matching subtype
   - ambiguous structural matches are rejected instead of picking an arbitrary model
   - primitive, array, map, and inline members are rejected with a clear
     unsupported-shape message instead of generating invalid Java
 
-This keeps generated source compilable and preserves assignability between
+Structural `oneOf` and `anyOf` matching is available only with Helidon JSON
+output. JSON-B supports regular object models, but rejects composed `oneOf` and
+`anyOf` models during generation.
+
+These rules keep generated source compilable and preserve assignability between
 concrete member models and the composed OpenAPI type used by operations while
-making the generated request/response types usable with Helidon JSON binding.
+making generated request and response types usable with the selected supported
+JSON binding.
 
 Project-level support:
 
@@ -350,8 +372,10 @@ normal project.
 This keeps verification close to the `openapi-ui` module pattern while still
 validating fresh generator output on every `it-tests` run. Most harness modules
 skip test execution and verify that generated projects build successfully;
-`composed-schemas` also runs a checked-in JSON-binding round-trip test against
-the freshly generated model classes.
+`composed-schemas` runs a checked-in Helidon JSON-binding round-trip test against
+the freshly generated model classes. The `serialization-jsonb` and
+`serialization-jackson` harnesses verify runtime JSON round trips for JSON-B
+regular models and Jackson discriminator polymorphism.
 
 ## Packaging
 

--- a/extensions/openapi-generator/docs/README.md
+++ b/extensions/openapi-generator/docs/README.md
@@ -148,7 +148,7 @@ java -jar openapi-generator/modules/openapi-generator/target/helidon-extensions-
   -g helidon-declarative \
   -i /path/to/openapi.yaml \
   -o /tmp/generated-openapi \
-  --additional-properties helidonVersion=4.4.1,avoidOptionalListParams=true
+  --additional-properties helidonVersion=4.4.1,serializationLibrary=jackson,avoidOptionalListParams=true
 ```
 
 ## Generator Options
@@ -159,6 +159,7 @@ Set these under Maven `<configOptions>` or CLI `--additional-properties`.
 |--------|---------|-------------|
 | `helidonVersion` | `4.4.1` | Helidon version written into generated Maven and Gradle builds |
 | `javaVersion` | `21` | Java version written into generated Maven compiler source/target and Gradle toolchain builds |
+| `serializationLibrary` | `helidon` | JSON serialization library for generated models and media dependency: `helidon`, `jsonb`, or `jackson` |
 | `apiPackage` | `io.helidon.example.api` | Package for generated API, endpoint, client, and error classes |
 | `modelPackage` | `io.helidon.example.model` | Package for generated model classes |
 | `invokerPackage` | `io.helidon.example` | Package for generated `Main.java` |
@@ -173,6 +174,86 @@ Set these under Maven `<configOptions>` or CLI `--additional-properties`.
 | `avoidOptionalListParams` | `false` | Generate `List<T>` instead of `Optional<List<T>>` for optional query list params |
 
 Legacy aliases `serveOpenApi` and `serveBasePath` are still accepted for compatibility.
+
+For composed schemas, `jackson` supports discriminator-based `oneOf`/`anyOf`
+models. Structural `oneOf`/`anyOf` models without a discriminator require the default
+`helidon` serialization library. JSON-B is supported for regular object models,
+but not for composed `oneOf`/`anyOf` models.
+
+For example, this structural `oneOf` has no discriminator and fails generation
+with `serializationLibrary=jackson`:
+
+```yaml
+components:
+  schemas:
+    EmailContact:
+      type: object
+      required:
+        - email
+      properties:
+        email:
+          type: string
+    PhoneContact:
+      type: object
+      required:
+        - phone
+      properties:
+        phone:
+          type: string
+    Contact:
+      oneOf:
+        - $ref: '#/components/schemas/EmailContact'
+        - $ref: '#/components/schemas/PhoneContact'
+```
+
+This discriminator-based `anyOf` is supported by `helidon` and `jackson`, but
+fails generation with `serializationLibrary=jsonb` because JSON-B composed
+models are not supported:
+
+```yaml
+components:
+  schemas:
+    Cat:
+      type: object
+      required:
+        - kind
+        - whiskers
+      properties:
+        kind:
+          type: string
+        whiskers:
+          type: integer
+    Dog:
+      type: object
+      required:
+        - kind
+        - bark
+      properties:
+        kind:
+          type: string
+        bark:
+          type: boolean
+    Pet:
+      anyOf:
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+      discriminator:
+        propertyName: kind
+        mapping:
+          cat: '#/components/schemas/Cat'
+          dog: '#/components/schemas/Dog'
+```
+
+### Serialization Libraries
+
+The `serializationLibrary` option controls both generated model annotations and
+the JSON media dependency in generated Maven and Gradle builds.
+
+| Value | Generated model annotations | Generated media dependency | Composed schema support |
+|-------|-----------------------------|----------------------------|-------------------------|
+| `helidon` | `io.helidon.json.binding.Json` annotations and generated converters | `io.helidon.http.media:helidon-http-media-json-binding` | `allOf`, discriminator `oneOf`/`anyOf`, and structural `oneOf`/`anyOf` |
+| `jsonb` | JSON-B annotations with field visibility for generated fluent model methods | `io.helidon.http.media:helidon-http-media-jsonb` | regular object models only; composed `oneOf`/`anyOf` fails generation |
+| `jackson` | Jackson annotations, using existing discriminator properties for polymorphism | `io.helidon.http.media:helidon-http-media-jackson` | `allOf` and discriminator-based `oneOf`/`anyOf`; structural `oneOf`/`anyOf` fails generation |
 
 ## What Gets Generated
 
@@ -191,7 +272,7 @@ Per schema:
 
 | File | Description |
 |------|-------------|
-| `{Model}.java` | Helidon JSON model type with generated builders, validation, and enum support |
+| `{Model}.java` | JSON model type using the selected serialization library, with generated builders, validation, and enum support |
 
 Supporting files:
 
@@ -214,29 +295,37 @@ The generator supports these schema-composition keywords:
 
 - `allOf`: generates an inherited model when there is a single referenced parent
   component; otherwise falls back to a flattened merged model. When the parent
-  schema declares a discriminator, the generator also emits `@Json.Polymorphic`
-  and `@Json.Subtype` metadata on the base model and initializes discriminator
-  values for `allOf` subtypes that provide `x-discriminator-value`
+  schema declares a discriminator, the generator also emits library-specific
+  polymorphism metadata on the base model and initializes discriminator values
+  for `allOf` subtypes that provide `x-discriminator-value`
 - `oneOf`: generates a Java interface for the composed schema, attaches a
-  generated `@Json.Converter`, makes member models implement it, and requires
-  exactly one matching subtype during deserialization. Members must be referenced
-  object model schemas; primitive, array, map, and inline members fail generation
-  with a clear unsupported-shape message.
+  generated Helidon JSON converter when `serializationLibrary=helidon`, makes
+  member models implement it, and requires exactly one matching subtype during
+  deserialization. With `serializationLibrary=jackson`, discriminator-based
+  `oneOf` uses Jackson polymorphism metadata. Members must be referenced object
+  model schemas; primitive, array, map, and inline members fail generation with
+  a clear unsupported-shape message.
 - `anyOf`: generates a Java interface for the composed schema, attaches a
-  generated `@Json.Converter`, makes member models implement it, and rejects
-  ambiguous structural matches during deserialization. Members must be referenced
-  object model schemas; primitive, array, map, and inline members fail generation
-  with a clear unsupported-shape message.
+  generated Helidon JSON converter when `serializationLibrary=helidon`, makes
+  member models implement it, and rejects ambiguous structural matches during
+  deserialization. With `serializationLibrary=jackson`, discriminator-based
+  `anyOf` uses Jackson polymorphism metadata. Members must be referenced object
+  model schemas; primitive, array, map, and inline members fail generation with
+  a clear unsupported-shape message.
 
 For union schemas, generated converters use the OpenAPI discriminator when one is
-present. Without a discriminator, they fall back to structural matching based on
-the member models' required and declared properties.
+present. Without a discriminator, Helidon JSON converters fall back to structural
+matching based on the member models' required and declared properties. JSON-B
+does not support generated composed `oneOf`/`anyOf` models.
 
 ### Model API
 
-Generated object schemas are mutable Helidon JSON entities with prefixless
-property accessors and mutators. A schema property named `id` produces `id()`
-and `id(value)` methods instead of JavaBean-style `getId()` and `setId(...)`.
+Generated object schemas are mutable JSON model classes with prefixless property
+accessors and mutators. A schema property named `id` produces `id()` and
+`id(value)` methods instead of JavaBean-style `getId()` and `setId(...)`.
+The selected serialization library determines whether the generated class uses
+Helidon JSON binding annotations, JSON-B field visibility, or Jackson property
+annotations.
 
 Each generated model also has a Helidon-style builder:
 
@@ -304,6 +393,7 @@ and covers:
 - observability options
 - optional query list handling
 - generated project build verification
+- serialization library dependency and runtime round-trip coverage
 
 Generated-project verification is opt-in and runs during `verify` under the
 `it-tests` Maven profile:
@@ -317,6 +407,11 @@ harness invokes `openapi-generator-maven-plugin` against one test spec, then
 compiles or tests the generated sources in-place. This keeps verification close
 to the `openapi-ui` module approach while still exercising the current generator
 output rather than stale checked-in generated sources.
+
+The `composed-schemas` harness runs a checked-in Helidon JSON-binding round-trip
+test against freshly generated composed models. The `serialization-jsonb` and
+`serialization-jackson` harnesses verify runtime JSON round trips for JSON-B
+regular models and Jackson discriminator polymorphism.
 
 ## Notes
 

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/pom.xml
@@ -42,6 +42,7 @@
         <ftEnabled>false</ftEnabled>
         <tracingEnabled>false</tracingEnabled>
         <metricsEnabled>false</metricsEnabled>
+        <serializationLibrary>helidon</serializationLibrary>
         <skipGeneratedTests>true</skipGeneratedTests>
     </properties>
 
@@ -69,6 +70,14 @@
         <dependency>
             <groupId>io.helidon.http.media</groupId>
             <artifactId>helidon-http-media-json-binding</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.http.media</groupId>
+            <artifactId>helidon-http-media-jsonb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.http.media</groupId>
+            <artifactId>helidon-http-media-jackson</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.validation</groupId>
@@ -221,6 +230,7 @@
                                 <ftEnabled>${ftEnabled}</ftEnabled>
                                 <tracingEnabled>${tracingEnabled}</tracingEnabled>
                                 <metricsEnabled>${metricsEnabled}</metricsEnabled>
+                                <serializationLibrary>${serializationLibrary}</serializationLibrary>
                             </configOptions>
                         </configuration>
                     </execution>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/serialization-jackson/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/serialization-jackson/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.extensions.openapi-generator.it</groupId>
+        <artifactId>openapi-generator-maven-harnesses-parent</artifactId>
+        <version>@project.version@</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>serialization-jackson</artifactId>
+    <name>OpenAPI Generator IT Jackson Serialization</name>
+
+    <properties>
+        <inputSpec>${project.basedir}/../../specs/discriminator-oneof-explicit-value.yaml</inputSpec>
+        <serializationLibrary>jackson</serializationLibrary>
+        <skipGeneratedTests>false</skipGeneratedTests>
+    </properties>
+</project>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/serialization-jackson/src/test/java/io/helidon/example/model/JacksonSerializationLibraryTest.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/serialization-jackson/src/test/java/io/helidon/example/model/JacksonSerializationLibraryTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.example.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class JacksonSerializationLibraryTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @Test
+    void discriminatorModelRoundTrips() throws Exception {
+        AuthorDefinedExpiryDetails value = new AuthorDefinedExpiryDetails();
+        value.expiryDuration(7);
+
+        String json = mapper.writerFor(ApprovalInvalidationTypeDetails.class).writeValueAsString(value);
+        assertThat(json, containsString("\"approvalInvalidationType\":\"AUTHOR_DEFINED_TIME_EXPIRY\""));
+        assertThat(json, containsString("\"expiryDuration\":7"));
+        assertThat(countOccurrences(json, "\"approvalInvalidationType\""), is(1));
+
+        ApprovalInvalidationTypeDetails parsed = mapper.readValue("""
+                {"approvalInvalidationType":"AUTHOR_DEFINED_TIME_EXPIRY","expiryDuration":7}
+                """, ApprovalInvalidationTypeDetails.class);
+
+        assertThat(parsed, instanceOf(AuthorDefinedExpiryDetails.class));
+        assertThat(((AuthorDefinedExpiryDetails) parsed).expiryDuration(), is(7));
+        assertThat(parsed.approvalInvalidationType(),
+                   is(ApprovalInvalidationTypeDetails.ApprovalInvalidationTypeEnum.AUTHOR_DEFINED_TIME_EXPIRY));
+    }
+
+    private static int countOccurrences(String text, String token) {
+        int count = 0;
+        int index = text.indexOf(token);
+        while (index >= 0) {
+            count++;
+            index = text.indexOf(token, index + token.length());
+        }
+        return count;
+    }
+}

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/serialization-jsonb/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/serialization-jsonb/pom.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.extensions.openapi-generator.it</groupId>
+        <artifactId>openapi-generator-maven-harnesses-parent</artifactId>
+        <version>@project.version@</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>serialization-jsonb</artifactId>
+    <name>OpenAPI Generator IT JSON-B Serialization</name>
+
+    <properties>
+        <inputSpec>${project.basedir}/../../specs/petstore.yaml</inputSpec>
+        <serializationLibrary>jsonb</serializationLibrary>
+        <skipGeneratedTests>false</skipGeneratedTests>
+    </properties>
+</project>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/serialization-jsonb/src/test/java/io/helidon/example/model/JsonbSerializationLibraryTest.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/serialization-jsonb/src/test/java/io/helidon/example/model/JsonbSerializationLibraryTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.example.model;
+
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+class JsonbSerializationLibraryTest {
+
+    private final Jsonb jsonb = JsonbBuilder.create();
+
+    @Test
+    void modelRoundTrips() {
+        Pet value = new Pet();
+        value.id(7L);
+        value.name("Mochi");
+        value.tag("cat");
+
+        String json = jsonb.toJson(value);
+        assertThat(json, containsString("\"id\":7"));
+        assertThat(json, containsString("\"name\":\"Mochi\""));
+        assertThat(json, containsString("\"tag\":\"cat\""));
+
+        Pet parsed = jsonb.fromJson("""
+                {"id":7,"name":"Mochi","tag":"cat"}
+                """, Pet.class);
+
+        assertThat(parsed.id(), is(7L));
+        assertThat(parsed.name(), is("Mochi"));
+        assertThat(parsed.tag(), is("cat"));
+    }
+}

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/pom.xml
@@ -39,6 +39,8 @@
         <module>modules/validation-private-field</module>
         <module>modules/discriminator-enum-mapping-repro</module>
         <module>modules/discriminator-enum-mapping-repro-2</module>
+        <module>modules/serialization-jsonb</module>
+        <module>modules/serialization-jackson</module>
         <module>modules/composed-schemas</module>
     </modules>
 </project>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/discriminator-oneof-explicit-value.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/discriminator-oneof-explicit-value.yaml
@@ -1,0 +1,58 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+openapi: 3.0.3
+info:
+  title: discriminator-explicit-value
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    ApprovalInvalidationTypeDetails:
+      type: object
+      required:
+        - approvalInvalidationType
+      properties:
+        approvalInvalidationType:
+          type: string
+          enum:
+            - NON_EXPIRING
+            - AUTHOR_DEFINED_TIME_EXPIRY
+      discriminator:
+        propertyName: approvalInvalidationType
+      oneOf:
+        - $ref: '#/components/schemas/AuthorDefinedExpiryDetails'
+        - $ref: '#/components/schemas/NonExpiringDetails'
+
+    AuthorDefinedExpiryDetails:
+      allOf:
+        - $ref: '#/components/schemas/ApprovalInvalidationTypeDetails'
+        - type: object
+          properties:
+            expiryDuration:
+              type: integer
+          example:
+            approvalInvalidationType: AUTHOR_DEFINED_TIME_EXPIRY
+          x-discriminator-value: AUTHOR_DEFINED_TIME_EXPIRY
+
+    NonExpiringDetails:
+      allOf:
+        - $ref: '#/components/schemas/ApprovalInvalidationTypeDetails'
+        - type: object
+          properties:
+            note:
+              type: string
+          x-discriminator-value: NON_EXPIRING

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -18,8 +18,6 @@ package io.helidon.openapi.generator;
 
 import java.io.File;
 import java.io.IOException;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -81,6 +79,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
 
     static final String OPT_HELIDON_VERSION = "helidonVersion";
     static final String OPT_JAVA_VERSION = "javaVersion";
+    static final String OPT_SERIALIZATION_LIBRARY = "serializationLibrary";
     static final String OPT_GENERATE_CLIENT = "generateClient";
     static final String OPT_GENERATE_ERROR_HANDLER = "generateErrorHandler";
     static final String OPT_SERVER_OPENAPI = "serverOpenApi";
@@ -114,6 +113,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
 
     private String helidonVersion = "4.4.1";
     private String javaVersion = "21";
+    private String serializationLibrary = "helidon";
     private boolean generateClient = true;
     private boolean generateErrorHandler = true;
     private boolean serverOpenApi = true;
@@ -178,6 +178,9 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         addOption(OPT_JAVA_VERSION,
                 "Java version used as the generated Maven source/target and Gradle toolchain version",
                 javaVersion);
+        addOption(OPT_SERIALIZATION_LIBRARY,
+                "JSON serialization library to use for generated models: helidon, jsonb, or jackson",
+                serializationLibrary);
         addOption(OPT_GENERATE_CLIENT,
                 "Generate @RestClient.Endpoint interface per tag",
                 String.valueOf(generateClient));
@@ -240,6 +243,10 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         if (additionalProperties.containsKey(OPT_JAVA_VERSION)) {
             javaVersion = normalizeJavaVersion(additionalProperties.get(OPT_JAVA_VERSION));
         }
+        if (additionalProperties.containsKey(OPT_SERIALIZATION_LIBRARY)) {
+            serializationLibrary = SerializationLibrarySupport.normalize(
+                    additionalProperties.get(OPT_SERIALIZATION_LIBRARY));
+        }
         if (additionalProperties.containsKey(OPT_GENERATE_CLIENT)) {
             generateClient = Boolean.parseBoolean(
                     additionalProperties.get(OPT_GENERATE_CLIENT).toString());
@@ -284,6 +291,10 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         // Expose options to all templates via additionalProperties
         additionalProperties.put("helidonVersion", helidonVersion);
         additionalProperties.put("javaVersion", javaVersion);
+        additionalProperties.put("serializationLibrary", serializationLibrary);
+        additionalProperties.put("serializationLibraryHelidon", "helidon".equals(serializationLibrary));
+        additionalProperties.put("serializationLibraryJsonb", "jsonb".equals(serializationLibrary));
+        additionalProperties.put("serializationLibraryJackson", "jackson".equals(serializationLibrary));
         additionalProperties.put("generateClient", generateClient);
         additionalProperties.put("generateErrorHandler", generateErrorHandler);
         additionalProperties.put("serverOpenApi", serverOpenApi);
@@ -644,7 +655,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             }
             // Parameter-level validation annotations
             for (CodegenParameter param : op.allParams) {
-                List<Map<String, Object>> paramValidations = buildParamValidationAnnotations(param);
+                List<Map<String, Object>> paramValidations = ValidationSupport.buildParamValidationAnnotations(param);
                 if (!paramValidations.isEmpty()) {
                     param.vendorExtensions.put("x-validation-annotations", paramValidations);
                     anyParamValidation = true;
@@ -821,6 +832,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         normalizeComposedModels(models, modelsByClassname, unionInterfacesByMember);
         applyUnionInterfaces(models, unionInterfacesByMember);
         applyAllOfDiscriminatorHierarchy(models, modelsByClassname);
+        SerializationLibrarySupport.rejectUnsupportedUnions(serializationLibrary, models);
 
         boolean anyValidation = false;
         for (Map.Entry<String, ModelsMap> entry : result.entrySet()) {
@@ -834,22 +846,33 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
 
                 boolean modelHasValidation = false;
                 List<CodegenProperty> renderVars = renderVars(model);
+                Set<String> discriminatorPropertyNames =
+                        SerializationLibrarySupport.discriminatorPropertyNames(model,
+                                                                               modelsByClassname,
+                                                                               unionInterfacesByMember);
 
                 for (CodegenProperty prop : renderVars) {
+                    String jsonPropertyName = prop.baseName == null ? prop.name : prop.baseName;
+                    prop.vendorExtensions.put("x-json-property-literal",
+                                              JavaStringLiterals.toJavaStringLiteral(jsonPropertyName));
+                    if (discriminatorPropertyNames.contains(jsonPropertyName) || discriminatorPropertyNames.contains(prop.name)) {
+                        prop.vendorExtensions.put("x-is-discriminator-property", Boolean.TRUE);
+                    }
+
                     // Mark required properties for @Json.Required
                     if (prop.required) {
                         prop.vendorExtensions.put("x-json-required", Boolean.TRUE);
                     }
 
                     // Build @Validation.* annotations from OpenAPI constraints
-                    List<Map<String, Object>> validationAnnotations = buildValidationAnnotations(prop);
+                    List<Map<String, Object>> validationAnnotations = ValidationSupport.buildValidationAnnotations(prop);
                     if (!validationAnnotations.isEmpty()) {
                         prop.vendorExtensions.put("x-validation-annotations", validationAnnotations);
                         modelHasValidation = true;
                     }
 
                     // Format default value as a Java literal for field initializer
-                    String javaDefault = formatDefaultValue(prop);
+                    String javaDefault = ValidationSupport.formatDefaultValue(prop);
                     if (javaDefault != null) {
                         prop.vendorExtensions.put("x-default-value", javaDefault);
                     }
@@ -1727,265 +1750,4 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         };
     }
 
-    /**
-     * Maps OpenAPI schema constraints on a property to Helidon {@code @Validation.*} annotations.
-     */
-    private List<Map<String, Object>> buildValidationAnnotations(CodegenProperty prop) {
-        List<Map<String, Object>> result = new ArrayList<>();
-
-        if (prop.isString) {
-            // minLength / maxLength → @Validation.String.Length
-            if (prop.minLength != null || prop.maxLength != null) {
-                List<String> attrs = new ArrayList<>();
-                if (prop.minLength != null) attrs.add("min = " + prop.minLength);
-                if (prop.maxLength != null) attrs.add("value = " + prop.maxLength);
-                result.add(Map.of("annotation",
-                        "@Validation.String.Length(" + String.join(", ", attrs) + ")"));
-            }
-            // pattern → @Validation.String.Pattern
-            if (prop.pattern != null && !prop.pattern.isEmpty()) {
-                String escaped = prop.pattern.replace("\\", "\\\\").replace("\"", "\\\"");
-                result.add(Map.of("annotation", "@Validation.String.Pattern(\"" + escaped + "\")"));
-            }
-        } else if (prop.isInteger) {
-            addIntegerBounds(result, prop.minimum, prop.exclusiveMinimum, prop.maximum, prop.exclusiveMaximum);
-            Integer multipleOf = toIntMultipleOfValue(prop.multipleOf);
-            if (multipleOf != null) {
-                result.add(Map.of("annotation", "@Validation.Integer.MultipleOf(" + multipleOf + ")"));
-            }
-        } else if (prop.isLong) {
-            addLongBounds(result, prop.minimum, prop.exclusiveMinimum, prop.maximum, prop.exclusiveMaximum);
-            Long multipleOf = toLongMultipleOfValue(prop.multipleOf);
-            if (multipleOf != null) {
-                result.add(Map.of("annotation", "@Validation.Long.MultipleOf(" + multipleOf + "L)"));
-            }
-        } else if (prop.isNumber || prop.isFloat || prop.isDouble) {
-            // minimum / maximum → @Validation.Number.Min / Max (string-valued)
-            if (prop.minimum != null) {
-                result.add(Map.of("annotation", "@Validation.Number.Min(\"" + prop.minimum + "\")"));
-            }
-            if (prop.maximum != null) {
-                result.add(Map.of("annotation", "@Validation.Number.Max(\"" + prop.maximum + "\")"));
-            }
-            String multipleOf = toNumberMultipleOfValue(prop.multipleOf);
-            if (multipleOf != null) {
-                result.add(Map.of("annotation", "@Validation.Number.MultipleOf(\"" + multipleOf + "\")"));
-            }
-        }
-
-        // minItems / maxItems → @Validation.Collection.Size (independent of element type)
-        if (prop.isArray && (prop.minItems != null || prop.maxItems != null)) {
-            List<String> attrs = new ArrayList<>();
-            if (prop.minItems != null) attrs.add("min = " + prop.minItems);
-            if (prop.maxItems != null) attrs.add("value = " + prop.maxItems);
-            result.add(Map.of("annotation",
-                    "@Validation.Collection.Size(" + String.join(", ", attrs) + ")"));
-        }
-
-        return result;
-    }
-
-    /**
-     * Formats a property's default value as a Java literal for use in a field initializer.
-     * Returns {@code null} when no useful initializer can be produced (e.g. arrays).
-     */
-    private String formatDefaultValue(CodegenProperty prop) {
-        if (prop.defaultValue == null || prop.defaultValue.isEmpty()) {
-            return null;
-        }
-        String val = prop.defaultValue;
-        if (prop.isEnum) {
-            // Upstream AbstractJavaCodegen already formats the default as "TypeName.CONSTANT"
-            return val;
-        }
-        if (prop.isString) {
-            // Escape backslashes and double-quotes, then wrap in quotes
-            return "\"" + val.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
-        }
-        if (prop.isLong) {
-            return val + "L";
-        }
-        if (prop.isFloat) {
-            return val + "f";
-        }
-        if (prop.isArray || prop.isMap) {
-            return null;  // skip — complex initialization
-        }
-        return val;  // integer, double, boolean — value as-is
-    }
-
-    /**
-     * Maps OpenAPI schema constraints on a parameter to Helidon {@code @Validation.*} annotations.
-     * Mirrors {@link #buildValidationAnnotations(CodegenProperty)} but operates on {@link CodegenParameter}.
-     */
-    private List<Map<String, Object>> buildParamValidationAnnotations(CodegenParameter param) {
-        List<Map<String, Object>> result = new ArrayList<>();
-
-        if (param.isString) {
-            if (param.minLength != null || param.maxLength != null) {
-                List<String> attrs = new ArrayList<>();
-                if (param.minLength != null) attrs.add("min = " + param.minLength);
-                if (param.maxLength != null) attrs.add("value = " + param.maxLength);
-                result.add(Map.of("annotation",
-                        "@Validation.String.Length(" + String.join(", ", attrs) + ")"));
-            }
-            if (param.pattern != null && !param.pattern.isEmpty()) {
-                String escaped = param.pattern.replace("\\", "\\\\").replace("\"", "\\\"");
-                result.add(Map.of("annotation", "@Validation.String.Pattern(\"" + escaped + "\")"));
-            }
-        } else if (param.isInteger) {
-            addIntegerBounds(result, param.minimum, param.exclusiveMinimum, param.maximum, param.exclusiveMaximum);
-            Integer multipleOf = toIntMultipleOfValue(param.multipleOf);
-            if (multipleOf != null) {
-                result.add(Map.of("annotation", "@Validation.Integer.MultipleOf(" + multipleOf + ")"));
-            }
-        } else if (param.isLong) {
-            addLongBounds(result, param.minimum, param.exclusiveMinimum, param.maximum, param.exclusiveMaximum);
-            Long multipleOf = toLongMultipleOfValue(param.multipleOf);
-            if (multipleOf != null) {
-                result.add(Map.of("annotation", "@Validation.Long.MultipleOf(" + multipleOf + "L)"));
-            }
-        } else if (param.isNumber || param.isFloat || param.isDouble) {
-            if (param.minimum != null) {
-                result.add(Map.of("annotation", "@Validation.Number.Min(\"" + param.minimum + "\")"));
-            }
-            if (param.maximum != null) {
-                result.add(Map.of("annotation", "@Validation.Number.Max(\"" + param.maximum + "\")"));
-            }
-            String multipleOf = toNumberMultipleOfValue(param.multipleOf);
-            if (multipleOf != null) {
-                result.add(Map.of("annotation", "@Validation.Number.MultipleOf(\"" + multipleOf + "\")"));
-            }
-        }
-
-        if (param.isArray && (param.minItems != null || param.maxItems != null)) {
-            List<String> attrs = new ArrayList<>();
-            if (param.minItems != null) attrs.add("min = " + param.minItems);
-            if (param.maxItems != null) attrs.add("value = " + param.maxItems);
-            result.add(Map.of("annotation",
-                    "@Validation.Collection.Size(" + String.join(", ", attrs) + ")"));
-        }
-
-        return result;
-    }
-
-    private void addIntegerBounds(List<Map<String, Object>> result,
-                                  String minimum,
-                                  boolean exclusiveMinimum,
-                                  String maximum,
-                                  boolean exclusiveMaximum) {
-        Integer minBound = toIntMinimumBound(minimum, exclusiveMinimum);
-        if (minBound != null) {
-            result.add(Map.of("annotation", "@Validation.Integer.Min(" + minBound + ")"));
-        }
-
-        Integer maxBound = toIntMaximumBound(maximum, exclusiveMaximum);
-        if (maxBound != null) {
-            result.add(Map.of("annotation", "@Validation.Integer.Max(" + maxBound + ")"));
-        }
-    }
-
-    private void addLongBounds(List<Map<String, Object>> result,
-                               String minimum,
-                               boolean exclusiveMinimum,
-                               String maximum,
-                               boolean exclusiveMaximum) {
-        Long minBound = toLongMinimumBound(minimum, exclusiveMinimum);
-        if (minBound != null) {
-            result.add(Map.of("annotation", "@Validation.Long.Min(" + minBound + "L)"));
-        }
-
-        Long maxBound = toLongMaximumBound(maximum, exclusiveMaximum);
-        if (maxBound != null) {
-            result.add(Map.of("annotation", "@Validation.Long.Max(" + maxBound + "L)"));
-        }
-    }
-
-    private Integer toIntMinimumBound(String value, boolean exclusive) {
-        Long bound = parseIntegralMinimumBound(value, exclusive);
-        if (bound == null || bound < Integer.MIN_VALUE || bound > Integer.MAX_VALUE) {
-            return null;
-        }
-        return bound.intValue();
-    }
-
-    private Integer toIntMaximumBound(String value, boolean exclusive) {
-        Long bound = parseIntegralMaximumBound(value, exclusive);
-        if (bound == null || bound < Integer.MIN_VALUE || bound > Integer.MAX_VALUE) {
-            return null;
-        }
-        return bound.intValue();
-    }
-
-    private Long toLongMinimumBound(String value, boolean exclusive) {
-        return parseIntegralMinimumBound(value, exclusive);
-    }
-
-    private Long toLongMaximumBound(String value, boolean exclusive) {
-        return parseIntegralMaximumBound(value, exclusive);
-    }
-
-    private Integer toIntMultipleOfValue(Number value) {
-        Long multipleOf = parseIntegralMultipleOf(value);
-        if (multipleOf == null || multipleOf < Integer.MIN_VALUE || multipleOf > Integer.MAX_VALUE) {
-            return null;
-        }
-        return multipleOf.intValue();
-    }
-
-    private Long toLongMultipleOfValue(Number value) {
-        return parseIntegralMultipleOf(value);
-    }
-
-    private String toNumberMultipleOfValue(Number value) {
-        if (value == null) {
-            return null;
-        }
-        try {
-            return new BigDecimal(value.toString()).stripTrailingZeros().toPlainString();
-        } catch (NumberFormatException ignored) {
-            return null;
-        }
-    }
-
-    private Long parseIntegralMinimumBound(String value, boolean exclusive) {
-        if (value == null) {
-            return null;
-        }
-        try {
-            BigDecimal numeric = new BigDecimal(value);
-            BigDecimal rounded = exclusive
-                    ? numeric.setScale(0, RoundingMode.FLOOR).add(BigDecimal.ONE)
-                    : numeric.setScale(0, RoundingMode.CEILING);
-            return rounded.longValueExact();
-        } catch (ArithmeticException | NumberFormatException ignored) {
-            return null;
-        }
-    }
-
-    private Long parseIntegralMaximumBound(String value, boolean exclusive) {
-        if (value == null) {
-            return null;
-        }
-        try {
-            BigDecimal numeric = new BigDecimal(value);
-            BigDecimal rounded = exclusive
-                    ? numeric.setScale(0, RoundingMode.CEILING).subtract(BigDecimal.ONE)
-                    : numeric.setScale(0, RoundingMode.FLOOR);
-            return rounded.longValueExact();
-        } catch (ArithmeticException | NumberFormatException ignored) {
-            return null;
-        }
-    }
-
-    private Long parseIntegralMultipleOf(Number value) {
-        if (value == null) {
-            return null;
-        }
-        try {
-            return new BigDecimal(value.toString()).longValueExact();
-        } catch (ArithmeticException | NumberFormatException ignored) {
-            return null;
-        }
-    }
 }

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/SerializationLibrarySupport.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/SerializationLibrarySupport.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.openapi.generator;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+import org.openapitools.codegen.CodegenModel;
+
+final class SerializationLibrarySupport {
+    private SerializationLibrarySupport() {
+    }
+
+    static String normalize(Object value) {
+        String text = String.valueOf(value).trim().toLowerCase(Locale.ROOT);
+        if (!Set.of("helidon", "jsonb", "jackson").contains(text)) {
+            throw new IllegalArgumentException("serializationLibrary must be one of helidon, jsonb, or jackson, but was '"
+                                                       + value + "'");
+        }
+        return text;
+    }
+
+    static void rejectUnsupportedUnions(String serializationLibrary, List<CodegenModel> models) {
+        if ("helidon".equals(serializationLibrary)) {
+            return;
+        }
+        for (CodegenModel model : models) {
+            if ("jsonb".equals(serializationLibrary)
+                    && (Boolean.TRUE.equals(model.vendorExtensions.get("x-is-union-interface"))
+                    || Boolean.TRUE.equals(model.vendorExtensions.get("x-has-polymorphic-subtypes")))) {
+                throw new IllegalArgumentException("serializationLibrary=jsonb does not support composed schema "
+                                                           + model.classname
+                                                           + "; use serializationLibrary=helidon for structural "
+                                                           + "oneOf/anyOf or serializationLibrary=jackson for "
+                                                           + "discriminator-based oneOf/anyOf");
+            }
+            if ("jackson".equals(serializationLibrary)
+                    && Boolean.TRUE.equals(model.vendorExtensions.get("x-is-union-interface"))
+                    && !Boolean.TRUE.equals(model.vendorExtensions.get("x-has-union-discriminator"))) {
+                throw new IllegalArgumentException("serializationLibrary=" + serializationLibrary
+                                                           + " requires a discriminator for composed schema "
+                                                           + model.classname
+                                                           + "; structural oneOf/anyOf unions are supported only with "
+                                                           + "serializationLibrary=helidon");
+            }
+        }
+    }
+
+    static Set<String> discriminatorPropertyNames(CodegenModel model,
+                                                  Map<String, CodegenModel> modelsByClassname,
+                                                  Map<String, LinkedHashSet<String>> unionInterfacesByMember) {
+        Set<String> result = new LinkedHashSet<>();
+        addDiscriminatorPropertyName(result, model.vendorExtensions.get("x-polymorphic-key"));
+        addDiscriminatorPropertyName(result, model.vendorExtensions.get("x-allof-discriminator-key"));
+        if (model.discriminator != null) {
+            addDiscriminatorPropertyName(result, model.discriminator.getPropertyBaseName());
+            addDiscriminatorPropertyName(result, model.discriminator.getPropertyName());
+        }
+
+        Set<String> unionInterfaces = unionInterfacesByMember.get(model.classname);
+        if (unionInterfaces != null) {
+            for (String unionInterface : unionInterfaces) {
+                CodegenModel unionModel = modelsByClassname.get(unionInterface);
+                if (unionModel != null) {
+                    addDiscriminatorPropertyName(result, unionModel.vendorExtensions.get("x-union-discriminator-key"));
+                }
+            }
+        }
+        return result;
+    }
+
+    private static void addDiscriminatorPropertyName(Set<String> names, Object name) {
+        if (name != null && !name.toString().isBlank()) {
+            names.add(name.toString());
+        }
+    }
+}

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/ValidationSupport.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/ValidationSupport.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.openapi.generator;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.openapitools.codegen.CodegenParameter;
+import org.openapitools.codegen.CodegenProperty;
+
+final class ValidationSupport {
+    private ValidationSupport() {
+    }
+
+    static List<Map<String, Object>> buildValidationAnnotations(CodegenProperty prop) {
+        List<Map<String, Object>> result = new ArrayList<>();
+
+        if (prop.isString) {
+            if (prop.minLength != null || prop.maxLength != null) {
+                List<String> attrs = new ArrayList<>();
+                if (prop.minLength != null) {
+                    attrs.add("min = " + prop.minLength);
+                }
+                if (prop.maxLength != null) {
+                    attrs.add("value = " + prop.maxLength);
+                }
+                result.add(Map.of("annotation",
+                                  "@Validation.String.Length(" + String.join(", ", attrs) + ")"));
+            }
+            if (prop.pattern != null && !prop.pattern.isEmpty()) {
+                String escaped = prop.pattern.replace("\\", "\\\\").replace("\"", "\\\"");
+                result.add(Map.of("annotation", "@Validation.String.Pattern(\"" + escaped + "\")"));
+            }
+        } else if (prop.isInteger) {
+            addIntegerBounds(result, prop.minimum, prop.exclusiveMinimum, prop.maximum, prop.exclusiveMaximum);
+            Integer multipleOf = toIntMultipleOfValue(prop.multipleOf);
+            if (multipleOf != null) {
+                result.add(Map.of("annotation", "@Validation.Integer.MultipleOf(" + multipleOf + ")"));
+            }
+        } else if (prop.isLong) {
+            addLongBounds(result, prop.minimum, prop.exclusiveMinimum, prop.maximum, prop.exclusiveMaximum);
+            Long multipleOf = toLongMultipleOfValue(prop.multipleOf);
+            if (multipleOf != null) {
+                result.add(Map.of("annotation", "@Validation.Long.MultipleOf(" + multipleOf + "L)"));
+            }
+        } else if (prop.isNumber || prop.isFloat || prop.isDouble) {
+            if (prop.minimum != null) {
+                result.add(Map.of("annotation", "@Validation.Number.Min(\"" + prop.minimum + "\")"));
+            }
+            if (prop.maximum != null) {
+                result.add(Map.of("annotation", "@Validation.Number.Max(\"" + prop.maximum + "\")"));
+            }
+            String multipleOf = toNumberMultipleOfValue(prop.multipleOf);
+            if (multipleOf != null) {
+                result.add(Map.of("annotation", "@Validation.Number.MultipleOf(\"" + multipleOf + "\")"));
+            }
+        }
+
+        if (prop.isArray && (prop.minItems != null || prop.maxItems != null)) {
+            List<String> attrs = new ArrayList<>();
+            if (prop.minItems != null) {
+                attrs.add("min = " + prop.minItems);
+            }
+            if (prop.maxItems != null) {
+                attrs.add("value = " + prop.maxItems);
+            }
+            result.add(Map.of("annotation",
+                              "@Validation.Collection.Size(" + String.join(", ", attrs) + ")"));
+        }
+
+        return result;
+    }
+
+    static String formatDefaultValue(CodegenProperty prop) {
+        if (prop.defaultValue == null || prop.defaultValue.isEmpty()) {
+            return null;
+        }
+        String val = prop.defaultValue;
+        if (prop.isEnum) {
+            return val;
+        }
+        if (prop.isString) {
+            return "\"" + val.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
+        }
+        if (prop.isLong) {
+            return val + "L";
+        }
+        if (prop.isFloat) {
+            return val + "f";
+        }
+        if (prop.isArray || prop.isMap) {
+            return null;
+        }
+        return val;
+    }
+
+    static List<Map<String, Object>> buildParamValidationAnnotations(CodegenParameter param) {
+        List<Map<String, Object>> result = new ArrayList<>();
+
+        if (param.isString) {
+            if (param.minLength != null || param.maxLength != null) {
+                List<String> attrs = new ArrayList<>();
+                if (param.minLength != null) {
+                    attrs.add("min = " + param.minLength);
+                }
+                if (param.maxLength != null) {
+                    attrs.add("value = " + param.maxLength);
+                }
+                result.add(Map.of("annotation",
+                                  "@Validation.String.Length(" + String.join(", ", attrs) + ")"));
+            }
+            if (param.pattern != null && !param.pattern.isEmpty()) {
+                String escaped = param.pattern.replace("\\", "\\\\").replace("\"", "\\\"");
+                result.add(Map.of("annotation", "@Validation.String.Pattern(\"" + escaped + "\")"));
+            }
+        } else if (param.isInteger) {
+            addIntegerBounds(result, param.minimum, param.exclusiveMinimum, param.maximum, param.exclusiveMaximum);
+            Integer multipleOf = toIntMultipleOfValue(param.multipleOf);
+            if (multipleOf != null) {
+                result.add(Map.of("annotation", "@Validation.Integer.MultipleOf(" + multipleOf + ")"));
+            }
+        } else if (param.isLong) {
+            addLongBounds(result, param.minimum, param.exclusiveMinimum, param.maximum, param.exclusiveMaximum);
+            Long multipleOf = toLongMultipleOfValue(param.multipleOf);
+            if (multipleOf != null) {
+                result.add(Map.of("annotation", "@Validation.Long.MultipleOf(" + multipleOf + "L)"));
+            }
+        } else if (param.isNumber || param.isFloat || param.isDouble) {
+            if (param.minimum != null) {
+                result.add(Map.of("annotation", "@Validation.Number.Min(\"" + param.minimum + "\")"));
+            }
+            if (param.maximum != null) {
+                result.add(Map.of("annotation", "@Validation.Number.Max(\"" + param.maximum + "\")"));
+            }
+            String multipleOf = toNumberMultipleOfValue(param.multipleOf);
+            if (multipleOf != null) {
+                result.add(Map.of("annotation", "@Validation.Number.MultipleOf(\"" + multipleOf + "\")"));
+            }
+        }
+
+        if (param.isArray && (param.minItems != null || param.maxItems != null)) {
+            List<String> attrs = new ArrayList<>();
+            if (param.minItems != null) {
+                attrs.add("min = " + param.minItems);
+            }
+            if (param.maxItems != null) {
+                attrs.add("value = " + param.maxItems);
+            }
+            result.add(Map.of("annotation",
+                              "@Validation.Collection.Size(" + String.join(", ", attrs) + ")"));
+        }
+
+        return result;
+    }
+
+    private static void addIntegerBounds(List<Map<String, Object>> result,
+                                         String minimum,
+                                         boolean exclusiveMinimum,
+                                         String maximum,
+                                         boolean exclusiveMaximum) {
+        Integer minBound = toIntMinimumBound(minimum, exclusiveMinimum);
+        if (minBound != null) {
+            result.add(Map.of("annotation", "@Validation.Integer.Min(" + minBound + ")"));
+        }
+
+        Integer maxBound = toIntMaximumBound(maximum, exclusiveMaximum);
+        if (maxBound != null) {
+            result.add(Map.of("annotation", "@Validation.Integer.Max(" + maxBound + ")"));
+        }
+    }
+
+    private static void addLongBounds(List<Map<String, Object>> result,
+                                      String minimum,
+                                      boolean exclusiveMinimum,
+                                      String maximum,
+                                      boolean exclusiveMaximum) {
+        Long minBound = toLongMinimumBound(minimum, exclusiveMinimum);
+        if (minBound != null) {
+            result.add(Map.of("annotation", "@Validation.Long.Min(" + minBound + "L)"));
+        }
+
+        Long maxBound = toLongMaximumBound(maximum, exclusiveMaximum);
+        if (maxBound != null) {
+            result.add(Map.of("annotation", "@Validation.Long.Max(" + maxBound + "L)"));
+        }
+    }
+
+    private static Integer toIntMinimumBound(String value, boolean exclusive) {
+        Long bound = parseIntegralMinimumBound(value, exclusive);
+        if (bound == null || bound < Integer.MIN_VALUE || bound > Integer.MAX_VALUE) {
+            return null;
+        }
+        return bound.intValue();
+    }
+
+    private static Integer toIntMaximumBound(String value, boolean exclusive) {
+        Long bound = parseIntegralMaximumBound(value, exclusive);
+        if (bound == null || bound < Integer.MIN_VALUE || bound > Integer.MAX_VALUE) {
+            return null;
+        }
+        return bound.intValue();
+    }
+
+    private static Long toLongMinimumBound(String value, boolean exclusive) {
+        return parseIntegralMinimumBound(value, exclusive);
+    }
+
+    private static Long toLongMaximumBound(String value, boolean exclusive) {
+        return parseIntegralMaximumBound(value, exclusive);
+    }
+
+    private static Integer toIntMultipleOfValue(Number value) {
+        Long multipleOf = parseIntegralMultipleOf(value);
+        if (multipleOf == null || multipleOf < Integer.MIN_VALUE || multipleOf > Integer.MAX_VALUE) {
+            return null;
+        }
+        return multipleOf.intValue();
+    }
+
+    private static Long toLongMultipleOfValue(Number value) {
+        return parseIntegralMultipleOf(value);
+    }
+
+    private static String toNumberMultipleOfValue(Number value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return new BigDecimal(value.toString()).stripTrailingZeros().toPlainString();
+        } catch (NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static Long parseIntegralMinimumBound(String value, boolean exclusive) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            BigDecimal numeric = new BigDecimal(value);
+            BigDecimal rounded = exclusive
+                    ? numeric.setScale(0, RoundingMode.FLOOR).add(BigDecimal.ONE)
+                    : numeric.setScale(0, RoundingMode.CEILING);
+            return rounded.longValueExact();
+        } catch (ArithmeticException | NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static Long parseIntegralMaximumBound(String value, boolean exclusive) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            BigDecimal numeric = new BigDecimal(value);
+            BigDecimal rounded = exclusive
+                    ? numeric.setScale(0, RoundingMode.CEILING).subtract(BigDecimal.ONE)
+                    : numeric.setScale(0, RoundingMode.FLOOR);
+            return rounded.longValueExact();
+        } catch (ArithmeticException | NumberFormatException ignored) {
+            return null;
+        }
+    }
+
+    private static Long parseIntegralMultipleOf(Number value) {
+        if (value == null) {
+            return null;
+        }
+        try {
+            return new BigDecimal(value.toString()).longValueExact();
+        } catch (ArithmeticException | NumberFormatException ignored) {
+            return null;
+        }
+    }
+}

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/build.gradle.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/build.gradle.mustache
@@ -41,7 +41,15 @@ dependencies {
 
     implementation 'io.helidon.webserver:helidon-webserver'
     implementation 'io.helidon.service:helidon-service-registry'
+    {{#serializationLibraryHelidon}}
     implementation 'io.helidon.http.media:helidon-http-media-json-binding'
+    {{/serializationLibraryHelidon}}
+    {{#serializationLibraryJsonb}}
+    implementation 'io.helidon.http.media:helidon-http-media-jsonb'
+    {{/serializationLibraryJsonb}}
+    {{#serializationLibraryJackson}}
+    implementation 'io.helidon.http.media:helidon-http-media-jackson'
+    {{/serializationLibraryJackson}}
 
     {{#hasValidation}}
     implementation 'io.helidon.validation:helidon-validation'

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
@@ -17,8 +17,24 @@ limitations under the License.
 {{#models}}
 package {{modelPackage}};
 
+{{#serializationLibraryHelidon}}
 import io.helidon.json.binding.Json;
-{{#model}}{{#vendorExtensions.x-is-union-interface}}import java.io.ByteArrayOutputStream;
+{{/serializationLibraryHelidon}}
+{{#serializationLibraryJsonb}}
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import jakarta.json.bind.annotation.JsonbProperty;
+import jakarta.json.bind.annotation.JsonbTransient;
+import jakarta.json.bind.annotation.JsonbVisibility;
+import jakarta.json.bind.config.PropertyVisibilityStrategy;
+{{/serializationLibraryJsonb}}
+{{#serializationLibraryJackson}}
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+{{/serializationLibraryJackson}}
+{{#model}}{{#vendorExtensions.x-is-union-interface}}{{#serializationLibraryHelidon}}import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -36,7 +52,7 @@ import io.helidon.json.binding.JsonConverter;
 import io.helidon.json.binding.JsonDeserializer;
 import io.helidon.json.binding.JsonSerializer;
 import io.helidon.service.registry.Service;
-{{/vendorExtensions.x-is-union-interface}}{{/model}}
+{{/serializationLibraryHelidon}}{{/vendorExtensions.x-is-union-interface}}{{/model}}
 {{#imports}}
 import {{import}};
 {{/imports}}
@@ -45,10 +61,16 @@ import {{import}};
 /**
  * {{description}}{{^description}}{{classname}} model.{{/description}}
  */
-{{#vendorExtensions.x-is-union-interface}}@Json.Converter({{classname}}.{{classname}}JsonConverter.class)
+{{#vendorExtensions.x-is-union-interface}}{{#serializationLibraryHelidon}}@Json.Converter({{classname}}.{{classname}}JsonConverter.class)
+{{/serializationLibraryHelidon}}{{#serializationLibraryJackson}}{{#vendorExtensions.x-has-union-discriminator}}@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = {{{vendorExtensions.x-union-discriminator-key-literal}}}, visible = true)
+@JsonSubTypes({
+{{#vendorExtensions.x-union-members}}        @JsonSubTypes.Type(value = {{name}}.class, name = {{{aliasLiteral}}}){{^last}},{{/last}}
+{{/vendorExtensions.x-union-members}}})
+{{/vendorExtensions.x-has-union-discriminator}}{{/serializationLibraryJackson}}
 {{#isDeprecated}}@Deprecated
 {{/isDeprecated}}public interface {{classname}} {
 
+{{#serializationLibraryHelidon}}
     final class {{classname}}JsonConverter implements JsonConverter<{{classname}}> {
 {{#vendorExtensions.x-union-members}}
         private JsonDeserializer<{{name}}> {{deserializerField}};
@@ -330,8 +352,10 @@ import {{import}};
         }
     }
 
+{{/serializationLibraryHelidon}}
 }
 
+{{#serializationLibraryHelidon}}
 @Service.Singleton
 final class {{classname}}JsonBindingFactory implements JsonBindingFactory<{{classname}}> {
 
@@ -360,19 +384,46 @@ final class {{classname}}JsonBindingFactory implements JsonBindingFactory<{{clas
         return Set.of({{classname}}.class);
     }
 }
-{{/vendorExtensions.x-is-union-interface}}{{^vendorExtensions.x-is-union-interface}}@Json.Entity
+{{/serializationLibraryHelidon}}
+{{/vendorExtensions.x-is-union-interface}}{{^vendorExtensions.x-is-union-interface}}{{#serializationLibraryHelidon}}@Json.Entity
 {{#vendorExtensions.x-has-polymorphic-subtypes}}@Json.Polymorphic(key = {{{vendorExtensions.x-polymorphic-key-literal}}})
 {{#vendorExtensions.x-polymorphic-subtypes}}@Json.Subtype(alias = {{{aliasLiteral}}}, value = {{name}}.class)
 {{/vendorExtensions.x-polymorphic-subtypes}}{{/vendorExtensions.x-has-polymorphic-subtypes}}
+{{/serializationLibraryHelidon}}{{#serializationLibraryJackson}}{{#vendorExtensions.x-has-polymorphic-subtypes}}@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.EXISTING_PROPERTY, property = {{{vendorExtensions.x-polymorphic-key-literal}}}, visible = true)
+@JsonSubTypes({
+{{#vendorExtensions.x-polymorphic-subtypes}}        @JsonSubTypes.Type(value = {{name}}.class, name = {{{aliasLiteral}}}){{^last}},{{/last}}
+{{/vendorExtensions.x-polymorphic-subtypes}}})
+{{/vendorExtensions.x-has-polymorphic-subtypes}}{{/serializationLibraryJackson}}
 {{#isDeprecated}}@Deprecated
 {{/isDeprecated}}{{#vendorExtensions.x-has-validations}}@Validation.Validated
-{{/vendorExtensions.x-has-validations}}@Json.BuilderInfo({{classname}}.Builder.class)
+{{/vendorExtensions.x-has-validations}}{{#serializationLibraryJsonb}}@JsonbVisibility({{classname}}.JsonbFieldVisibility.class)
+{{/serializationLibraryJsonb}}{{#serializationLibraryHelidon}}@Json.BuilderInfo({{classname}}.Builder.class)
+{{/serializationLibraryHelidon}}
 public class {{classname}}{{#vendorExtensions.x-extends-model}} extends {{vendorExtensions.x-extends-model}}{{/vendorExtensions.x-extends-model}}{{#vendorExtensions.x-has-implements-models}} implements {{#vendorExtensions.x-implements-models}}{{name}}{{^last}}, {{/last}}{{/vendorExtensions.x-implements-models}}{{/vendorExtensions.x-has-implements-models}} {
 
+{{#serializationLibraryJsonb}}
+    public static class JsonbFieldVisibility implements PropertyVisibilityStrategy {
+
+        @Override
+        public boolean isVisible(Field field) {
+            return true;
+        }
+
+        @Override
+        public boolean isVisible(Method method) {
+            return false;
+        }
+    }
+
+{{/serializationLibraryJsonb}}
 {{#vendorExtensions.x-render-vars}}
     {{#description}}/** {{description}} */
-    {{/description}}{{#vendorExtensions.x-json-required}}@Json.Required
-    {{/vendorExtensions.x-json-required}}private {{{datatypeWithEnum}}} {{name}}{{#vendorExtensions.x-default-value}} = {{{vendorExtensions.x-default-value}}}{{/vendorExtensions.x-default-value}};
+    {{/description}}{{#serializationLibraryHelidon}}{{#vendorExtensions.x-json-required}}@Json.Required
+    {{/vendorExtensions.x-json-required}}{{/serializationLibraryHelidon}}{{#serializationLibraryJsonb}}{{#vendorExtensions.x-is-discriminator-property}}@JsonbTransient
+    {{/vendorExtensions.x-is-discriminator-property}}{{^vendorExtensions.x-is-discriminator-property}}@JsonbProperty({{{vendorExtensions.x-json-property-literal}}})
+    {{/vendorExtensions.x-is-discriminator-property}}
+    {{/serializationLibraryJsonb}}{{#serializationLibraryJackson}}@JsonProperty(value = {{{vendorExtensions.x-json-property-literal}}}{{#vendorExtensions.x-json-required}}, required = true{{/vendorExtensions.x-json-required}})
+    {{/serializationLibraryJackson}}private {{{datatypeWithEnum}}} {{name}}{{#vendorExtensions.x-default-value}} = {{{vendorExtensions.x-default-value}}}{{/vendorExtensions.x-default-value}};
 
 {{/vendorExtensions.x-render-vars}}
     /** No-arg constructor. */
@@ -383,11 +434,15 @@ public class {{classname}}{{#vendorExtensions.x-extends-model}} extends {{vendor
 
 {{#vendorExtensions.x-render-vars}}
 {{#vendorExtensions.x-validation-annotations}}    {{{annotation}}}
-{{/vendorExtensions.x-validation-annotations}}    public {{{datatypeWithEnum}}} {{name}}() {
+{{/vendorExtensions.x-validation-annotations}}{{#serializationLibraryJsonb}}{{^vendorExtensions.x-is-discriminator-property}}    @JsonbProperty({{{vendorExtensions.x-json-property-literal}}})
+{{/vendorExtensions.x-is-discriminator-property}}{{#vendorExtensions.x-is-discriminator-property}}    @JsonbTransient
+{{/vendorExtensions.x-is-discriminator-property}}{{/serializationLibraryJsonb}}    public {{{datatypeWithEnum}}} {{name}}() {
         return {{name}};
     }
 
-    public void {{name}}({{{datatypeWithEnum}}} {{name}}) {
+{{#serializationLibraryJsonb}}{{^vendorExtensions.x-is-discriminator-property}}    @JsonbProperty({{{vendorExtensions.x-json-property-literal}}})
+{{/vendorExtensions.x-is-discriminator-property}}{{#vendorExtensions.x-is-discriminator-property}}    @JsonbTransient
+{{/vendorExtensions.x-is-discriminator-property}}{{/serializationLibraryJsonb}}    public void {{name}}({{{datatypeWithEnum}}} {{name}}) {
         this.{{name}} = {{name}};
     }
 
@@ -398,7 +453,13 @@ public class {{classname}}{{#vendorExtensions.x-extends-model}} extends {{vendor
      *
      * @return new builder
      */
+    {{#serializationLibraryHelidon}}
     @Json.Ignore
+    {{/serializationLibraryHelidon}}{{#serializationLibraryJsonb}}
+    @JsonbTransient
+    {{/serializationLibraryJsonb}}{{#serializationLibraryJackson}}
+    @JsonIgnore
+    {{/serializationLibraryJackson}}
     public static BuilderBase<?, ? extends {{classname}}> builder() {
         return new Builder();
     }
@@ -492,7 +553,13 @@ public class {{classname}}{{#vendorExtensions.x-extends-model}} extends {{vendor
      *
      * @return new builder
      */
+    {{#serializationLibraryHelidon}}
     @Json.Ignore
+    {{/serializationLibraryHelidon}}{{#serializationLibraryJsonb}}
+    @JsonbTransient
+    {{/serializationLibraryJsonb}}{{#serializationLibraryJackson}}
+    @JsonIgnore
+    {{/serializationLibraryJackson}}
     public static BuilderBase<?, ? extends {{classname}}> builder() {
         return new Builder();
     }

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/pom.xml.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/pom.xml.mustache
@@ -51,11 +51,27 @@ limitations under the License.
             <artifactId>helidon-service-registry</artifactId>
         </dependency>
 
+        {{#serializationLibraryHelidon}}
         <!-- Helidon build-time JSON media support -->
         <dependency>
             <groupId>io.helidon.http.media</groupId>
             <artifactId>helidon-http-media-json-binding</artifactId>
         </dependency>
+        {{/serializationLibraryHelidon}}
+        {{#serializationLibraryJsonb}}
+        <!-- JSON-B media support -->
+        <dependency>
+            <groupId>io.helidon.http.media</groupId>
+            <artifactId>helidon-http-media-jsonb</artifactId>
+        </dependency>
+        {{/serializationLibraryJsonb}}
+        {{#serializationLibraryJackson}}
+        <!-- Jackson media support -->
+        <dependency>
+            <groupId>io.helidon.http.media</groupId>
+            <artifactId>helidon-http-media-jackson</artifactId>
+        </dependency>
+        {{/serializationLibraryJackson}}
 
         {{#hasValidation}}
         <!-- Helidon build-time validation (@Validation.Validated, @Validation.String.*, etc.) -->

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/HelidonDeclarativeCodegenTest.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/HelidonDeclarativeCodegenTest.java
@@ -233,11 +233,32 @@ class HelidonDeclarativeCodegenTest {
     }
 
     @Test
+    void processOptsRejectsUnknownSerializationLibrary() {
+        codegen.additionalProperties().put("serializationLibrary", "gson");
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                          () -> codegen.processOpts());
+
+        assertThat(exception.getMessage(), containsString("serializationLibrary must be one of helidon, jsonb, or jackson"));
+    }
+
+    @Test
     void processOptsExposesIntegerJavaVersion() {
         codegen.additionalProperties().put("javaVersion", "17");
 
         codegen.processOpts();
 
         assertThat(codegen.additionalProperties().get("javaVersion"), is("17"));
+    }
+
+    @Test
+    void processOptsExposesSerializationLibraryFlags() {
+        codegen.additionalProperties().put("serializationLibrary", "Jackson");
+
+        codegen.processOpts();
+
+        assertThat(codegen.additionalProperties().get("serializationLibrary"), is("jackson"));
+        assertThat(codegen.additionalProperties().get("serializationLibraryJackson"), is(true));
+        assertThat(codegen.additionalProperties().get("serializationLibraryHelidon"), is(false));
     }
 }

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/SerializationLibraryGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/SerializationLibraryGenerationIT.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.openapi.generator;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.config.CodegenConfigurator;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class SerializationLibraryGenerationIT {
+
+    @TempDir
+    Path outputDir;
+
+    @Test
+    void jsonbSerializationLibraryUsesJsonbAnnotationsAndMedia() throws Exception {
+        generate("petstore.yaml", "jsonb");
+
+        String pet = read(modelFile("Pet.java"));
+        assertThat(pet, containsString("import jakarta.json.bind.annotation.JsonbProperty;"));
+        assertThat(pet, containsString("@JsonbProperty(\"name\")"));
+        assertThat(pet, not(containsString("io.helidon.json.binding.Json")));
+        assertThat(pet, not(containsString("com.fasterxml.jackson.annotation.JsonProperty")));
+
+        String pom = read(outputDir.resolve("pom.xml"));
+        assertThat(pom, containsString("helidon-http-media-jsonb"));
+        assertThat(pom, not(containsString("helidon-http-media-json-binding")));
+        assertThat(pom, not(containsString("helidon-http-media-jackson")));
+
+        String gradle = read(outputDir.resolve("build.gradle"));
+        assertThat(gradle, containsString("io.helidon.http.media:helidon-http-media-jsonb"));
+        assertThat(gradle, not(containsString("io.helidon.http.media:helidon-http-media-json-binding")));
+    }
+
+    @Test
+    void jacksonSerializationLibraryUsesJacksonAnnotationsAndMedia() throws Exception {
+        generate("petstore.yaml", "jackson");
+
+        String pet = read(modelFile("Pet.java"));
+        assertThat(pet, containsString("import com.fasterxml.jackson.annotation.JsonProperty;"));
+        assertThat(pet, containsString("@JsonProperty(value = \"name\", required = true)"));
+        assertThat(pet, not(containsString("io.helidon.json.binding.Json")));
+        assertThat(pet, not(containsString("jakarta.json.bind.annotation.JsonbProperty")));
+
+        String pom = read(outputDir.resolve("pom.xml"));
+        assertThat(pom, containsString("helidon-http-media-jackson"));
+        assertThat(pom, not(containsString("helidon-http-media-json-binding")));
+        assertThat(pom, not(containsString("helidon-http-media-jsonb")));
+
+        String gradle = read(outputDir.resolve("build.gradle"));
+        assertThat(gradle, containsString("io.helidon.http.media:helidon-http-media-jackson"));
+        assertThat(gradle, not(containsString("io.helidon.http.media:helidon-http-media-json-binding")));
+    }
+
+    @Test
+    void jsonbSerializationLibraryRejectsComposedSchemas() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                          () -> generate("discriminator-oneof-explicit-value.yaml", "jsonb"));
+
+        assertThat(exception.getMessage(), containsString("serializationLibrary=jsonb does not support composed schema"));
+    }
+
+    @Test
+    void jacksonSerializationLibraryAnnotatesDiscriminatorUnions() throws Exception {
+        generate("discriminator-oneof-explicit-value.yaml", "jackson");
+
+        String model = read(modelFile("ApprovalInvalidationTypeDetails.java"));
+        assertThat(model, containsString("import com.fasterxml.jackson.annotation.JsonSubTypes;"));
+        assertThat(model, containsString("import com.fasterxml.jackson.annotation.JsonTypeInfo;"));
+        assertThat(model, containsString("@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, "
+                                                 + "include = JsonTypeInfo.As.EXISTING_PROPERTY, "
+                                                 + "property = \"approvalInvalidationType\", visible = true)"));
+        assertThat(model, containsString("@JsonSubTypes.Type(value = AuthorDefinedExpiryDetails.class, "
+                                                 + "name = \"AUTHOR_DEFINED_TIME_EXPIRY\")"));
+        assertThat(model, containsString("@JsonSubTypes.Type(value = NonExpiringDetails.class, "
+                                                 + "name = \"NON_EXPIRING\")"));
+    }
+
+    @Test
+    void nonHelidonSerializationLibraryRejectsStructuralUnions() {
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+                                                          () -> generate("composed-schemas.yaml", "jackson"));
+
+        assertThat(exception.getMessage(), containsString("requires a discriminator for composed schema"));
+        assertThat(exception.getMessage(), containsString("structural oneOf/anyOf unions are supported only with "
+                                                                  + "serializationLibrary=helidon"));
+    }
+
+    private void generate(String specName, String serializationLibrary) throws Exception {
+        URL resource = SerializationLibraryGenerationIT.class
+                .getClassLoader()
+                .getResource(specName);
+        String specPath = Paths.get(resource.toURI()).toAbsolutePath().toString();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("helidon-declarative")
+                .setInputSpec(specPath)
+                .setOutputDir(outputDir.toString())
+                .addAdditionalProperty("helidonVersion", "4.4.1")
+                .addAdditionalProperty("serializationLibrary", serializationLibrary)
+                .addAdditionalProperty("apiPackage", "io.helidon.example.api")
+                .addAdditionalProperty("modelPackage", "io.helidon.example.model")
+                .addAdditionalProperty("invokerPackage", "io.helidon.example");
+
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+    }
+
+    private Path modelFile(String name) {
+        return outputDir.resolve("src/main/java/io/helidon/example/model/" + name);
+    }
+
+    private static String read(Path file) throws IOException {
+        return Files.readString(file);
+    }
+}


### PR DESCRIPTION
## Summary
- restore the OpenAPI generator serializationLibrary option with helidon, jsonb, and jackson values
- switch generated Maven/Gradle media dependencies and model annotations by selected library
- support Jackson discriminator polymorphism, keep Helidon JSON as the full oneOf/anyOf implementation, and fail fast for unsupported JSON-B/composed cases
- add generator tests and src/it runtime serialization harnesses for JSON-B and Jackson
- update OpenAPI generator docs and architecture notes

## Testing
- mvn -q -pl extensions/openapi-generator/modules/openapi-generator test
- mvn -q -pl extensions/openapi-generator/modules/openapi-generator -Pit-tests verify
- git diff --check