### PR TITLE
Add OCI SDK v3 SE examples

### DIFF
--- a/extensions/oci-v3/examples/pom.xml
+++ b/extensions/oci-v3/examples/pom.xml
@@ -37,4 +37,9 @@
         <maven.sources.skip>true</maven.sources.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>
     </properties>
+
+    <modules>
+        <module>se-imperative</module>
+        <module>se-declarative</module>
+    </modules>
 </project>

--- a/extensions/oci-v3/examples/se-declarative/README.md
+++ b/extensions/oci-v3/examples/se-declarative/README.md
@@ -1,0 +1,25 @@
+# OCI SDK v3 SE Declarative Example
+
+This example shows how to use the OCI SDK v3 extension from a Helidon SE WebServer built using declarative APIs.
+The application injects OCI authentication and region services from Helidon Service Registry, provides an OCI Object
+Storage client as an application service, and injects that client into a declarative HTTP endpoint.
+
+## Prerequisites
+
+- An OCI tenancy with Object Storage access.
+- A configured OCI authentication method, such as `~/.oci/config`, or an edited `src/main/resources/oci-config.yaml`.
+
+## Build and Run
+
+```shell
+mvn clean package
+java -jar target/helidon-extensions-oci-v3-examples-se-declarative.jar
+```
+
+The application starts on localhost port `8080`.
+
+```shell
+curl http://localhost:8080/objectstorage/namespace
+```
+
+The response is the Object Storage namespace visible to the configured OCI principal.

--- a/extensions/oci-v3/examples/se-declarative/pom.xml
+++ b/extensions/oci-v3/examples/se-declarative/pom.xml
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-se</artifactId>
+        <version>27.0.0-SNAPSHOT</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>io.helidon.extensions.oci.v3.examples</groupId>
+    <artifactId>helidon-extensions-oci-v3-examples-se-declarative</artifactId>
+    <version>27.0.0-SNAPSHOT</version>
+    <name>Helidon Extensions OCI SDK v3 Example SE Declarative</name>
+    <description>Example for Helidon SE using the OCI SDK v3 extension with declarative APIs.</description>
+
+    <properties>
+        <mainClass>io.helidon.extensions.oci.v3.examples.declarative.Main</mainClass>
+        <helidon.extension.oci.v3.version>27.0.0-SNAPSHOT</helidon.extension.oci.v3.version>
+        <version.lib.oci>3.78.1</version.lib.oci>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.extensions.oci.v3</groupId>
+            <artifactId>helidon-extensions-oci-v3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-objectstorage</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-common-httpclient-jersey3</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.oracle.oci.sdk</groupId>
+                <artifactId>oci-java-sdk-bom</artifactId>
+                <version>${version.lib.oci}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.extensions.oci.v3</groupId>
+                <artifactId>helidon-extensions-oci-v3-bom</artifactId>
+                <version>${helidon.extension.oci.v3.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <compilerArgs>
+                        <arg>-Ahelidon.api.incubating=ignore</arg>
+                    </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.bundles</groupId>
+                            <artifactId>helidon-bundles-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.helidon.service</groupId>
+                <artifactId>helidon-service-maven-plugin</artifactId>
+                <version>${helidon.version}</version>
+                <executions>
+                    <execution>
+                        <id>create-application</id>
+                        <goals>
+                            <goal>create-application</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/oci-v3/examples/se-declarative/src/main/java/io/helidon/extensions/oci/v3/examples/declarative/Main.java
+++ b/extensions/oci-v3/examples/se-declarative/src/main/java/io/helidon/extensions/oci/v3/examples/declarative/Main.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.oci.v3.examples.declarative;
+
+import io.helidon.logging.common.LogConfig;
+import io.helidon.service.registry.Service;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.service.registry.Services;
+import io.helidon.webserver.WebServer;
+
+/**
+ * Main class of the example.
+ */
+@Service.GenerateBinding
+public final class Main {
+    static {
+        LogConfig.initClass();
+    }
+
+    private Main() {
+    }
+
+    /**
+     * Application main entry point.
+     *
+     * @param args command line arguments
+     */
+    public static void main(String[] args) {
+        LogConfig.configureRuntime();
+        ServiceRegistryManager.start(ApplicationBinding.create());
+
+        WebServer webServer = Services.get(WebServer.class);
+        System.out.println("WEB server is up! http://localhost:" + webServer.port() + "/objectstorage/namespace");
+    }
+}

--- a/extensions/oci-v3/examples/se-declarative/src/main/java/io/helidon/extensions/oci/v3/examples/declarative/ObjectStorageEndpoint.java
+++ b/extensions/oci-v3/examples/se-declarative/src/main/java/io/helidon/extensions/oci/v3/examples/declarative/ObjectStorageEndpoint.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.oci.v3.examples.declarative;
+
+import io.helidon.http.Http;
+import io.helidon.service.registry.Service;
+import io.helidon.webserver.http.RestServer;
+
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.requests.GetNamespaceRequest;
+
+/**
+ * Declarative REST API for the OCI Object Storage example.
+ */
+@Service.Singleton
+@RestServer.Endpoint
+@Http.Path("/objectstorage")
+class ObjectStorageEndpoint {
+    private final ObjectStorage objectStorage;
+
+    @Service.Inject
+    ObjectStorageEndpoint(ObjectStorage objectStorage) {
+        this.objectStorage = objectStorage;
+    }
+
+    @Http.GET
+    @Http.Path("/namespace")
+    String namespace() {
+        return objectStorage.getNamespace(GetNamespaceRequest.builder().build())
+                .getValue();
+    }
+}

--- a/extensions/oci-v3/examples/se-declarative/src/main/java/io/helidon/extensions/oci/v3/examples/declarative/ObjectStorageFactory.java
+++ b/extensions/oci-v3/examples/se-declarative/src/main/java/io/helidon/extensions/oci/v3/examples/declarative/ObjectStorageFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.oci.v3.examples.declarative;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import io.helidon.service.registry.Service;
+
+import com.oracle.bmc.Region;
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.ObjectStorageClient;
+
+/**
+ * Provides the OCI Object Storage client as an application service.
+ */
+@Service.Singleton
+@Service.ExternalContracts(ObjectStorage.class)
+class ObjectStorageFactory implements Supplier<ObjectStorage> {
+    private final ObjectStorage objectStorage;
+
+    @Service.Inject
+    ObjectStorageFactory(BasicAuthenticationDetailsProvider authenticationDetailsProvider, Optional<Region> region) {
+        ObjectStorageClient.Builder builder = ObjectStorageClient.builder();
+
+        region.ifPresent(builder::region);
+
+        this.objectStorage = builder.build(authenticationDetailsProvider);
+    }
+
+    @Override
+    public ObjectStorage get() {
+        return objectStorage;
+    }
+
+    @Service.PreDestroy
+    void shutdown() {
+        try {
+            objectStorage.close();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to close OCI Object Storage client.", e);
+        }
+    }
+}

--- a/extensions/oci-v3/examples/se-declarative/src/main/java/io/helidon/extensions/oci/v3/examples/declarative/package-info.java
+++ b/extensions/oci-v3/examples/se-declarative/src/main/java/io/helidon/extensions/oci/v3/examples/declarative/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Declarative example for the OCI SDK v3 extension for Helidon.
+ */
+package io.helidon.extensions.oci.v3.examples.declarative;

--- a/extensions/oci-v3/examples/se-declarative/src/main/resources/application.yaml
+++ b/extensions/oci-v3/examples/se-declarative/src/main/resources/application.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server:
+  port: 8080
+  host: 127.0.0.1
+
+declarative:
+  ignore-incubating: true

--- a/extensions/oci-v3/examples/se-declarative/src/main/resources/logging.properties
+++ b/extensions/oci-v3/examples/se-declarative/src/main/resources/logging.properties
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+handlers=java.util.logging.ConsoleHandler
+.level=INFO
+java.util.logging.ConsoleHandler.level=INFO
+java.util.logging.ConsoleHandler.formatter=io.helidon.logging.jul.HelidonFormatter
+com.oracle.bmc.level=INFO

--- a/extensions/oci-v3/examples/se-declarative/src/main/resources/oci-config.yaml
+++ b/extensions/oci-v3/examples/se-declarative/src/main/resources/oci-config.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+helidon.oci:
+  authentication-method: "config-file"
+  authentication:
+    config-file:
+      profile: "DEFAULT"

--- a/extensions/oci-v3/examples/se-declarative/src/test/java/io/helidon/extensions/oci/v3/examples/declarative/MainTest.java
+++ b/extensions/oci-v3/examples/se-declarative/src/test/java/io/helidon/extensions/oci/v3/examples/declarative/MainTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.oci.v3.examples.declarative;
+
+import io.helidon.http.Status;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientResponse;
+import io.helidon.webserver.testing.junit5.ServerTest;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class MainTest {
+    private final Http1Client client;
+
+    MainTest(Http1Client client) {
+        this.client = client;
+    }
+
+    @Test
+    void testNamespace() {
+        try (Http1ClientResponse response = client.get("/objectstorage/namespace").request()) {
+            assertThat(response.status(), is(Status.OK_200));
+            assertThat(response.as(String.class), is(TestObjectStorageFactory.NAMESPACE));
+        }
+    }
+}

--- a/extensions/oci-v3/examples/se-declarative/src/test/java/io/helidon/extensions/oci/v3/examples/declarative/TestObjectStorage.java
+++ b/extensions/oci-v3/examples/se-declarative/src/test/java/io/helidon/extensions/oci/v3/examples/declarative/TestObjectStorage.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.oci.v3.examples.declarative;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.responses.GetNamespaceResponse;
+
+final class TestObjectStorage {
+    private TestObjectStorage() {
+    }
+
+    static ObjectStorage create(String namespace) {
+        return (ObjectStorage) Proxy.newProxyInstance(ObjectStorage.class.getClassLoader(),
+                                                      new Class<?>[] {ObjectStorage.class},
+                                                      (proxy, method, args) -> invoke(proxy, method, args, namespace));
+    }
+
+    private static Object invoke(Object proxy, Method method, Object[] args, String namespace) {
+        return switch (method.getName()) {
+        case "getNamespace" -> GetNamespaceResponse.builder()
+                .value(namespace)
+                .build();
+        case "close" -> null;
+        case "equals" -> proxy == args[0];
+        case "hashCode" -> System.identityHashCode(proxy);
+        case "toString" -> "TestObjectStorage";
+        default -> throw new UnsupportedOperationException(method.toString());
+        };
+    }
+}

--- a/extensions/oci-v3/examples/se-declarative/src/test/java/io/helidon/extensions/oci/v3/examples/declarative/TestObjectStorageFactory.java
+++ b/extensions/oci-v3/examples/se-declarative/src/test/java/io/helidon/extensions/oci/v3/examples/declarative/TestObjectStorageFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.oci.v3.examples.declarative;
+
+import java.util.function.Supplier;
+
+import io.helidon.common.Weight;
+import io.helidon.common.Weighted;
+import io.helidon.service.registry.Service;
+
+import com.oracle.bmc.objectstorage.ObjectStorage;
+
+@Service.Singleton
+@Service.ExternalContracts(ObjectStorage.class)
+@Weight(Weighted.DEFAULT_WEIGHT + 100D)
+class TestObjectStorageFactory implements Supplier<ObjectStorage> {
+    static final String NAMESPACE = "example-namespace";
+
+    private final ObjectStorage objectStorage = TestObjectStorage.create(NAMESPACE);
+
+    @Override
+    public ObjectStorage get() {
+        return objectStorage;
+    }
+}

--- a/extensions/oci-v3/examples/se-declarative/src/test/java/io/helidon/extensions/oci/v3/examples/declarative/package-info.java
+++ b/extensions/oci-v3/examples/se-declarative/src/test/java/io/helidon/extensions/oci/v3/examples/declarative/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the declarative OCI SDK v3 extension example.
+ */
+package io.helidon.extensions.oci.v3.examples.declarative;

--- a/extensions/oci-v3/examples/se-imperative/README.md
+++ b/extensions/oci-v3/examples/se-imperative/README.md
@@ -1,0 +1,25 @@
+# OCI SDK v3 SE Imperative Example
+
+This example shows how to use the OCI SDK v3 extension from a Helidon SE WebServer built using imperative APIs.
+The application obtains `BasicAuthenticationDetailsProvider` and, when configured, `Region` from Helidon Service Registry,
+then builds an OCI Object Storage client directly from the OCI Java SDK.
+
+## Prerequisites
+
+- An OCI tenancy with Object Storage access.
+- A configured OCI authentication method, such as `~/.oci/config`, or an edited `src/main/resources/oci-config.yaml`.
+
+## Build and Run
+
+```shell
+mvn clean package
+java -jar target/helidon-extensions-oci-v3-examples-se-imperative.jar
+```
+
+The application starts on localhost port `8080`.
+
+```shell
+curl http://localhost:8080/objectstorage/namespace
+```
+
+The response is the Object Storage namespace visible to the configured OCI principal.

--- a/extensions/oci-v3/examples/se-imperative/pom.xml
+++ b/extensions/oci-v3/examples/se-imperative/pom.xml
@@ -1,0 +1,119 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.applications</groupId>
+        <artifactId>helidon-se</artifactId>
+        <version>27.0.0-SNAPSHOT</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>io.helidon.extensions.oci.v3.examples</groupId>
+    <artifactId>helidon-extensions-oci-v3-examples-se-imperative</artifactId>
+    <version>27.0.0-SNAPSHOT</version>
+    <name>Helidon Extensions OCI SDK v3 Example SE Imperative</name>
+    <description>Example for Helidon SE using the OCI SDK v3 extension with imperative APIs.</description>
+
+    <properties>
+        <mainClass>io.helidon.extensions.oci.v3.examples.imperative.Main</mainClass>
+        <helidon.extension.oci.v3.version>27.0.0-SNAPSHOT</helidon.extension.oci.v3.version>
+        <version.lib.oci>3.78.1</version.lib.oci>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.extensions.oci.v3</groupId>
+            <artifactId>helidon-extensions-oci-v3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-objectstorage</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-common-httpclient-jersey3</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>com.oracle.oci.sdk</groupId>
+                <artifactId>oci-java-sdk-bom</artifactId>
+                <version>${version.lib.oci}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon.extensions.oci.v3</groupId>
+                <artifactId>helidon-extensions-oci-v3-bom</artifactId>
+                <version>${helidon.extension.oci.v3.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-libs</id>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/oci-v3/examples/se-imperative/src/main/java/io/helidon/extensions/oci/v3/examples/imperative/Main.java
+++ b/extensions/oci-v3/examples/se-imperative/src/main/java/io/helidon/extensions/oci/v3/examples/imperative/Main.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.oci.v3.examples.imperative;
+
+import io.helidon.config.Config;
+import io.helidon.http.Status;
+import io.helidon.logging.common.LogConfig;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.http.HttpRouting;
+
+import com.oracle.bmc.Region;
+import com.oracle.bmc.auth.BasicAuthenticationDetailsProvider;
+import com.oracle.bmc.model.BmcException;
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.ObjectStorageClient;
+
+/**
+ * Main class of the example.
+ */
+public final class Main {
+    private Main() {
+    }
+
+    /**
+     * Application main entry point.
+     *
+     * @param args command line arguments
+     */
+    public static void main(String[] args) {
+        LogConfig.configureRuntime();
+
+        Config config = Config.create();
+        ServiceRegistryManager registryManager = ServiceRegistryManager.create();
+        ObjectStorage objectStorage = objectStorage(registryManager.registry());
+
+        WebServer server = WebServer.builder()
+                .config(config.get("server"))
+                .routing(routing -> routing(routing, objectStorage))
+                .build()
+                .start();
+
+        System.out.println("WEB server is up! http://localhost:" + server.port() + "/objectstorage/namespace");
+    }
+
+    static void routing(HttpRouting.Builder routing, ObjectStorage objectStorage) {
+        routing.register("/objectstorage", new ObjectStorageService(objectStorage))
+                .error(BmcException.class, (req, res, ex) -> res.status(status(ex))
+                        .send(ex.getMessage()));
+    }
+
+    static Status status(BmcException exception) {
+        if (exception.isTimeout()) {
+            return Status.GATEWAY_TIMEOUT_504;
+        }
+        if (exception.isClientSide()) {
+            return Status.BAD_GATEWAY_502;
+        }
+        int status = exception.getStatusCode();
+        if (status >= 100 && status <= 599) {
+            return Status.create(status);
+        }
+        return Status.BAD_GATEWAY_502;
+    }
+
+    static ObjectStorage objectStorage(ServiceRegistry registry) {
+        BasicAuthenticationDetailsProvider authenticationDetailsProvider =
+                registry.get(BasicAuthenticationDetailsProvider.class);
+        ObjectStorageClient.Builder builder = ObjectStorageClient.builder();
+
+        registry.first(Region.class).ifPresent(builder::region);
+
+        return builder.build(authenticationDetailsProvider);
+    }
+}

--- a/extensions/oci-v3/examples/se-imperative/src/main/java/io/helidon/extensions/oci/v3/examples/imperative/ObjectStorageService.java
+++ b/extensions/oci-v3/examples/se-imperative/src/main/java/io/helidon/extensions/oci/v3/examples/imperative/ObjectStorageService.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.oci.v3.examples.imperative;
+
+import java.util.Objects;
+
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.HttpService;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.requests.GetNamespaceRequest;
+
+/**
+ * REST API for the OCI Object Storage example.
+ */
+class ObjectStorageService implements HttpService {
+    private final ObjectStorage objectStorage;
+
+    ObjectStorageService(ObjectStorage objectStorage) {
+        this.objectStorage = Objects.requireNonNull(objectStorage);
+    }
+
+    @Override
+    public void routing(HttpRules rules) {
+        rules.get("/namespace", this::namespace);
+    }
+
+    @Override
+    public void afterStop() {
+        try {
+            objectStorage.close();
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to close OCI Object Storage client.", e);
+        }
+    }
+
+    private void namespace(ServerRequest req, ServerResponse res) {
+        String namespace = objectStorage.getNamespace(GetNamespaceRequest.builder().build())
+                .getValue();
+        res.send(namespace);
+    }
+}

--- a/extensions/oci-v3/examples/se-imperative/src/main/java/io/helidon/extensions/oci/v3/examples/imperative/package-info.java
+++ b/extensions/oci-v3/examples/se-imperative/src/main/java/io/helidon/extensions/oci/v3/examples/imperative/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Imperative example for the OCI SDK v3 extension for Helidon.
+ */
+package io.helidon.extensions.oci.v3.examples.imperative;

--- a/extensions/oci-v3/examples/se-imperative/src/main/resources/application.yaml
+++ b/extensions/oci-v3/examples/se-imperative/src/main/resources/application.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+server:
+  port: 8080
+  host: 127.0.0.1

--- a/extensions/oci-v3/examples/se-imperative/src/main/resources/logging.properties
+++ b/extensions/oci-v3/examples/se-imperative/src/main/resources/logging.properties
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+handlers=java.util.logging.ConsoleHandler
+.level=INFO
+java.util.logging.ConsoleHandler.level=INFO
+java.util.logging.ConsoleHandler.formatter=io.helidon.logging.jul.HelidonFormatter
+com.oracle.bmc.level=INFO

--- a/extensions/oci-v3/examples/se-imperative/src/main/resources/oci-config.yaml
+++ b/extensions/oci-v3/examples/se-imperative/src/main/resources/oci-config.yaml
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+helidon.oci:
+  authentication-method: "config-file"
+  authentication:
+    config-file:
+      profile: "DEFAULT"

--- a/extensions/oci-v3/examples/se-imperative/src/test/java/io/helidon/extensions/oci/v3/examples/imperative/MainTest.java
+++ b/extensions/oci-v3/examples/se-imperative/src/test/java/io/helidon/extensions/oci/v3/examples/imperative/MainTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.oci.v3.examples.imperative;
+
+import io.helidon.http.Status;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+
+import com.oracle.bmc.model.BmcException;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+@ServerTest
+class MainTest {
+    private static final String NAMESPACE = "example-namespace";
+    private static final TestObjectStorage OBJECT_STORAGE = new TestObjectStorage(NAMESPACE);
+
+    private final Http1Client client;
+
+    MainTest(Http1Client client) {
+        this.client = client;
+    }
+
+    @SetUpServer
+    static void server(WebServerConfig.Builder server) {
+        server.routing(routing -> Main.routing(routing, OBJECT_STORAGE.client()));
+    }
+
+    @Test
+    void testNamespace() {
+        var response = client.get("/objectstorage/namespace")
+                .request(String.class);
+
+        assertThat(response.status(), is(Status.OK_200));
+        assertThat(response.entity(), is(NAMESPACE));
+    }
+
+    @Test
+    void testObjectStorageClosedAfterStop() {
+        TestObjectStorage objectStorage = new TestObjectStorage(NAMESPACE);
+
+        new ObjectStorageService(objectStorage.client()).afterStop();
+
+        assertThat(objectStorage.closed(), is(true));
+    }
+
+    @Test
+    void testStatusForServiceException() {
+        assertThat(Main.status(new BmcException(404, "NotFound", "missing", "request-id")), is(Status.NOT_FOUND_404));
+    }
+
+    @Test
+    void testStatusForClientSideException() {
+        BmcException exception = BmcException.createClientSide("client failed",
+                                                              new IllegalStateException("client failed"),
+                                                              null,
+                                                              null);
+
+        assertThat(Main.status(exception), is(Status.BAD_GATEWAY_502));
+    }
+
+    @Test
+    void testStatusForTimeoutException() {
+        BmcException exception = new BmcException(true,
+                                                 "timeout",
+                                                 new IllegalStateException("timeout"),
+                                                 null);
+
+        assertThat(Main.status(exception), is(Status.GATEWAY_TIMEOUT_504));
+    }
+}

--- a/extensions/oci-v3/examples/se-imperative/src/test/java/io/helidon/extensions/oci/v3/examples/imperative/TestObjectStorage.java
+++ b/extensions/oci-v3/examples/se-imperative/src/test/java/io/helidon/extensions/oci/v3/examples/imperative/TestObjectStorage.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.oci.v3.examples.imperative;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.responses.GetNamespaceResponse;
+
+final class TestObjectStorage {
+    private final AtomicBoolean closed = new AtomicBoolean();
+    private final ObjectStorage client;
+
+    TestObjectStorage(String namespace) {
+        this.client = (ObjectStorage) Proxy.newProxyInstance(ObjectStorage.class.getClassLoader(),
+                                                             new Class<?>[] {ObjectStorage.class},
+                                                             (proxy, method, args) -> invoke(proxy, method, args, namespace));
+    }
+
+    ObjectStorage client() {
+        return client;
+    }
+
+    boolean closed() {
+        return closed.get();
+    }
+
+    private Object invoke(Object proxy, Method method, Object[] args, String namespace) {
+        return switch (method.getName()) {
+        case "getNamespace" -> GetNamespaceResponse.builder()
+                .value(namespace)
+                .build();
+        case "close" -> {
+            closed.set(true);
+            yield null;
+        }
+        case "equals" -> proxy == args[0];
+        case "hashCode" -> System.identityHashCode(proxy);
+        case "toString" -> "TestObjectStorage";
+        default -> throw new UnsupportedOperationException(method.toString());
+        };
+    }
+}

--- a/extensions/oci-v3/examples/se-imperative/src/test/java/io/helidon/extensions/oci/v3/examples/imperative/package-info.java
+++ b/extensions/oci-v3/examples/se-imperative/src/test/java/io/helidon/extensions/oci/v3/examples/imperative/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for the imperative OCI SDK v3 extension example.
+ */
+package io.helidon.extensions.oci.v3.examples.imperative;


### PR DESCRIPTION
Resolves helidon-io/helidon-extensions#54

- Adds OCI SDK v3 SE imperative example
- Adds OCI SDK v3 SE declarative example using Helidon Service Registry
- Adds offline route tests with stubbed OCI Object Storage clients

Validation:
- mvn -Pexamples -pl extensions/oci-v3/examples/se-imperative,extensions/oci-v3/examples/se-declarative -am -ntp test
- mvn -Pexamples -pl extensions/oci-v3/examples/se-imperative,extensions/oci-v3/examples/se-declarative -am -ntp package
- mvn -Pexamples,copyright -pl extensions/oci-v3/examples/se-imperative,extensions/oci-v3/examples/se-declarative -am -DskipTests -ntp validate
- git diff --check

Pre-PR review:
- Reran prior-finding lanes: quality, tests, runtime safety, security
- No findings