### PR TITLE
Use Helidon JSON in agentic MCP server

### DIFF
--- a/extensions/langchain4j/tests/agentic-mcp/src/main/java/io/helidon/extensions/langchain4j/tests/agenticmcp/CliExpert.java
+++ b/extensions/langchain4j/tests/agentic-mcp/src/main/java/io/helidon/extensions/langchain4j/tests/agenticmcp/CliExpert.java
@@ -30,6 +30,12 @@ import dev.langchain4j.service.V;
 @Ai.McpClients("cli-tools-mcp-server")
 public interface CliExpert {
 
+    /**
+     * Answer a Helidon CLI request.
+     *
+     * @param request user request
+     * @return CLI guidance
+     */
     @UserMessage("""
             You are a command line expert helping users with Helidon CLI.
             Provide a short step-by-step answer to the request: {{request}}

--- a/extensions/langchain4j/tests/agentic-mcp/src/main/java/io/helidon/extensions/langchain4j/tests/agenticmcp/CliService.java
+++ b/extensions/langchain4j/tests/agentic-mcp/src/main/java/io/helidon/extensions/langchain4j/tests/agenticmcp/CliService.java
@@ -21,9 +21,19 @@ import io.helidon.extensions.langchain4j.Ai;
 import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
 
+/**
+ * Declarative service that answers Helidon CLI requests through an MCP client.
+ */
 @Ai.Service("cli-service")
 @Ai.McpClients("cli-tools-mcp-server")
 public interface CliService {
+
+    /**
+     * Answer a Helidon CLI request.
+     *
+     * @param request user request
+     * @return CLI guidance
+     */
     @UserMessage("""
             You are a command line expert helping users with Helidon CLI.
             Provide a short step-by-step answer to the request: {{request}}

--- a/extensions/langchain4j/tests/agentic-mcp/src/main/java/io/helidon/extensions/langchain4j/tests/agenticmcp/package-info.java
+++ b/extensions/langchain4j/tests/agentic-mcp/src/main/java/io/helidon/extensions/langchain4j/tests/agenticmcp/package-info.java
@@ -14,27 +14,7 @@
  * limitations under the License.
  */
 
-package io.helidon.extensions.langchain4j.tests.agenticmcp;
-
-import io.helidon.extensions.langchain4j.Ai;
-
-import dev.langchain4j.agentic.declarative.SequenceAgent;
-import dev.langchain4j.service.V;
-
 /**
- * Sequential agent that delegates Helidon CLI requests to the CLI expert.
+ * Test fixtures for LangChain4j agentic MCP integration.
  */
-@Ai.Agent("sequential-agent")
-public interface SequentialAgent {
-
-    /**
-     * Ask the sequential agent for a response.
-     *
-     * @param request user request
-     * @return agent response
-     */
-    @SequenceAgent(outputKey = "response", subAgents = {
-            CliExpert.class
-    })
-    String ask(@V("request") String request);
-}
+package io.helidon.extensions.langchain4j.tests.agenticmcp;

--- a/extensions/langchain4j/tests/agentic-mcp/src/main/java/module-info.java
+++ b/extensions/langchain4j/tests/agentic-mcp/src/main/java/module-info.java
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+/**
+ * Test module for LangChain4j agentic MCP integration.
+ */
 module io.helidon.extensions.langchain4j.tests.agenticmcp {
     requires langchain4j.agentic;
     requires langchain4j;

--- a/extensions/langchain4j/tests/agentic-mcp/src/test/java/io/helidon/extensions/langchain4j/tests/agenticmcp/SimpleMcpServer.java
+++ b/extensions/langchain4j/tests/agentic-mcp/src/test/java/io/helidon/extensions/langchain4j/tests/agenticmcp/SimpleMcpServer.java
@@ -16,22 +16,16 @@
 
 package io.helidon.extensions.langchain4j.tests.agenticmcp;
 
-import java.util.Map;
+import java.util.List;
 
 import io.helidon.http.HeaderValues;
+import io.helidon.json.JsonObject;
 import io.helidon.webserver.jsonrpc.JsonRpcHandlers;
 import io.helidon.webserver.jsonrpc.JsonRpcRequest;
 import io.helidon.webserver.jsonrpc.JsonRpcResponse;
 import io.helidon.webserver.jsonrpc.JsonRpcRouting;
 
-import jakarta.json.Json;
-import jakarta.json.JsonBuilderFactory;
-import jakarta.json.JsonObject;
-
-import static jakarta.json.JsonValue.EMPTY_JSON_OBJECT;
-
 class SimpleMcpServer {
-    private static final JsonBuilderFactory JSON = Json.createBuilderFactory(Map.of());
 
     static JsonRpcRouting create() {
         return JsonRpcRouting.builder()
@@ -46,18 +40,18 @@ class SimpleMcpServer {
 
     private static void call(JsonRpcRequest req, JsonRpcResponse res) {
         res.header(HeaderValues.create("Mcp-Session-Id", "2fd8e7af-1673-49ad-83d1-7cf22f913cc5"));
-        var params = req.asJsonObject().getJsonObject("params");
-        var toolName = params.getString("name");
-        var arguments = params.getJsonObject("arguments");
+        var params = req.asJsonObject().objectValue("params").orElseThrow();
+        var toolName = params.stringValue("name").orElseThrow();
+        var arguments = params.objectValue("arguments").orElse(JsonObject.empty());
 
         if (toolName.equals("getLatestHelidonVersion")) {
             res.result(toolCallResponse("4.2.0"));
         }
         if (toolName.equals("getInitHelidonSeProjectWithCliCmd")) {
-            var projectName = arguments.getString("projectName");
-            var version = arguments.getString("version");
-            var flavor = arguments.getString("flavor");
-            var packageName = arguments.getString("packageName");
+            var projectName = arguments.stringValue("projectName").orElseThrow();
+            var version = arguments.stringValue("version").orElseThrow();
+            var flavor = arguments.stringValue("flavor").orElseThrow();
+            var packageName = arguments.stringValue("packageName").orElseThrow();
             res.result(toolCallResponse(String.format("""
                                                               helidon init --batch \\
                                                               --version %s \\
@@ -71,88 +65,92 @@ class SimpleMcpServer {
     }
 
     private static JsonObject toolCallResponse(String text) {
-        return JSON.createObjectBuilder()
-                .add("content", JSON.createArrayBuilder()
-                        .add(JSON.createObjectBuilder()
-                                     .add("type", "text")
-                                     .add("text", text)
-                        )
-                )
-                .add("isError", false).build();
+        return JsonObject.builder()
+                .setValues("content", List.of(JsonObject.builder()
+                                                      .set("type", "text")
+                                                      .set("text", text)
+                                                      .build()))
+                .set("isError", false)
+                .build();
     }
 
     private static void list(JsonRpcRequest req, JsonRpcResponse res) {
         res.header(HeaderValues.create("Mcp-Session-Id", "2fd8e7af-1673-49ad-83d1-7cf22f913cc5"));
-        res.result(JSON.createObjectBuilder()
-                           .add("tools", JSON.createArrayBuilder()
-                                   .add(JSON.createObjectBuilder()
-                                                .add("name", "getLatestHelidonVersion")
-                                                .add("description", "Returns a version of the latest released Helidon")
-                                                .add("inputSchema", JSON.createObjectBuilder()
-                                                        .add("type", "object")
-                                                        .add("properties", EMPTY_JSON_OBJECT)
-                                                )
-                                   )
-                                   .add(JSON.createObjectBuilder()
-                                                .add("name", "getInitHelidonSeProjectWithCliCmd")
-                                                .add("description", """
-                                                        Returns example of Helidon CLI command to create Helidon quickstart
-                                                        example with provided projectName version, package name and Helidon
-                                                        flavor as parameters.Resulting CLI command can be used for generating
-                                                        new quickstart project based on Helidon SE.Version parameter
-                                                        should be the latest released version unless specified otherwise.""")
-                                                .add("inputSchema", JSON.createObjectBuilder()
-                                                        .add("type", "object")
-                                                        .add("properties", JSON.createObjectBuilder()
-                                                                .add("projectName", JSON.createObjectBuilder()
-                                                                        .add("description", """
-                                                                                Desired quickstart project name,
-                                                                                also a name of the project folder""")
-                                                                        .add("type", "string")
-                                                                )
-                                                                .add("version", JSON.createObjectBuilder()
-                                                                        .add("description", """
-                                                                                Version of the Helidon release to create
-                                                                                a quickstart project with""")
-                                                                        .add("type", "string")
-                                                                )
-                                                                .add("flavor", JSON.createObjectBuilder()
-                                                                        .add("description", """
-                                                                                Desired flavor of Helidon used in the new project,
-                                                                                `SE` or `MP` are the only options.""")
-                                                                        .add("type", "string")
-                                                                )
-                                                                .add("packageName", JSON.createObjectBuilder()
-                                                                        .add("description", """
-                                                                                Java package name of the quickstart project
-                                                                                which will be created with resulting command""")
-                                                                        .add("type", "string")
-                                                                )
-                                                        )
-                                                )
-                                   )
-                           )
+        res.result(JsonObject.builder()
+                           .setValues("tools", List.of(
+                                   JsonObject.builder()
+                                           .set("name", "getLatestHelidonVersion")
+                                           .set("description", "Returns a version of the latest released Helidon")
+                                           .set("inputSchema", JsonObject.builder()
+                                                   .set("type", "object")
+                                                   .set("properties", JsonObject.empty())
+                                                   .build())
+                                           .build(),
+                                   JsonObject.builder()
+                                           .set("name", "getInitHelidonSeProjectWithCliCmd")
+                                           .set("description", """
+                                                   Returns example of Helidon CLI command to create Helidon quickstart
+                                                   example with provided projectName version, package name and Helidon
+                                                   flavor as parameters.Resulting CLI command can be used for generating
+                                                   new quickstart project based on Helidon SE.Version parameter
+                                                   should be the latest released version unless specified otherwise.""")
+                                           .set("inputSchema", JsonObject.builder()
+                                                   .set("type", "object")
+                                                   .set("properties", JsonObject.builder()
+                                                           .set("projectName", JsonObject.builder()
+                                                                   .set("description", """
+                                                                           Desired quickstart project name,
+                                                                           also a name of the project folder""")
+                                                                   .set("type", "string")
+                                                                   .build())
+                                                           .set("version", JsonObject.builder()
+                                                                   .set("description", """
+                                                                           Version of the Helidon release to create
+                                                                           a quickstart project with""")
+                                                                   .set("type", "string")
+                                                                   .build())
+                                                           .set("flavor", JsonObject.builder()
+                                                                   .set("description", """
+                                                                           Desired flavor of Helidon used in the new project,
+                                                                           `SE` or `MP` are the only options.""")
+                                                                   .set("type", "string")
+                                                                   .build())
+                                                           .set("packageName", JsonObject.builder()
+                                                                   .set("description", """
+                                                                           Java package name of the quickstart project
+                                                                           which will be created with resulting command""")
+                                                                   .set("type", "string")
+                                                                   .build())
+                                                           .build())
+                                                   .build())
+                                           .build()))
                            .build()).send();
     }
 
     private static void initialize(JsonRpcRequest req, JsonRpcResponse res) {
         res.header(HeaderValues.create("Mcp-Session-Id", "2fd8e7af-1673-49ad-83d1-7cf22f913cc5"));
-        res.result(JSON.createObjectBuilder()
-                           .add("protocolVersion", "2025-06-18")
-                           .add("capabilities", JSON.createObjectBuilder()
-                                   .add("logging", EMPTY_JSON_OBJECT)
-                                   .add("prompts", JSON.createObjectBuilder()
-                                           .add("listChanged", false))
-                                   .add("tools", JSON.createObjectBuilder()
-                                           .add("listChanged", true))
-                                   .add("resources", JSON.createObjectBuilder()
-                                           .add("listChanged", false)
-                                           .add("subscribe", false))
-                                   .add("completions", EMPTY_JSON_OBJECT))
-                           .add("serverInfo", JSON.createObjectBuilder()
-                                   .add("name", "helidon-mcp-cli-expert")
-                                   .add("version", "0.0.1"))
-                           .add("instructions", "").build()).send();
+        res.result(JsonObject.builder()
+                           .set("protocolVersion", "2025-06-18")
+                           .set("capabilities", JsonObject.builder()
+                                   .set("logging", JsonObject.empty())
+                                   .set("prompts", JsonObject.builder()
+                                           .set("listChanged", false)
+                                           .build())
+                                   .set("tools", JsonObject.builder()
+                                           .set("listChanged", true)
+                                           .build())
+                                   .set("resources", JsonObject.builder()
+                                           .set("listChanged", false)
+                                           .set("subscribe", false)
+                                           .build())
+                                   .set("completions", JsonObject.empty())
+                                   .build())
+                           .set("serverInfo", JsonObject.builder()
+                                   .set("name", "helidon-mcp-cli-expert")
+                                   .set("version", "0.0.1")
+                                   .build())
+                           .set("instructions", "")
+                           .build()).send();
     }
 
 }


### PR DESCRIPTION
Refactors the LangChain4j agentic MCP test server to build JSON-RPC payloads with Helidon JSON instead of JSON-P. Adds missing Javadocs and package documentation for the test module so static validation passes.