### PR TITLE
Fix array enum model generation

### DIFF
--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -836,6 +836,8 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                 List<CodegenProperty> renderVars = renderVars(model);
 
                 for (CodegenProperty prop : renderVars) {
+                    normalizeEnumProperty(prop);
+
                     // Mark required properties for @Json.Required
                     if (prop.required) {
                         prop.vendorExtensions.put("x-json-required", Boolean.TRUE);
@@ -873,6 +875,21 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             additionalProperties.put("hasValidation", Boolean.TRUE);
         }
         return result;
+    }
+
+    private void normalizeEnumProperty(CodegenProperty prop) {
+        if (!prop.isEnum) {
+            return;
+        }
+
+        String enumName = prop.datatypeWithEnum;
+        if (prop.isArray && prop.items != null && prop.items.datatypeWithEnum != null) {
+            enumName = prop.items.datatypeWithEnum;
+        }
+
+        if (enumName != null && !enumName.isBlank()) {
+            prop.vendorExtensions.put("x-enum-name", enumName);
+        }
     }
 
     private void normalizeComposedModels(List<CodegenModel> models,

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -836,7 +836,13 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                 List<CodegenProperty> renderVars = renderVars(model);
 
                 for (CodegenProperty prop : renderVars) {
-                    normalizeEnumProperty(prop);
+                    if (prop.isEnum) {
+                        String enumName = prop.isArray && prop.items != null && prop.items.datatypeWithEnum != null
+                                ? prop.items.datatypeWithEnum : prop.datatypeWithEnum;
+                        if (enumName != null && !enumName.isBlank()) {
+                            prop.vendorExtensions.put("x-enum-name", enumName);
+                        }
+                    }
 
                     // Mark required properties for @Json.Required
                     if (prop.required) {
@@ -875,21 +881,6 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             additionalProperties.put("hasValidation", Boolean.TRUE);
         }
         return result;
-    }
-
-    private void normalizeEnumProperty(CodegenProperty prop) {
-        if (!prop.isEnum) {
-            return;
-        }
-
-        String enumName = prop.datatypeWithEnum;
-        if (prop.isArray && prop.items != null && prop.items.datatypeWithEnum != null) {
-            enumName = prop.items.datatypeWithEnum;
-        }
-
-        if (enumName != null && !enumName.isBlank()) {
-            prop.vendorExtensions.put("x-enum-name", enumName);
-        }
     }
 
     private void normalizeComposedModels(List<CodegenModel> models,

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
@@ -568,7 +568,7 @@ public class {{classname}}{{#vendorExtensions.x-extends-model}} extends {{vendor
 
 {{/vendorExtensions.x-extends-model}}
 {{#vendorExtensions.x-render-vars}}{{#isEnum}}
-    public enum {{datatypeWithEnum}} {
+    public enum {{vendorExtensions.x-enum-name}} {
         {{#allowableValues}}{{#enumVars}}{{name}}{{^-last}},
         {{/-last}}{{/enumVars}};{{/allowableValues}}
     }

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/ArrayEnumPropertyGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/ArrayEnumPropertyGenerationIT.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.openapi.generator;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.config.CodegenConfigurator;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+/**
+ * Integration test for model properties that are arrays of enum values.
+ */
+class ArrayEnumPropertyGenerationIT {
+
+    @TempDir
+    static Path outputDir;
+
+    @BeforeAll
+    static void generate() throws Exception {
+        URL resource = ArrayEnumPropertyGenerationIT.class
+                .getClassLoader()
+                .getResource("array-enum-property.yaml");
+        String specPath = Paths.get(resource.toURI()).toAbsolutePath().toString();
+
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("helidon-declarative")
+                .setInputSpec(specPath)
+                .setOutputDir(outputDir.toString())
+                .addAdditionalProperty("helidonVersion", "4.4.1")
+                .addAdditionalProperty("apiPackage", "io.helidon.example.api")
+                .addAdditionalProperty("modelPackage", "io.helidon.example.model")
+                .addAdditionalProperty("invokerPackage", "io.helidon.example");
+
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+    }
+
+    @Test
+    void arrayEnumPropertyUsesItemEnumNameForInnerEnumDeclaration() throws IOException {
+        String model = read(outputDir.resolve("src/main/java/io/helidon/example/model/AgentRuntimeDetails.java"));
+
+        assertThat(model, containsString("private List<SupportedAgentTypesEnum> supportedAgentTypes"));
+        assertThat(model, containsString("public enum SupportedAgentTypesEnum"));
+        assertThat(model, not(containsString("public enum List&lt;SupportedAgentTypesEnum&gt;")));
+    }
+
+    private static String read(Path file) throws IOException {
+        return Files.readString(file).replace("\r\n", "\n");
+    }
+}

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/ArrayEnumPropertyGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/ArrayEnumPropertyGenerationIT.java
@@ -61,11 +61,11 @@ class ArrayEnumPropertyGenerationIT {
 
     @Test
     void arrayEnumPropertyUsesItemEnumNameForInnerEnumDeclaration() throws IOException {
-        String model = read(outputDir.resolve("src/main/java/io/helidon/example/model/AgentRuntimeDetails.java"));
+        String model = read(outputDir.resolve("src/main/java/io/helidon/example/model/SampleModel.java"));
 
-        assertThat(model, containsString("private List<SupportedAgentTypesEnum> supportedAgentTypes"));
-        assertThat(model, containsString("public enum SupportedAgentTypesEnum"));
-        assertThat(model, not(containsString("public enum List&lt;SupportedAgentTypesEnum&gt;")));
+        assertThat(model, containsString("private List<ValuesEnum> values"));
+        assertThat(model, containsString("public enum ValuesEnum"));
+        assertThat(model, not(containsString("public enum List&lt;ValuesEnum&gt;")));
     }
 
     private static String read(Path file) throws IOException {

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/array-enum-property.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/array-enum-property.yaml
@@ -3,36 +3,30 @@ info:
   title: Array Enum Property Repro
   version: 1.0.0
 paths:
-  /agentRuntimeDetails:
+  /sample:
     get:
-      operationId: getAgentRuntimeDetails
+      operationId: getSample
       responses:
         '200':
           description: OK
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/AgentRuntimeDetails'
+                $ref: '#/components/schemas/SampleModel'
 components:
   schemas:
-    AgentRuntimeDetails:
+    SampleModel:
       type: object
       required:
-        - backend
-        - supportedAgentTypes
-        - placement
+        - values
       properties:
-        backend:
-          type: string
-        supportedAgentTypes:
-          description: Agent definition types this runtime can host.
+        values:
+          description: Sample enum values.
           type: array
           minItems: 1
           items:
             type: string
             enum:
-              - CONTAINERIZED_AGENT
-              - HARNESS_AGENT
-              - AGENT_SPEC_AGENT
-        placement:
-          type: string
+              - FIRST
+              - SECOND
+              - THIRD

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/array-enum-property.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/array-enum-property.yaml
@@ -1,0 +1,38 @@
+openapi: 3.0.3
+info:
+  title: Array Enum Property Repro
+  version: 1.0.0
+paths:
+  /agentRuntimeDetails:
+    get:
+      operationId: getAgentRuntimeDetails
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AgentRuntimeDetails'
+components:
+  schemas:
+    AgentRuntimeDetails:
+      type: object
+      required:
+        - backend
+        - supportedAgentTypes
+        - placement
+      properties:
+        backend:
+          type: string
+        supportedAgentTypes:
+          description: Agent definition types this runtime can host.
+          type: array
+          minItems: 1
+          items:
+            type: string
+            enum:
+              - CONTAINERIZED_AGENT
+              - HARNESS_AGENT
+              - AGENT_SPEC_AGENT
+        placement:
+          type: string

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/array-enum-property.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/array-enum-property.yaml
@@ -1,3 +1,18 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 openapi: 3.0.3
 info:
   title: Array Enum Property Repro


### PR DESCRIPTION
Fixes generation of Helidon declarative models containing array properties whose items define inline enum values.

Previously, the model template used datatypeWithEnum for the inner enum declaration. For array enum properties that value is the collection type, so generated code rendered an invalid enum declaration such as public enum List&lt;SupportedAgentTypesEnum&gt;.

This change records a separate enum declaration name during model post-processing. Array enum properties use the item enum type for the declaration while retaining List<...> for fields and accessors. Issue #96.

Validation:
- mvn -pl modules/openapi-generator -Dtest=ArrayEnumPropertyGenerationIT test
- Generated the repro project with patched classes
- mvn -q -DskipTests compile in the generated repro project