### PR TITLE
Mark ServiceLoader constructors internal

### DIFF
--- a/extensions/crac/modules/crac/pom.xml
+++ b/extensions/crac/modules/crac/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/extensions/crac/modules/crac/pom.xml
+++ b/extensions/crac/modules/crac/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common</artifactId>
-            <optional>true</optional>
         </dependency>
     </dependencies>
     <build>

--- a/extensions/crac/modules/crac/src/main/java/io/helidon/extensions/crac/CracSupport.java
+++ b/extensions/crac/modules/crac/src/main/java/io/helidon/extensions/crac/CracSupport.java
@@ -19,6 +19,7 @@ package io.helidon.extensions.crac;
 import java.util.Map;
 import java.util.WeakHashMap;
 
+import io.helidon.common.Api;
 import io.helidon.common.resumable.Resumable;
 import io.helidon.common.resumable.ResumableSupport;
 
@@ -36,8 +37,9 @@ public class CracSupport implements ResumableSupport {
     private static final Map<Resumable, Resource> REFERENCES = new WeakHashMap<>();
 
     /**
-     * Constructor required by Java {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public CracSupport() {
     }
 

--- a/extensions/crac/modules/crac/src/main/java/module-info.java
+++ b/extensions/crac/modules/crac/src/main/java/module-info.java
@@ -27,6 +27,7 @@ import io.helidon.common.features.api.HelidonFlavor;
 @Features.Path("CRaC")
 @Features.Since("4.2.0")
 module io.helidon.extensions.crac {
+    requires static io.helidon.common;
     requires static io.helidon.common.features.api; // @Feature
 
     requires transitive org.crac;

--- a/extensions/eureka/modules/eureka/src/main/java/io/helidon/extensions/eureka/EurekaRegistrationServerFeatureProvider.java
+++ b/extensions/eureka/modules/eureka/src/main/java/io/helidon/extensions/eureka/EurekaRegistrationServerFeatureProvider.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.extensions.eureka;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webserver.spi.ServerFeatureProvider;
 
@@ -31,13 +32,10 @@ import static io.helidon.extensions.eureka.EurekaRegistrationServerFeature.EUREK
 public final class EurekaRegistrationServerFeatureProvider implements ServerFeatureProvider<EurekaRegistrationServerFeature> {
 
     /**
-     * Creates a new {@link EurekaRegistrationServerFeatureProvider}.
-     *
-     * @deprecated For {@link java.util.ServiceLoader} use only.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated // For java.util.ServiceLoader use only.
+    @Api.Internal
     public EurekaRegistrationServerFeatureProvider() {
-        super();
     }
 
     /**

--- a/extensions/gson/modules/gson-media/src/main/java/io/helidon/extensions/gson/media/GsonMediaSupportProvider.java
+++ b/extensions/gson/modules/gson-media/src/main/java/io/helidon/extensions/gson/media/GsonMediaSupportProvider.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.extensions.gson.media;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weighted;
 import io.helidon.config.Config;
 import io.helidon.http.media.MediaSupport;
@@ -26,11 +27,10 @@ import io.helidon.http.media.spi.MediaSupportProvider;
 public class GsonMediaSupportProvider implements MediaSupportProvider, Weighted {
 
     /**
-     * This class should be only instantiated as part of java {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public GsonMediaSupportProvider() {
-        super();
     }
 
     @Override

--- a/extensions/hashicorp-vault/modules/auths/approle/pom.xml
+++ b/extensions/hashicorp-vault/modules/auths/approle/pom.xml
@@ -45,6 +45,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/extensions/hashicorp-vault/modules/auths/approle/pom.xml
+++ b/extensions/hashicorp-vault/modules/auths/approle/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/extensions/hashicorp-vault/modules/auths/approle/src/main/java/io/helidon/extensions/hashicorp/vault/auths/approle/AppRoleVaultAuth.java
+++ b/extensions/hashicorp-vault/modules/auths/approle/src/main/java/io/helidon/extensions/hashicorp/vault/auths/approle/AppRoleVaultAuth.java
@@ -19,6 +19,7 @@ package io.helidon.extensions.hashicorp.vault.auths.approle;
 import java.lang.System.Logger.Level;
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.config.Config;
@@ -43,11 +44,9 @@ public class AppRoleVaultAuth implements VaultAuth {
     private final String methodPath;
 
     /**
-     * Constructor required for Java Service Loader.
-     *
-     * @deprecated please use {@link #builder()}
+     * Constructor required for Java Service Loader. Use {@link #builder()} for application code.
      */
-    @Deprecated
+    @Api.Internal
     public AppRoleVaultAuth() {
         this.appRoleId = null;
         this.secretId = null;

--- a/extensions/hashicorp-vault/modules/auths/approle/src/main/java/module-info.java
+++ b/extensions/hashicorp-vault/modules/auths/approle/src/main/java/module-info.java
@@ -30,6 +30,7 @@ module io.helidon.extensions.hashicorp.vault.auths.approle {
     requires io.helidon.extensions.hashicorp.vault.auths.common;
     requires io.helidon.webclient;
 
+    requires static io.helidon.common;
     requires static io.helidon.common.features.api;
 
     requires transitive io.helidon.extensions.hashicorp.vault;

--- a/extensions/hashicorp-vault/modules/auths/common/pom.xml
+++ b/extensions/hashicorp-vault/modules/auths/common/pom.xml
@@ -35,6 +35,11 @@
             <groupId>io.helidon.extensions.hashicorp.vault</groupId>
             <artifactId>helidon-extensions-hashicorp-vault</artifactId>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/extensions/hashicorp-vault/modules/auths/common/pom.xml
+++ b/extensions/hashicorp-vault/modules/auths/common/pom.xml
@@ -38,7 +38,6 @@
         <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common</artifactId>
-            <optional>true</optional>
         </dependency>
 
         <dependency>

--- a/extensions/hashicorp-vault/modules/auths/common/src/main/java/io/helidon/extensions/hashicorp/vault/auths/common/NoVaultAuth.java
+++ b/extensions/hashicorp-vault/modules/auths/common/src/main/java/io/helidon/extensions/hashicorp/vault/auths/common/NoVaultAuth.java
@@ -18,6 +18,7 @@ package io.helidon.extensions.hashicorp.vault.auths.common;
 
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.config.Config;
 import io.helidon.extensions.hashicorp.vault.VaultConfig;
@@ -34,8 +35,9 @@ public class NoVaultAuth implements VaultAuth {
     private static final HeaderName VAULT_NAMESPACE_HEADER_NAME = HeaderNames.create("X-Vault-Namespace");
 
     /**
-     * Required for service loader.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public NoVaultAuth() {
     }
 

--- a/extensions/hashicorp-vault/modules/auths/common/src/main/java/module-info.java
+++ b/extensions/hashicorp-vault/modules/auths/common/src/main/java/module-info.java
@@ -19,6 +19,8 @@
  */
 module io.helidon.extensions.hashicorp.vault.auths.common {
 
+    requires static io.helidon.common;
+
     requires io.helidon.http;
     requires io.helidon.webclient;
     requires io.helidon.json;

--- a/extensions/hashicorp-vault/modules/auths/k8s/pom.xml
+++ b/extensions/hashicorp-vault/modules/auths/k8s/pom.xml
@@ -49,6 +49,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/extensions/hashicorp-vault/modules/auths/k8s/pom.xml
+++ b/extensions/hashicorp-vault/modules/auths/k8s/pom.xml
@@ -51,7 +51,6 @@
         <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/extensions/hashicorp-vault/modules/auths/k8s/src/main/java/io/helidon/extensions/hashicorp/vault/auths/k8s/K8sVaultAuth.java
+++ b/extensions/hashicorp-vault/modules/auths/k8s/src/main/java/io/helidon/extensions/hashicorp/vault/auths/k8s/K8sVaultAuth.java
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.config.Config;
@@ -48,11 +49,9 @@ public class K8sVaultAuth implements VaultAuth {
     private final String methodPath;
 
     /**
-     * Constructor required for Java Service Loader.
-     *
-     * @deprecated please use {@link #builder()}
+     * Constructor required for Java Service Loader. Use {@link #builder()} for application code.
      */
-    @Deprecated
+    @Api.Internal
     public K8sVaultAuth() {
         this.serviceAccountToken = null;
         this.tokenRole = null;

--- a/extensions/hashicorp-vault/modules/auths/k8s/src/main/java/module-info.java
+++ b/extensions/hashicorp-vault/modules/auths/k8s/src/main/java/module-info.java
@@ -30,6 +30,7 @@ module io.helidon.extensions.hashicorp.vault.auths.k8s {
     requires io.helidon.extensions.hashicorp.vault.auths.common;
     requires io.helidon.webclient;
 
+    requires static io.helidon.common;
     requires static io.helidon.common.features.api;
 
     requires transitive io.helidon.extensions.hashicorp.vault;

--- a/extensions/hashicorp-vault/modules/auths/token/pom.xml
+++ b/extensions/hashicorp-vault/modules/auths/token/pom.xml
@@ -45,6 +45,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/extensions/hashicorp-vault/modules/auths/token/pom.xml
+++ b/extensions/hashicorp-vault/modules/auths/token/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common</artifactId>
-            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/extensions/hashicorp-vault/modules/auths/token/src/main/java/io/helidon/extensions/hashicorp/vault/auths/token/TokenVaultAuth.java
+++ b/extensions/hashicorp-vault/modules/auths/token/src/main/java/io/helidon/extensions/hashicorp/vault/auths/token/TokenVaultAuth.java
@@ -19,6 +19,7 @@ package io.helidon.extensions.hashicorp.vault.auths.token;
 import java.lang.System.Logger.Level;
 import java.util.Optional;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.config.Config;
@@ -43,8 +44,9 @@ public class TokenVaultAuth implements VaultAuth {
     private final String baseNamespace;
 
     /**
-     * Required for service loader.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public TokenVaultAuth() {
         this.token = null;
         this.baseNamespace = null;

--- a/extensions/hashicorp-vault/modules/auths/token/src/main/java/module-info.java
+++ b/extensions/hashicorp-vault/modules/auths/token/src/main/java/module-info.java
@@ -30,6 +30,7 @@ module io.helidon.extensions.hashicorp.vault.auths.token {
     requires io.helidon.extensions.hashicorp.vault.auths.common;
     requires io.helidon.webclient;
 
+    requires static io.helidon.common;
     requires static io.helidon.common.features.api;
 
     requires transitive io.helidon.extensions.hashicorp.vault;

--- a/extensions/hashicorp-vault/modules/secrets/cubbyhole/pom.xml
+++ b/extensions/hashicorp-vault/modules/secrets/cubbyhole/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/hashicorp-vault/modules/secrets/cubbyhole/pom.xml
+++ b/extensions/hashicorp-vault/modules/secrets/cubbyhole/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common</artifactId>
-            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/extensions/hashicorp-vault/modules/secrets/cubbyhole/src/main/java/io/helidon/extensions/hashicorp/vault/secrets/cubbyhole/CubbyholeEngineProvider.java
+++ b/extensions/hashicorp-vault/modules/secrets/cubbyhole/src/main/java/io/helidon/extensions/hashicorp/vault/secrets/cubbyhole/CubbyholeEngineProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.extensions.hashicorp.vault.secrets.cubbyhole;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.extensions.hashicorp.vault.Engine;
 import io.helidon.extensions.hashicorp.vault.rest.RestApi;
@@ -27,9 +28,9 @@ import io.helidon.extensions.hashicorp.vault.spi.SecretsEngineProvider;
 public class CubbyholeEngineProvider implements SecretsEngineProvider<CubbyholeSecrets> {
 
     /**
-     * @deprecated Do not use this constructor, this is a service loader service!
+     * Required by this service loader service.
      */
-    @Deprecated
+    @Api.Internal
     public CubbyholeEngineProvider() {
     }
 

--- a/extensions/hashicorp-vault/modules/secrets/cubbyhole/src/main/java/io/helidon/extensions/hashicorp/vault/secrets/cubbyhole/CubbyholeSecurityService.java
+++ b/extensions/hashicorp-vault/modules/secrets/cubbyhole/src/main/java/io/helidon/extensions/hashicorp/vault/secrets/cubbyhole/CubbyholeSecurityService.java
@@ -16,6 +16,7 @@
 
 package io.helidon.extensions.hashicorp.vault.secrets.cubbyhole;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.extensions.hashicorp.vault.Vault;
 import io.helidon.security.spi.SecurityProvider;
@@ -26,9 +27,9 @@ import io.helidon.security.spi.SecurityProviderService;
  */
 public class CubbyholeSecurityService implements SecurityProviderService {
     /**
-     * @deprecated Do not use this constructor, this is a service loader service!
+     * Required by this service loader service.
      */
-    @Deprecated
+    @Api.Internal
     public CubbyholeSecurityService() {
     }
 

--- a/extensions/hashicorp-vault/modules/secrets/cubbyhole/src/main/java/module-info.java
+++ b/extensions/hashicorp-vault/modules/secrets/cubbyhole/src/main/java/module-info.java
@@ -26,6 +26,7 @@ import io.helidon.common.features.api.HelidonFlavor;
 @Features.Path({"HCP Vault", "Secrets", "Cubbyhole"})
 module io.helidon.extensions.hashicorp.vault.secrets.cubbyhole {
 
+    requires static io.helidon.common;
     requires static io.helidon.common.features.api;
 
     requires transitive io.helidon.extensions.hashicorp.vault;

--- a/extensions/hashicorp-vault/modules/secrets/kv1/pom.xml
+++ b/extensions/hashicorp-vault/modules/secrets/kv1/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/hashicorp-vault/modules/secrets/kv1/pom.xml
+++ b/extensions/hashicorp-vault/modules/secrets/kv1/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common</artifactId>
-            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/extensions/hashicorp-vault/modules/secrets/kv1/src/main/java/io/helidon/extensions/hashicorp/vault/secrets/kv1/Kv1SecurityService.java
+++ b/extensions/hashicorp-vault/modules/secrets/kv1/src/main/java/io/helidon/extensions/hashicorp/vault/secrets/kv1/Kv1SecurityService.java
@@ -16,6 +16,7 @@
 
 package io.helidon.extensions.hashicorp.vault.secrets.kv1;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.extensions.hashicorp.vault.Vault;
 import io.helidon.security.spi.SecurityProvider;
@@ -26,9 +27,9 @@ import io.helidon.security.spi.SecurityProviderService;
  */
 public class Kv1SecurityService implements SecurityProviderService {
     /**
-     * @deprecated Do not use this constructor, this is a service loader service!
+     * Required by this service loader service.
      */
-    @Deprecated
+    @Api.Internal
     public Kv1SecurityService() {
     }
 

--- a/extensions/hashicorp-vault/modules/secrets/kv1/src/main/java/module-info.java
+++ b/extensions/hashicorp-vault/modules/secrets/kv1/src/main/java/module-info.java
@@ -26,6 +26,7 @@ import io.helidon.common.features.api.HelidonFlavor;
 @Features.Path({"HCP Vault", "Secrets", "K/V 1"})
 module io.helidon.extensions.hashicorp.vault.secrets.kvone {
 
+    requires static io.helidon.common;
     requires static io.helidon.common.features.api;
 
     requires transitive io.helidon.extensions.hashicorp.vault;

--- a/extensions/hashicorp-vault/modules/secrets/kv2/pom.xml
+++ b/extensions/hashicorp-vault/modules/secrets/kv2/pom.xml
@@ -44,6 +44,11 @@
             <artifactId>helidon-common-features-api</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
     <build>

--- a/extensions/hashicorp-vault/modules/secrets/kv2/pom.xml
+++ b/extensions/hashicorp-vault/modules/secrets/kv2/pom.xml
@@ -47,7 +47,6 @@
         <dependency>
             <groupId>io.helidon.common</groupId>
             <artifactId>helidon-common</artifactId>
-            <optional>true</optional>
         </dependency>
     </dependencies>
 

--- a/extensions/hashicorp-vault/modules/secrets/kv2/src/main/java/io/helidon/extensions/hashicorp/vault/secrets/kv2/Kv2SecurityService.java
+++ b/extensions/hashicorp-vault/modules/secrets/kv2/src/main/java/io/helidon/extensions/hashicorp/vault/secrets/kv2/Kv2SecurityService.java
@@ -16,6 +16,7 @@
 
 package io.helidon.extensions.hashicorp.vault.secrets.kv2;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.extensions.hashicorp.vault.Vault;
 import io.helidon.security.spi.SecurityProvider;
@@ -26,9 +27,9 @@ import io.helidon.security.spi.SecurityProviderService;
  */
 public class Kv2SecurityService implements SecurityProviderService {
     /**
-     * @deprecated Do not use this constructor, this is a service loader service!
+     * Required by this service loader service.
      */
-    @Deprecated
+    @Api.Internal
     public Kv2SecurityService() {
     }
 

--- a/extensions/hashicorp-vault/modules/secrets/kv2/src/main/java/module-info.java
+++ b/extensions/hashicorp-vault/modules/secrets/kv2/src/main/java/module-info.java
@@ -28,6 +28,7 @@ module io.helidon.extensions.hashicorp.vault.secrets.kv {
 
     requires io.helidon.http;
 
+    requires static io.helidon.common;
     requires static io.helidon.common.features.api;
 
     requires transitive io.helidon.extensions.hashicorp.vault;

--- a/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/AgentCodegenProvider.java
+++ b/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/AgentCodegenProvider.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import io.helidon.codegen.CodegenContext;
 import io.helidon.codegen.spi.CodegenExtension;
 import io.helidon.codegen.spi.CodegenExtensionProvider;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AI_AGENT;
@@ -31,8 +32,9 @@ import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AI_AGENT;
  */
 public class AgentCodegenProvider implements CodegenExtensionProvider {
     /**
-     * Public no-arg constructor required by {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public AgentCodegenProvider() {
     }
 

--- a/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/AiServiceCodegenProvider.java
+++ b/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/AiServiceCodegenProvider.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import io.helidon.codegen.CodegenContext;
 import io.helidon.codegen.spi.CodegenExtension;
 import io.helidon.codegen.spi.CodegenExtensionProvider;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AI_SERVICE;
@@ -31,8 +32,9 @@ import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AI_SERVIC
  */
 public class AiServiceCodegenProvider implements CodegenExtensionProvider {
     /**
-     * Public no-arg constructor required by {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public AiServiceCodegenProvider() {
     }
 

--- a/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/LcToolsMapperProvider.java
+++ b/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/LcToolsMapperProvider.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import io.helidon.codegen.CodegenOptions;
 import io.helidon.codegen.spi.TypeMapper;
 import io.helidon.codegen.spi.TypeMapperProvider;
+import io.helidon.common.Api;
 import io.helidon.common.types.TypeName;
 
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_TOOL;
@@ -31,8 +32,9 @@ import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_TOOL;
  */
 public class LcToolsMapperProvider implements TypeMapperProvider {
     /**
-     * Public no-arg constructor required by {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public LcToolsMapperProvider() {
     }
 

--- a/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/ModelConfigCodegenProvider.java
+++ b/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/ModelConfigCodegenProvider.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import io.helidon.codegen.CodegenContext;
 import io.helidon.codegen.spi.CodegenExtension;
 import io.helidon.codegen.spi.CodegenExtensionProvider;
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.TypeName;
@@ -35,8 +36,9 @@ import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.MODEL_CON
 @Weight(Weighted.DEFAULT_WEIGHT - 12)
 public class ModelConfigCodegenProvider implements CodegenExtensionProvider {
     /**
-     * Public no-arg constructor required by {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public ModelConfigCodegenProvider() {
     }
 

--- a/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/ModelFactoryCodegenProvider.java
+++ b/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/ModelFactoryCodegenProvider.java
@@ -21,6 +21,7 @@ import java.util.Set;
 import io.helidon.codegen.CodegenContext;
 import io.helidon.codegen.spi.CodegenExtension;
 import io.helidon.codegen.spi.CodegenExtensionProvider;
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.common.Weighted;
 import io.helidon.common.types.TypeName;
@@ -36,8 +37,9 @@ import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.MODEL_CUS
 public class ModelFactoryCodegenProvider implements CodegenExtensionProvider {
 
     /**
-     * Public no-arg constructor required by {@link java.util.ServiceLoader}.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public ModelFactoryCodegenProvider() {
     }
 

--- a/extensions/oci-v3/modules/secrets-config-source/src/main/java/io/helidon/extensions/oci/v3/secrets/configsource/OciSecretsConfigSourceProvider.java
+++ b/extensions/oci-v3/modules/secrets-config-source/src/main/java/io/helidon/extensions/oci/v3/secrets/configsource/OciSecretsConfigSourceProvider.java
@@ -17,6 +17,7 @@ package io.helidon.extensions.oci.v3.secrets.configsource;
 
 import java.util.Set;
 
+import io.helidon.common.Api;
 import io.helidon.common.Weight;
 import io.helidon.config.AbstractConfigSource;
 import io.helidon.config.Config;
@@ -64,11 +65,9 @@ public final class OciSecretsConfigSourceProvider implements ConfigSourceProvide
     private static final Set<String> SUPPORTED_TYPES = Set.of("oci-secrets");
 
     /**
-     * Creates a new {@link OciSecretsConfigSourceProvider}.
-     *
-     * @deprecated For use by {@link java.util.ServiceLoader} only.
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public OciSecretsConfigSourceProvider() {
     }
 

--- a/extensions/oci-v3/modules/tls-certificates/src/main/java/io/helidon/extensions/oci/v3/tls/certificates/DefaultOciCertificatesTlsManagerProvider.java
+++ b/extensions/oci-v3/modules/tls-certificates/src/main/java/io/helidon/extensions/oci/v3/tls/certificates/DefaultOciCertificatesTlsManagerProvider.java
@@ -16,6 +16,7 @@
 
 package io.helidon.extensions.oci.v3.tls.certificates;
 
+import io.helidon.common.Api;
 import io.helidon.common.tls.TlsManager;
 import io.helidon.common.tls.spi.TlsManagerProvider;
 import io.helidon.config.Config;
@@ -26,10 +27,9 @@ import io.helidon.config.Config;
 public class DefaultOciCertificatesTlsManagerProvider implements TlsManagerProvider {
 
     /**
-     * Service loader based constructor.
-     *
-     * @deprecated this is a Java ServiceLoader implementation and the constructor should not be used directly
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
+    @Api.Internal
     public DefaultOciCertificatesTlsManagerProvider() {
     }
 

--- a/extensions/openapi-ui/modules/openapi-ui/src/main/java/io/helidon/extensions/openapi/ui/OpenApiUiProvider.java
+++ b/extensions/openapi-ui/modules/openapi-ui/src/main/java/io/helidon/extensions/openapi/ui/OpenApiUiProvider.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.extensions.openapi.ui;
 
+import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.openapi.spi.OpenApiServiceProvider;
 
@@ -24,11 +25,9 @@ import io.helidon.openapi.spi.OpenApiServiceProvider;
 public final class OpenApiUiProvider implements OpenApiServiceProvider {
 
     /**
-     * Create a new instance.
-     *
-     * @deprecated to be used solely by {@link java.util.ServiceLoader}
+     * Required public constructor for {@link java.util.ServiceLoader}.
      */
-    @Deprecated
+    @Api.Internal
     public OpenApiUiProvider() {
     }
 


### PR DESCRIPTION
Carries forward helidon-io/helidon#11688 and helidon-io/helidon#11783.

Replaces deprecation-only markers on ServiceLoader constructors with `@Api.Internal` in modules now owned by this repository. It also marks current-repository ServiceLoader constructors that have the same internal-only contract.

Direct `helidon-common` declarations preserve the transitivity already provided by each module's existing dependency graph.
