### PR TITLE
Generate Helidon JSON value-backed enums from OpenAPI enum values

### DIFF
--- a/extensions/openapi-generator/docs/README.md
+++ b/extensions/openapi-generator/docs/README.md
@@ -208,6 +208,23 @@ Supporting files:
 
 ## OpenAPI Mapping Notes
 
+### String enums
+
+OpenAPI schemas with `type: string` and `enum` generate typed, immutable Java
+enums for top-level schemas, model properties and collection elements, HTTP
+parameters, and request entities. Each constant retains the exact OpenAPI wire
+value, including case and punctuation. The generated `value()` method returns
+that value, `toString()` uses it for declarative-client HTTP parameters, and
+`fromValue(String)` performs a strict non-null lookup. Distinct wire values that
+normalize to the same Java identifier receive deterministic numeric suffixes.
+
+Helidon JSON remains the JSON implementation. A stateless generated
+`JsonConverter` preserves exact values and JSON `null` for entity and model
+binding. Enums used by path, query, or header parameters additionally receive a
+typed `Mapper<String, EnumType>`; request-entity-only enums do not. Helidon 4.5
+or later is required for declarative HTTP binding to translate a mapper failure
+for a client-supplied enum value into the standard HTTP 400 response.
+
 ### Composed Schemas
 
 The generator supports these schema-composition keywords:

--- a/extensions/openapi-generator/docs/README.md
+++ b/extensions/openapi-generator/docs/README.md
@@ -58,7 +58,7 @@ The module is packaged as a thin jar. Runtime dependencies are copied to
 
 In the examples below, `4.0.0-SNAPSHOT` is the version of this extension artifact.
 The separate `helidonVersion` option controls which Helidon version is written
-into generated Maven and Gradle projects, and its current default is `4.4.1`.
+into generated Maven and Gradle projects, and its current default is `4.5.0`.
 The `javaVersion` option controls the generated Maven compiler source and target
 values and the generated Gradle Java toolchain version, and its current default is
 `21`.
@@ -93,7 +93,7 @@ Add the generator as a dependency of `openapi-generator-maven-plugin`:
                 <inputSpec>${project.basedir}/src/main/resources/openapi.yaml</inputSpec>
                 <output>${project.build.directory}/generated-sources/openapi</output>
                 <configOptions>
-                    <helidonVersion>4.4.1</helidonVersion>
+                    <helidonVersion>4.5.0</helidonVersion>
                     <javaVersion>21</javaVersion>
                     <apiPackage>com.example.api</apiPackage>
                     <modelPackage>com.example.model</modelPackage>
@@ -121,7 +121,7 @@ mvn generate-sources
 In that example:
 
 - `4.0.0-SNAPSHOT` is the version of `helidon-extensions-openapi-generator`
-- `4.4.1` is the Helidon version used in the generated project
+- `4.5.0` is the Helidon version used in the generated project
 
 ## CLI Usage
 
@@ -133,11 +133,11 @@ java -jar openapi-generator/modules/openapi-generator/target/helidon-extensions-
   -g helidon-declarative \
   -i /path/to/openapi.yaml \
   -o /path/to/output \
-  --additional-properties helidonVersion=4.4.1,javaVersion=21,apiPackage=com.example.api,modelPackage=com.example.model,invokerPackage=com.example
+  --additional-properties helidonVersion=4.5.0,javaVersion=21,apiPackage=com.example.api,modelPackage=com.example.model,invokerPackage=com.example
 ```
 
 Here again, the jar version (`4.0.0-SNAPSHOT`) is the generator version, while
-`helidonVersion=4.4.1` controls the generated Helidon dependencies and
+`helidonVersion=4.5.0` controls the generated Helidon dependencies and
 `javaVersion=21` controls the generated project Java compilation level.
 
 Example with the optional-list flag enabled:
@@ -148,7 +148,7 @@ java -jar openapi-generator/modules/openapi-generator/target/helidon-extensions-
   -g helidon-declarative \
   -i /path/to/openapi.yaml \
   -o /tmp/generated-openapi \
-  --additional-properties helidonVersion=4.4.1,avoidOptionalListParams=true
+  --additional-properties helidonVersion=4.5.0,avoidOptionalListParams=true
 ```
 
 ## Generator Options
@@ -157,7 +157,7 @@ Set these under Maven `<configOptions>` or CLI `--additional-properties`.
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `helidonVersion` | `4.4.1` | Helidon version written into generated Maven and Gradle builds |
+| `helidonVersion` | `4.5.0` | Helidon version written into generated Maven and Gradle builds |
 | `javaVersion` | `21` | Java version written into generated Maven compiler source/target and Gradle toolchain builds |
 | `apiPackage` | `io.helidon.example.api` | Package for generated API, endpoint, client, and error classes |
 | `modelPackage` | `io.helidon.example.model` | Package for generated model classes |
@@ -224,6 +224,8 @@ binding. Enums used by path, query, or header parameters additionally receive a
 typed `Mapper<String, EnumType>`; request-entity-only enums do not. Helidon 4.5
 or later is required for declarative HTTP binding to translate a mapper failure
 for a client-supplied enum value into the standard HTTP 400 response.
+String-enum cookie parameters fail generation with an actionable diagnostic because
+Helidon declarative HTTP does not provide a cookie-parameter annotation.
 
 ### Composed Schemas
 

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/json-string-enums/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/json-string-enums/pom.xml
@@ -6,7 +6,7 @@
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+        http://www.apache.org/licenses/LICENSE-2.0
 
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/json-string-enums/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/json-string-enums/pom.xml
@@ -30,6 +30,7 @@
     <name>OpenAPI Generator IT JSON String Enums</name>
 
     <properties>
+        <helidon.version>4.5.0</helidon.version>
         <inputSpec>${project.basedir}/../../specs/json-string-enums.yaml</inputSpec>
         <skipGeneratedTests>false</skipGeneratedTests>
     </properties>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/json-string-enums/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/json-string-enums/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.helidon.extensions.openapi-generator.it</groupId>
+        <artifactId>openapi-generator-maven-harnesses-parent</artifactId>
+        <version>@project.version@</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>json-string-enums</artifactId>
+    <name>OpenAPI Generator IT JSON String Enums</name>
+
+    <properties>
+        <inputSpec>${project.basedir}/../../specs/json-string-enums.yaml</inputSpec>
+        <skipGeneratedTests>false</skipGeneratedTests>
+    </properties>
+</project>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/json-string-enums/src/test/java/io/helidon/example/api/JsonStringEnumOperationTest.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/json-string-enums/src/test/java/io/helidon/example/api/JsonStringEnumOperationTest.java
@@ -16,14 +16,46 @@
 
 package io.helidon.example.api;
 
+import io.helidon.common.GenericType;
+import io.helidon.common.mapper.Mappers;
+import io.helidon.http.BadRequestException;
+import io.helidon.http.Status;
 import io.helidon.json.binding.JsonBinding;
+import io.helidon.service.registry.Services;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ServerTest
 class JsonStringEnumOperationTest {
+    private final Http1Client client;
+
+    JsonStringEnumOperationTest(Http1Client client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    static void setupRoute(HttpRouting.Builder routing) {
+        var mappers = Services.get(Mappers.class);
+        var targetType = GenericType.create(EnumsApi.InspectModeRouteModeEnum.class);
+        routing.post("/mapped-enum/{value}", (request, response) -> {
+            var value = request.path().pathParameters().first("value")
+                    .map(it -> mappers.map(it,
+                                           GenericType.STRING,
+                                           targetType,
+                                           failure -> new BadRequestException("Invalid enum value.", failure),
+                                           "http",
+                                           "path"))
+                    .orElseThrow();
+            response.send(value.toString());
+        });
+    }
 
     @Test
     void exactHttpMapperUsesWireValue() {
@@ -33,6 +65,14 @@ class JsonStringEnumOperationTest {
         assertThat(mapper.map("authZ"), is(EnumsApi.InspectModeRouteModeEnum.AUTH_Z));
         assertThat(mapper.map("authZ").toString(), is("authZ"));
         assertThrows(IllegalArgumentException.class, () -> mapper.map("AUTH_Z"));
+        assertThrows(NullPointerException.class, () -> mapper.map(null));
+    }
+
+    @Test
+    void invalidHttpEnumValueIsRejectedAsBadRequest() {
+        try (var response = client.post("/mapped-enum/not-a-mode").request()) {
+            assertThat(response.status(), is(Status.BAD_REQUEST_400));
+        }
     }
 
     @Test

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/json-string-enums/src/test/java/io/helidon/example/api/JsonStringEnumOperationTest.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/json-string-enums/src/test/java/io/helidon/example/api/JsonStringEnumOperationTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.example.api;
+
+import io.helidon.json.binding.JsonBinding;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JsonStringEnumOperationTest {
+
+    @Test
+    void exactHttpMapperUsesWireValue() {
+        var mapper = new EnumsApiInspectModeRouteModeEnumJsonConverter();
+
+        assertThat(mapper.map("fast-mode"), is(EnumsApi.InspectModeRouteModeEnum.FAST_MODE));
+        assertThat(mapper.map("authZ"), is(EnumsApi.InspectModeRouteModeEnum.AUTH_Z));
+        assertThat(mapper.map("authZ").toString(), is("authZ"));
+        assertThrows(IllegalArgumentException.class, () -> mapper.map("AUTH_Z"));
+    }
+
+    @Test
+    void requestEntityRoundTripsWithJsonConverterButNoHttpMapper() {
+        JsonBinding jsonBinding = JsonBinding.create();
+
+        assertThat(jsonBinding.serialize(EnumsApi.InspectModeBodyEnum.REQUEST_QUICK,
+                                         EnumsApi.InspectModeBodyEnum.class),
+                   is("\"request-quick\""));
+        assertThat(jsonBinding.deserialize("\"requestAuthZ\"", EnumsApi.InspectModeBodyEnum.class),
+                   is(EnumsApi.InspectModeBodyEnum.REQUEST_AUTH_Z));
+    }
+}

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/json-string-enums/src/test/java/io/helidon/example/model/JsonStringEnumBindingTest.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/json-string-enums/src/test/java/io/helidon/example/model/JsonStringEnumBindingTest.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.example.model;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import io.helidon.json.binding.JsonBinding;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JsonStringEnumBindingTest {
+
+    private final JsonBinding jsonBinding = JsonBinding.create();
+
+    @Test
+    void topLevelEnumRoundTripsExactWireValueAndNull() {
+        assertThat(jsonBinding.serialize(Mode.FAST_MODE, Mode.class), is("\"fast-mode\""));
+        assertThat(jsonBinding.serialize(Mode.AUTH_Z, Mode.class), is("\"authZ\""));
+        assertThat(jsonBinding.deserialize("\"legacy.value\"", Mode.class), is(Mode.LEGACY_VALUE));
+        assertThat(jsonBinding.serialize((Mode) null, Mode.class), is("null"));
+        assertThat(jsonBinding.deserialize("null", Mode.class), is((Mode) null));
+    }
+
+    @Test
+    void modelPropertiesAndCollectionsRoundTripThroughHelidonJson() {
+        EnumEnvelope envelope = new EnumEnvelope();
+        envelope.inlineMode(EnumEnvelope.InlineModeEnum.ON_HOLD);
+        envelope.mode(Mode.AUTH_Z);
+        envelope.modes(List.of(Mode.FAST_MODE, Mode.LEGACY_VALUE));
+        envelope.inlineModes(List.of(EnumEnvelope.InlineModesEnum.BATCH_FAST,
+                                     EnumEnvelope.InlineModesEnum.BATCH_AUTH_Z));
+
+        String json = jsonBinding.serialize(envelope, EnumEnvelope.class);
+        assertThat(json, is("{\"inlineMode\":\"on-hold\",\"mode\":\"authZ\","
+                                    + "\"modes\":[\"fast-mode\",\"legacy.value\"],"
+                                    + "\"inlineModes\":[\"batch-fast\",\"batchAuthZ\"]}"));
+
+        EnumEnvelope restored = jsonBinding.deserialize(json, EnumEnvelope.class);
+        assertThat(restored.inlineMode(), is(EnumEnvelope.InlineModeEnum.ON_HOLD));
+        assertThat(restored.mode(), is(Mode.AUTH_Z));
+        assertThat(restored.modes(), is(List.of(Mode.FAST_MODE, Mode.LEGACY_VALUE)));
+        assertThat(restored.inlineModes(), is(List.of(EnumEnvelope.InlineModesEnum.BATCH_FAST,
+                                                      EnumEnvelope.InlineModesEnum.BATCH_AUTH_Z)));
+    }
+
+    @Test
+    void unknownWireValueIsRejected() {
+        assertThrows(RuntimeException.class, () -> jsonBinding.deserialize("\"FAST_MODE\"", Mode.class));
+        assertThrows(IllegalArgumentException.class, () -> Mode.fromValue("FAST_MODE"));
+    }
+
+    @Test
+    void sharedBindingConvertsAlternatingValuesConcurrently() {
+        List<Mode> converted = IntStream.range(0, 2_000)
+                .parallel()
+                .mapToObj(index -> index % 2 == 0 ? "\"fast-mode\"" : "\"authZ\"")
+                .map(json -> jsonBinding.deserialize(json, Mode.class))
+                .toList();
+
+        for (int i = 0; i < converted.size(); i++) {
+            assertThat(converted.get(i), is(i % 2 == 0 ? Mode.FAST_MODE : Mode.AUTH_Z));
+        }
+    }
+}

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/pom.xml
@@ -40,5 +40,6 @@
         <module>modules/discriminator-enum-mapping-repro</module>
         <module>modules/discriminator-enum-mapping-repro-2</module>
         <module>modules/composed-schemas</module>
+        <module>modules/json-string-enums</module>
     </modules>
 </project>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/json-string-enums.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/json-string-enums.yaml
@@ -89,13 +89,13 @@ paths:
       responses:
         '204':
           description: Accepted
-  /validated-enum:
+  /validated-enum/{mode}:
     get:
       tags: [enums]
       operationId: validatedEnum
       parameters:
         - name: mode
-          in: query
+          in: path
           required: true
           schema:
             type: string
@@ -144,7 +144,7 @@ paths:
       parameters:
         - name: apiBazMode
           in: query
-          required: true
+          required: false
           schema:
             type: string
             enum: [a]
@@ -158,7 +158,7 @@ paths:
       parameters:
         - name: mode
           in: query
-          required: true
+          required: false
           schema:
             type: string
             enum: [b]

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/json-string-enums.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/json-string-enums.yaml
@@ -48,12 +48,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Mode'
+  /enum-no-id:
+    post:
+      tags: [enums]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: string
+              enum: [foo-bar, foo_bar]
+      responses:
+        '204':
+          description: Accepted
+  /numeric-enum-body:
+    post:
+      tags: [enums]
+      operationId: numericEnumBody
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: integer
+              enum: [1, 2]
+      responses:
+        '204':
+          description: Accepted
 components:
   schemas:
     Mode:
       type: string
       nullable: true
       enum: [fast-mode, authZ, legacy.value]
+    CollidingMode:
+      type: string
+      enum: [foo-bar, foo_bar, FOO-BAR]
     EnumEnvelope:
       type: object
       properties:

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/json-string-enums.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/json-string-enums.yaml
@@ -89,6 +89,82 @@ paths:
       responses:
         '204':
           description: Accepted
+  /validated-enum:
+    get:
+      tags: [enums]
+      operationId: validatedEnum
+      parameters:
+        - name: mode
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [safe]
+            minLength: 4
+            pattern: ^safe$
+      responses:
+        '204':
+          description: Accepted
+  /text-enum-body:
+    post:
+      tags: [enums]
+      operationId: textEnumBody
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+              enum: [one]
+      responses:
+        '204':
+          description: Accepted
+  /mixed-enum-body:
+    post:
+      tags: [enums]
+      operationId: mixedEnumBody
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: string
+              enum: [one]
+          text/plain:
+            schema:
+              type: string
+              enum: [one]
+      responses:
+        '204':
+          description: Accepted
+  /helper-name-a:
+    get:
+      tags: [foo]
+      operationId: bar
+      parameters:
+        - name: apiBazMode
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [a]
+      responses:
+        '204':
+          description: Accepted
+  /helper-name-b:
+    get:
+      tags: [foo-api-bar]
+      operationId: baz
+      parameters:
+        - name: mode
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [b]
+      responses:
+        '204':
+          description: Accepted
 components:
   schemas:
     Mode:
@@ -98,6 +174,12 @@ components:
     CollidingMode:
       type: string
       enum: [foo-bar, foo_bar, FOO-BAR]
+    ModeJsonConverter:
+      type: string
+      enum: [slow]
+    EnumEnvelopeInlineModeEnumJsonConverter:
+      type: string
+      enum: [reserved]
     EnumEnvelope:
       type: object
       properties:
@@ -116,3 +198,8 @@ components:
           items:
             type: string
             enum: [batch-fast, batchAuthZ]
+        validatedInline:
+          type: string
+          enum: [safe]
+          minLength: 4
+          pattern: ^safe$

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/json-string-enums.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/json-string-enums.yaml
@@ -1,0 +1,74 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+openapi: 3.0.3
+info:
+  title: JSON String Enum Test
+  version: 1.0.0
+paths:
+  /enum/{routeMode}:
+    post:
+      tags: [enums]
+      operationId: inspectMode
+      parameters:
+        - name: routeMode
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [fast-mode, authZ]
+        - name: mode
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/Mode'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: string
+              enum: [request-quick, requestAuthZ]
+      responses:
+        '200':
+          description: Exact enum response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Mode'
+components:
+  schemas:
+    Mode:
+      type: string
+      nullable: true
+      enum: [fast-mode, authZ, legacy.value]
+    EnumEnvelope:
+      type: object
+      properties:
+        inlineMode:
+          type: string
+          nullable: true
+          enum: [on-hold, authZ]
+        mode:
+          $ref: '#/components/schemas/Mode'
+        modes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Mode'
+        inlineModes:
+          type: array
+          items:
+            type: string
+            enum: [batch-fast, batchAuthZ]

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/json-string-enums.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/json-string-enums.yaml
@@ -75,6 +75,20 @@ paths:
       responses:
         '204':
           description: Accepted
+  /boolean-enum-body:
+    post:
+      tags: [enums]
+      operationId: booleanEnumBody
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: boolean
+              enum: [true, false]
+      responses:
+        '204':
+          description: Accepted
 components:
   schemas:
     Mode:

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -132,7 +132,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
      */
     public HelidonDeclarativeCodegen() {
         super();
-        jsonStringEnums = new JsonStringEnumSupport(this::toEnumVarName);
+        jsonStringEnums = new JsonStringEnumSupport(this::toEnumVarName, this::toModelName);
 
         outputFolder = "generated-code/helidon-declarative";
         // Setting the fields directly configures where templates are resolved from
@@ -1740,7 +1740,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
     private List<Map<String, Object>> buildValidationAnnotations(CodegenProperty prop) {
         List<Map<String, Object>> result = new ArrayList<>();
 
-        if (prop.isString) {
+        if (prop.isString && !prop.vendorExtensions.containsKey("x-enum-wire-constraints-validated")) {
             // minLength / maxLength → @Validation.String.Length
             if (prop.minLength != null || prop.maxLength != null) {
                 List<String> attrs = new ArrayList<>();
@@ -1828,7 +1828,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
     private List<Map<String, Object>> buildParamValidationAnnotations(CodegenParameter param) {
         List<Map<String, Object>> result = new ArrayList<>();
 
-        if (param.isString) {
+        if (param.isString && !param.vendorExtensions.containsKey("x-enum-wire-constraints-validated")) {
             if (param.minLength != null || param.maxLength != null) {
                 List<String> attrs = new ArrayList<>();
                 if (param.minLength != null) attrs.add("min = " + param.minLength);

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -375,7 +375,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
 
     @Override
     public void preprocessOpenAPI(io.swagger.v3.oas.models.OpenAPI openAPI) {
-        jsonStringEnums.preprocess(openAPI, inputSpec);
+        jsonStringEnums.preprocess(openAPI);
         super.preprocessOpenAPI(openAPI);
         globalSecurityRequirements = openAPI.getSecurity() == null
                 ? List.of()
@@ -451,9 +451,8 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                                           String httpMethod,
                                           Operation operation,
                                           List<Server> servers) {
-        String operationId = operation.getOperationId();
         CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
-        jsonStringEnums.restoreInlineRequestEntityEnum(operationId, op);
+        jsonStringEnums.restoreInlineRequestEntityEnum(path, httpMethod, op);
 
         // HTTP method annotation string (e.g. "@Http.GET")
         op.vendorExtensions.put("x-http-annotation", "@Http." + httpMethod.toUpperCase());

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -125,15 +125,14 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
     private boolean avoidOptionalListParams = false;
     private List<SecurityRequirement> globalSecurityRequirements = List.of();
     private Map<String, String> rawAllOfDiscriminatorValuesBySchema = Map.of();
-    private Set<String> httpParameterEnumSchemas = Set.of();
-    private Map<String, List<String>> inlineRequestEntityEnumValues = Map.of();
-    private Set<String> inlineRequestEntityEnumCollections = Set.of();
+    private final JsonStringEnumSupport jsonStringEnums;
 
     /**
      * Creates a new generator with default options and template mappings.
      */
     public HelidonDeclarativeCodegen() {
         super();
+        jsonStringEnums = new JsonStringEnumSupport(this::toEnumVarName);
 
         outputFolder = "generated-code/helidon-declarative";
         // Setting the fields directly configures where templates are resolved from
@@ -376,13 +375,12 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
 
     @Override
     public void preprocessOpenAPI(io.swagger.v3.oas.models.OpenAPI openAPI) {
-        captureInlineRequestEntityEnums(openAPI);
+        jsonStringEnums.preprocess(openAPI, inputSpec);
         super.preprocessOpenAPI(openAPI);
         globalSecurityRequirements = openAPI.getSecurity() == null
                 ? List.of()
                 : new ArrayList<>(openAPI.getSecurity());
         rawAllOfDiscriminatorValuesBySchema = loadRawAllOfDiscriminatorValues();
-        httpParameterEnumSchemas = findHttpParameterEnumSchemas(openAPI);
 
         if (openAPI.getServers() != null && !openAPI.getServers().isEmpty()) {
             String serverUrl = openAPI.getServers().get(0).getUrl();
@@ -413,57 +411,6 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         }
     }
 
-    private Set<String> findHttpParameterEnumSchemas(io.swagger.v3.oas.models.OpenAPI openAPI) {
-        if (openAPI.getPaths() == null) {
-            return Set.of();
-        }
-
-        Set<String> result = new LinkedHashSet<>();
-        openAPI.getPaths().values().forEach(pathItem -> {
-            collectHttpParameterEnumSchemas(openAPI, pathItem.getParameters(), result);
-            pathItem.readOperations().forEach(operation ->
-                    collectHttpParameterEnumSchemas(openAPI, operation.getParameters(), result));
-        });
-        return Set.copyOf(result);
-    }
-
-    private void collectHttpParameterEnumSchemas(io.swagger.v3.oas.models.OpenAPI openAPI,
-                                                 List<io.swagger.v3.oas.models.parameters.Parameter> parameters,
-                                                 Set<String> result) {
-        if (parameters == null) {
-            return;
-        }
-        for (io.swagger.v3.oas.models.parameters.Parameter parameter : parameters) {
-            io.swagger.v3.oas.models.parameters.Parameter resolved = parameter;
-            if (parameter.get$ref() != null && parameter.get$ref().startsWith("#/components/parameters/")
-                    && openAPI.getComponents() != null && openAPI.getComponents().getParameters() != null) {
-                String parameterName = refName(parameter.get$ref());
-                resolved = openAPI.getComponents().getParameters().getOrDefault(parameterName, parameter);
-            }
-            collectEnumSchemaRefs(resolved.getSchema(), result);
-            if (resolved.getContent() != null) {
-                resolved.getContent().values().forEach(mediaType -> collectEnumSchemaRefs(mediaType.getSchema(), result));
-            }
-        }
-    }
-
-    private void collectEnumSchemaRefs(Schema<?> schema, Set<String> result) {
-        if (schema == null) {
-            return;
-        }
-        if (schema.get$ref() != null && schema.get$ref().startsWith("#/components/schemas/")) {
-            result.add(refName(schema.get$ref()));
-        }
-        collectEnumSchemaRefs(schema.getItems(), result);
-        if (schema.getAdditionalProperties() instanceof Schema<?> additionalProperties) {
-            collectEnumSchemaRefs(additionalProperties, result);
-        }
-    }
-
-    private String refName(String ref) {
-        return ref.substring(ref.lastIndexOf('/') + 1);
-    }
-
     // -------------------------------------------------------------------------
     // Per-model: strip swagger 1.x annotation imports (not on Helidon SE classpath)
     // -------------------------------------------------------------------------
@@ -491,9 +438,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         if (allOfDiscriminatorValue != null) {
             model.vendorExtensions.put("x-allof-discriminator-value", allOfDiscriminatorValue);
         }
-        if (httpParameterEnumSchemas.contains(name)) {
-            model.vendorExtensions.put("x-http-parameter-enum", Boolean.TRUE);
-        }
+        jsonStringEnums.markHttpParameterEnum(name, model);
         return model;
     }
 
@@ -507,13 +452,8 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                                           Operation operation,
                                           List<Server> servers) {
         String operationId = operation.getOperationId();
-        List<?> requestEntityEnumValues = operationId == null
-                ? List.of()
-                : inlineRequestEntityEnumValues.getOrDefault(operationId, List.of());
-        boolean requestEntityEnumCollection = operationId != null
-                && inlineRequestEntityEnumCollections.contains(operationId);
         CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
-        restoreInlineRequestEntityEnum(op, requestEntityEnumValues, requestEntityEnumCollection);
+        jsonStringEnums.restoreInlineRequestEntityEnum(operationId, op);
 
         // HTTP method annotation string (e.g. "@Http.GET")
         op.vendorExtensions.put("x-http-annotation", "@Http." + httpMethod.toUpperCase());
@@ -653,113 +593,6 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         return op;
     }
 
-    private void captureInlineRequestEntityEnums(io.swagger.v3.oas.models.OpenAPI openAPI) {
-        if (openAPI.getPaths() == null) {
-            inlineRequestEntityEnumValues = Map.of();
-            inlineRequestEntityEnumCollections = Set.of();
-            return;
-        }
-        Map<String, List<String>> valuesByOperation = new LinkedHashMap<>();
-        Set<String> collections = new LinkedHashSet<>();
-        openAPI.getPaths().values().forEach(pathItem -> pathItem.readOperations().forEach(operation -> {
-            if (operation.getOperationId() == null || operation.getRequestBody() == null
-                    || operation.getRequestBody().getContent() == null
-                    || operation.getRequestBody().getContent().isEmpty()) {
-                return;
-            }
-            Schema<?> schema = operation.getRequestBody().getContent().values().iterator().next().getSchema();
-            if (schema == null || schema.get$ref() != null) {
-                return;
-            }
-            Schema<?> enumSchema = schema.getItems() == null ? schema : schema.getItems();
-            if (enumSchema.get$ref() == null && enumSchema.getEnum() != null && !enumSchema.getEnum().isEmpty()) {
-                valuesByOperation.put(operation.getOperationId(), enumSchema.getEnum().stream()
-                        .map(Object::toString)
-                        .toList());
-                if (schema.getItems() != null) {
-                    collections.add(operation.getOperationId());
-                }
-            }
-        }));
-        captureRawInlineRequestEntityEnums(valuesByOperation, collections);
-        inlineRequestEntityEnumValues = Map.copyOf(valuesByOperation);
-        inlineRequestEntityEnumCollections = Set.copyOf(collections);
-    }
-
-    private void captureRawInlineRequestEntityEnums(Map<String, List<String>> valuesByOperation,
-                                                     Set<String> collections) {
-        if (inputSpec == null || inputSpec.isBlank()) {
-            return;
-        }
-        try {
-            String specContent = InputSpecContentReader.read(inputSpec);
-            ObjectMapper mapper = looksLikeJson(inputSpec, specContent) ? Json.mapper() : Yaml.mapper();
-            JsonNode paths = mapper.readTree(specContent).path("paths");
-            paths.fields().forEachRemaining(pathEntry -> pathEntry.getValue().fields().forEachRemaining(methodEntry -> {
-                JsonNode operation = methodEntry.getValue();
-                String operationId = operation.path("operationId").asText(null);
-                JsonNode content = operation.path("requestBody").path("content");
-                if (operationId == null || !content.isObject() || content.isEmpty()) {
-                    return;
-                }
-                JsonNode schema = content.elements().next().path("schema");
-                JsonNode enumSchema = schema.has("items") ? schema.path("items") : schema;
-                JsonNode enumNode = enumSchema.path("enum");
-                if (!enumNode.isArray() || enumNode.isEmpty()) {
-                    return;
-                }
-                List<String> values = new ArrayList<>();
-                enumNode.forEach(value -> values.add(value.asText()));
-                valuesByOperation.put(operationId, List.copyOf(values));
-                if (schema.has("items")) {
-                    collections.add(operationId);
-                }
-            }));
-        } catch (IOException | RuntimeException ignored) {
-            // The parsed OpenAPI model remains the source of truth when raw input cannot be read.
-        }
-    }
-
-    private void restoreInlineRequestEntityEnum(CodegenOperation codegenOperation,
-                                                List<?> enumValues,
-                                                boolean collection) {
-        if (enumValues.isEmpty()) {
-            return;
-        }
-
-        Map<String, Object> allowableValues = stringAllowableValues(enumValues);
-        List<CodegenParameter> bodyParameters = new ArrayList<>();
-        if (codegenOperation.bodyParam != null) {
-            bodyParameters.add(codegenOperation.bodyParam);
-        }
-        if (codegenOperation.allParams != null) {
-            codegenOperation.allParams.stream()
-                    .filter(parameter -> parameter.isBodyParam && parameter != codegenOperation.bodyParam)
-                    .forEach(bodyParameters::add);
-        }
-        for (CodegenParameter bodyParameter : bodyParameters) {
-            if (!collection) {
-                bodyParameter.isEnum = true;
-                bodyParameter.isString = true;
-                bodyParameter.allowableValues = allowableValues;
-            } else if (bodyParameter.items != null) {
-                bodyParameter.items.isEnum = true;
-                bodyParameter.items.isString = true;
-                bodyParameter.items.allowableValues = allowableValues;
-            }
-        }
-    }
-
-    private Map<String, Object> stringAllowableValues(List<?> values) {
-        List<Map<String, String>> enumVars = new ArrayList<>();
-        for (Object value : values) {
-            String wireValue = value.toString();
-            enumVars.add(Map.of("name", toEnumVarName(wireValue, "String"),
-                                "value", JavaStringLiterals.toJavaStringLiteral(wireValue)));
-        }
-        return Map.of("enumVars", enumVars);
-    }
-
     // -------------------------------------------------------------------------
     // Per-tag post-processing: compute paths, error model, optional-param flags
     // -------------------------------------------------------------------------
@@ -818,11 +651,12 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             }
             // Parameter-level validation annotations
             for (CodegenParameter param : op.allParams) {
-                prepareInlineRequestEntityEnum(op, param);
-                Map<String, Object> operationEnum = promoteInlineOperationEnum(ops.getClassname(), op, param);
-                if (operationEnum != null) {
-                    operationEnums.putIfAbsent(operationEnum.get("enumName").toString(), operationEnum);
-                }
+                jsonStringEnums.prepareInlineRequestEntityEnum(op, param);
+                jsonStringEnums.promoteInlineOperationEnum(operationEnums,
+                                                           ops.getClassname(),
+                                                           op,
+                                                           param,
+                                                           value -> camelize(sanitizeName(value)));
                 List<Map<String, Object>> paramValidations = buildParamValidationAnnotations(param);
                 if (!paramValidations.isEmpty()) {
                     param.vendorExtensions.put("x-validation-annotations", paramValidations);
@@ -853,13 +687,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         result.put("hasParamValidation", anyParamValidation);
         result.put("hasFormOperations", anyFormOperations);
         result.put("hasMultipartOperations", anyMultipartOperations);
-        if (!operationEnums.isEmpty()) {
-            result.put("x-operation-string-enums", new ArrayList<>(operationEnums.values()));
-            result.put("x-has-operation-string-enums", Boolean.TRUE);
-            if (operationEnums.values().stream().anyMatch(enumDefinition -> enumDefinition.containsKey("httpMapper"))) {
-                result.put("x-has-http-enum-mappers", Boolean.TRUE);
-            }
-        }
+        jsonStringEnums.applyOperationEnums(result, operationEnums);
         if (anyParamValidation) {
             // Needed by pom.xml.mustache when only parameters (not models) use @Validation.*
             additionalProperties.put("hasValidation", Boolean.TRUE);
@@ -903,67 +731,6 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         }
 
         return result;
-    }
-
-    private void prepareInlineRequestEntityEnum(CodegenOperation operation, CodegenParameter parameter) {
-        if (!parameter.isBodyParam) {
-            return;
-        }
-        List<String> values = inlineRequestEntityEnumValues.get(operation.operationId);
-        if (values == null || values.isEmpty()) {
-            return;
-        }
-        Map<String, Object> allowableValues = stringAllowableValues(values);
-        if (inlineRequestEntityEnumCollections.contains(operation.operationId) && parameter.items != null) {
-            parameter.items.isEnum = true;
-            parameter.items.isString = true;
-            parameter.items.allowableValues = allowableValues;
-        } else {
-            parameter.isEnum = true;
-            parameter.isString = true;
-            parameter.allowableValues = allowableValues;
-        }
-    }
-
-    private Map<String, Object> promoteInlineOperationEnum(String apiClassname,
-                                                           CodegenOperation operation,
-                                                           CodegenParameter parameter) {
-        CodegenProperty item = parameter.isArray ? parameter.items : null;
-        boolean itemEnum = item != null && item.isEnum && !item.isEnumRef && item.isString;
-        boolean directEnum = !parameter.isArray && parameter.isEnum && !parameter.isEnumRef && parameter.isString;
-        Map<String, Object> allowableValues = itemEnum ? item.allowableValues : parameter.allowableValues;
-        if ((!itemEnum && !directEnum) || enumValues(allowableValues).isEmpty()) {
-            return null;
-        }
-
-        String enumName = camelize(sanitizeName(operation.operationId))
-                + camelize(sanitizeName(parameter.paramName))
-                + "Enum";
-        String bareType = parameter.vendorExtensions.containsKey("x-bare-type")
-                ? parameter.vendorExtensions.get("x-bare-type").toString()
-                : parameter.dataType;
-        String promotedBareType;
-        if (parameter.isArray) {
-            String itemType = item.dataType == null ? "String" : item.dataType;
-            promotedBareType = bareType.replace(itemType, enumName);
-        } else {
-            promotedBareType = enumName;
-        }
-        if (parameter.vendorExtensions.containsKey("x-optional")) {
-            parameter.vendorExtensions.put("x-bare-type", promotedBareType);
-            parameter.dataType = "Optional<" + promotedBareType + ">";
-        } else {
-            parameter.dataType = promotedBareType;
-        }
-        parameter.datatypeWithEnum = parameter.dataType;
-
-        boolean httpMapper = parameter.isPathParam || parameter.isQueryParam
-                || parameter.isHeaderParam || parameter.isCookieParam;
-        return enumDefinition(enumName,
-                              apiClassname + "Api." + enumName,
-                              apiClassname + "Api" + enumName + "JsonConverter",
-                              allowableValues,
-                              httpMapper);
     }
 
     private void generateComputedHeaderFunctionFiles(String apiClassName, List<Map<String, String>> headerFunctions) {
@@ -1074,20 +841,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             ModelsMap modelsMap = entry.getValue();
             for (ModelMap modelContainer : modelsMap.getModels()) {
                 var model = modelContainer.getModel();
-                if (model.isEnum && model.isString) {
-                    Map<String, Object> enumDefinition = enumDefinition(model.classname,
-                                                                        model.classname,
-                                                                        model.classname + "JsonConverter",
-                                                                        model.allowableValues,
-                                                                        Boolean.TRUE.equals(model.vendorExtensions
-                                                                                                    .get("x-http-parameter-enum")));
-                    if (enumDefinition != null) {
-                        model.vendorExtensions.put("x-top-level-string-enum", enumDefinition);
-                        model.vendorExtensions.put("x-has-string-enums", Boolean.TRUE);
-                        if (enumDefinition.containsKey("httpMapper")) {
-                            model.vendorExtensions.put("x-has-http-enum-mappers", Boolean.TRUE);
-                        }
-                    }
+                if (jsonStringEnums.prepareTopLevelModel(model)) {
                     continue;
                 }
                 if (Boolean.TRUE.equals(model.vendorExtensions.get("x-is-union-interface"))) {
@@ -1096,27 +850,9 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                 }
 
                 boolean modelHasValidation = false;
-                List<CodegenProperty> renderVars = renderVars(model);
-                List<Map<String, Object>> inlineEnums = new ArrayList<>();
+                List<CodegenProperty> renderVars = jsonStringEnums.prepareInlineModelEnums(model);
 
                 for (CodegenProperty prop : renderVars) {
-                    CodegenProperty enumProperty = inlineStringEnumProperty(prop);
-                    if (enumProperty != null) {
-                        String enumName = enumProperty.datatypeWithEnum;
-                        if (enumName != null && !enumName.isBlank()) {
-                            prop.vendorExtensions.put("x-enum-name", enumName);
-                            Map<String, Object> enumDefinition = enumDefinition(
-                                    enumName,
-                                    model.classname + "." + enumName,
-                                    model.classname + enumName + "JsonConverter",
-                                    enumProperty.allowableValues,
-                                    false);
-                            if (enumDefinition != null) {
-                                inlineEnums.add(enumDefinition);
-                            }
-                        }
-                    }
-
                     // Mark required properties for @Json.Required
                     if (prop.required) {
                         prop.vendorExtensions.put("x-json-required", Boolean.TRUE);
@@ -1148,60 +884,10 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                     }
                     anyValidation = true;
                 }
-                if (!inlineEnums.isEmpty()) {
-                    model.vendorExtensions.put("x-inline-string-enums", inlineEnums);
-                    model.vendorExtensions.put("x-has-string-enums", Boolean.TRUE);
-                }
             }
         }
         if (anyValidation) {
             additionalProperties.put("hasValidation", Boolean.TRUE);
-        }
-        return result;
-    }
-
-    private CodegenProperty inlineStringEnumProperty(CodegenProperty property) {
-        CodegenProperty candidate = property.isArray ? property.items : property;
-        if (candidate == null || !candidate.isEnum || candidate.isEnumRef || !candidate.isString) {
-            return null;
-        }
-        return enumValues(candidate.allowableValues).isEmpty() ? null : candidate;
-    }
-
-    private Map<String, Object> enumDefinition(String enumName,
-                                               String qualifiedType,
-                                               String converterName,
-                                               Map<String, Object> allowableValues,
-                                               boolean httpMapper) {
-        List<Map<String, String>> values = enumValues(allowableValues);
-        if (values.isEmpty()) {
-            return null;
-        }
-        Map<String, Object> result = new LinkedHashMap<>();
-        result.put("enumName", enumName);
-        result.put("qualifiedType", qualifiedType);
-        result.put("converterName", converterName);
-        result.put("values", values);
-        if (httpMapper) {
-            result.put("httpMapper", Boolean.TRUE);
-        }
-        return result;
-    }
-
-    private List<Map<String, String>> enumValues(Map<String, Object> allowableValues) {
-        if (allowableValues == null || !(allowableValues.get("enumVars") instanceof List<?> enumVars)) {
-            return List.of();
-        }
-        List<Map<String, String>> result = new ArrayList<>();
-        for (Object enumVar : enumVars) {
-            if (!(enumVar instanceof Map<?, ?> values)) {
-                continue;
-            }
-            Object name = values.get("name");
-            Object value = values.get("value");
-            if (name != null && value != null) {
-                result.add(Map.of("name", name.toString(), "value", value.toString()));
-            }
         }
         return result;
     }
@@ -1459,15 +1145,6 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         return properties.stream()
                 .filter(prop -> !inheritedNames.contains(prop.name))
                 .toList();
-    }
-
-    @SuppressWarnings("unchecked")
-    private List<CodegenProperty> renderVars(CodegenModel model) {
-        Object renderVars = model.vendorExtensions.get("x-render-vars");
-        if (renderVars instanceof List<?> vars) {
-            return (List<CodegenProperty>) vars;
-        }
-        return model.vars;
     }
 
     private List<Map<String, Object>> toNamedList(List<String> names) {

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -125,6 +125,9 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
     private boolean avoidOptionalListParams = false;
     private List<SecurityRequirement> globalSecurityRequirements = List.of();
     private Map<String, String> rawAllOfDiscriminatorValuesBySchema = Map.of();
+    private Set<String> httpParameterEnumSchemas = Set.of();
+    private Map<String, List<String>> inlineRequestEntityEnumValues = Map.of();
+    private Set<String> inlineRequestEntityEnumCollections = Set.of();
 
     /**
      * Creates a new generator with default options and template mappings.
@@ -373,11 +376,13 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
 
     @Override
     public void preprocessOpenAPI(io.swagger.v3.oas.models.OpenAPI openAPI) {
+        captureInlineRequestEntityEnums(openAPI);
         super.preprocessOpenAPI(openAPI);
         globalSecurityRequirements = openAPI.getSecurity() == null
                 ? List.of()
                 : new ArrayList<>(openAPI.getSecurity());
         rawAllOfDiscriminatorValuesBySchema = loadRawAllOfDiscriminatorValues();
+        httpParameterEnumSchemas = findHttpParameterEnumSchemas(openAPI);
 
         if (openAPI.getServers() != null && !openAPI.getServers().isEmpty()) {
             String serverUrl = openAPI.getServers().get(0).getUrl();
@@ -408,6 +413,57 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         }
     }
 
+    private Set<String> findHttpParameterEnumSchemas(io.swagger.v3.oas.models.OpenAPI openAPI) {
+        if (openAPI.getPaths() == null) {
+            return Set.of();
+        }
+
+        Set<String> result = new LinkedHashSet<>();
+        openAPI.getPaths().values().forEach(pathItem -> {
+            collectHttpParameterEnumSchemas(openAPI, pathItem.getParameters(), result);
+            pathItem.readOperations().forEach(operation ->
+                    collectHttpParameterEnumSchemas(openAPI, operation.getParameters(), result));
+        });
+        return Set.copyOf(result);
+    }
+
+    private void collectHttpParameterEnumSchemas(io.swagger.v3.oas.models.OpenAPI openAPI,
+                                                 List<io.swagger.v3.oas.models.parameters.Parameter> parameters,
+                                                 Set<String> result) {
+        if (parameters == null) {
+            return;
+        }
+        for (io.swagger.v3.oas.models.parameters.Parameter parameter : parameters) {
+            io.swagger.v3.oas.models.parameters.Parameter resolved = parameter;
+            if (parameter.get$ref() != null && parameter.get$ref().startsWith("#/components/parameters/")
+                    && openAPI.getComponents() != null && openAPI.getComponents().getParameters() != null) {
+                String parameterName = refName(parameter.get$ref());
+                resolved = openAPI.getComponents().getParameters().getOrDefault(parameterName, parameter);
+            }
+            collectEnumSchemaRefs(resolved.getSchema(), result);
+            if (resolved.getContent() != null) {
+                resolved.getContent().values().forEach(mediaType -> collectEnumSchemaRefs(mediaType.getSchema(), result));
+            }
+        }
+    }
+
+    private void collectEnumSchemaRefs(Schema<?> schema, Set<String> result) {
+        if (schema == null) {
+            return;
+        }
+        if (schema.get$ref() != null && schema.get$ref().startsWith("#/components/schemas/")) {
+            result.add(refName(schema.get$ref()));
+        }
+        collectEnumSchemaRefs(schema.getItems(), result);
+        if (schema.getAdditionalProperties() instanceof Schema<?> additionalProperties) {
+            collectEnumSchemaRefs(additionalProperties, result);
+        }
+    }
+
+    private String refName(String ref) {
+        return ref.substring(ref.lastIndexOf('/') + 1);
+    }
+
     // -------------------------------------------------------------------------
     // Per-model: strip swagger 1.x annotation imports (not on Helidon SE classpath)
     // -------------------------------------------------------------------------
@@ -435,6 +491,9 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         if (allOfDiscriminatorValue != null) {
             model.vendorExtensions.put("x-allof-discriminator-value", allOfDiscriminatorValue);
         }
+        if (httpParameterEnumSchemas.contains(name)) {
+            model.vendorExtensions.put("x-http-parameter-enum", Boolean.TRUE);
+        }
         return model;
     }
 
@@ -447,7 +506,14 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                                           String httpMethod,
                                           Operation operation,
                                           List<Server> servers) {
+        String operationId = operation.getOperationId();
+        List<?> requestEntityEnumValues = operationId == null
+                ? List.of()
+                : inlineRequestEntityEnumValues.getOrDefault(operationId, List.of());
+        boolean requestEntityEnumCollection = operationId != null
+                && inlineRequestEntityEnumCollections.contains(operationId);
         CodegenOperation op = super.fromOperation(path, httpMethod, operation, servers);
+        restoreInlineRequestEntityEnum(op, requestEntityEnumValues, requestEntityEnumCollection);
 
         // HTTP method annotation string (e.g. "@Http.GET")
         op.vendorExtensions.put("x-http-annotation", "@Http." + httpMethod.toUpperCase());
@@ -587,6 +653,113 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         return op;
     }
 
+    private void captureInlineRequestEntityEnums(io.swagger.v3.oas.models.OpenAPI openAPI) {
+        if (openAPI.getPaths() == null) {
+            inlineRequestEntityEnumValues = Map.of();
+            inlineRequestEntityEnumCollections = Set.of();
+            return;
+        }
+        Map<String, List<String>> valuesByOperation = new LinkedHashMap<>();
+        Set<String> collections = new LinkedHashSet<>();
+        openAPI.getPaths().values().forEach(pathItem -> pathItem.readOperations().forEach(operation -> {
+            if (operation.getOperationId() == null || operation.getRequestBody() == null
+                    || operation.getRequestBody().getContent() == null
+                    || operation.getRequestBody().getContent().isEmpty()) {
+                return;
+            }
+            Schema<?> schema = operation.getRequestBody().getContent().values().iterator().next().getSchema();
+            if (schema == null || schema.get$ref() != null) {
+                return;
+            }
+            Schema<?> enumSchema = schema.getItems() == null ? schema : schema.getItems();
+            if (enumSchema.get$ref() == null && enumSchema.getEnum() != null && !enumSchema.getEnum().isEmpty()) {
+                valuesByOperation.put(operation.getOperationId(), enumSchema.getEnum().stream()
+                        .map(Object::toString)
+                        .toList());
+                if (schema.getItems() != null) {
+                    collections.add(operation.getOperationId());
+                }
+            }
+        }));
+        captureRawInlineRequestEntityEnums(valuesByOperation, collections);
+        inlineRequestEntityEnumValues = Map.copyOf(valuesByOperation);
+        inlineRequestEntityEnumCollections = Set.copyOf(collections);
+    }
+
+    private void captureRawInlineRequestEntityEnums(Map<String, List<String>> valuesByOperation,
+                                                     Set<String> collections) {
+        if (inputSpec == null || inputSpec.isBlank()) {
+            return;
+        }
+        try {
+            String specContent = InputSpecContentReader.read(inputSpec);
+            ObjectMapper mapper = looksLikeJson(inputSpec, specContent) ? Json.mapper() : Yaml.mapper();
+            JsonNode paths = mapper.readTree(specContent).path("paths");
+            paths.fields().forEachRemaining(pathEntry -> pathEntry.getValue().fields().forEachRemaining(methodEntry -> {
+                JsonNode operation = methodEntry.getValue();
+                String operationId = operation.path("operationId").asText(null);
+                JsonNode content = operation.path("requestBody").path("content");
+                if (operationId == null || !content.isObject() || content.isEmpty()) {
+                    return;
+                }
+                JsonNode schema = content.elements().next().path("schema");
+                JsonNode enumSchema = schema.has("items") ? schema.path("items") : schema;
+                JsonNode enumNode = enumSchema.path("enum");
+                if (!enumNode.isArray() || enumNode.isEmpty()) {
+                    return;
+                }
+                List<String> values = new ArrayList<>();
+                enumNode.forEach(value -> values.add(value.asText()));
+                valuesByOperation.put(operationId, List.copyOf(values));
+                if (schema.has("items")) {
+                    collections.add(operationId);
+                }
+            }));
+        } catch (IOException | RuntimeException ignored) {
+            // The parsed OpenAPI model remains the source of truth when raw input cannot be read.
+        }
+    }
+
+    private void restoreInlineRequestEntityEnum(CodegenOperation codegenOperation,
+                                                List<?> enumValues,
+                                                boolean collection) {
+        if (enumValues.isEmpty()) {
+            return;
+        }
+
+        Map<String, Object> allowableValues = stringAllowableValues(enumValues);
+        List<CodegenParameter> bodyParameters = new ArrayList<>();
+        if (codegenOperation.bodyParam != null) {
+            bodyParameters.add(codegenOperation.bodyParam);
+        }
+        if (codegenOperation.allParams != null) {
+            codegenOperation.allParams.stream()
+                    .filter(parameter -> parameter.isBodyParam && parameter != codegenOperation.bodyParam)
+                    .forEach(bodyParameters::add);
+        }
+        for (CodegenParameter bodyParameter : bodyParameters) {
+            if (!collection) {
+                bodyParameter.isEnum = true;
+                bodyParameter.isString = true;
+                bodyParameter.allowableValues = allowableValues;
+            } else if (bodyParameter.items != null) {
+                bodyParameter.items.isEnum = true;
+                bodyParameter.items.isString = true;
+                bodyParameter.items.allowableValues = allowableValues;
+            }
+        }
+    }
+
+    private Map<String, Object> stringAllowableValues(List<?> values) {
+        List<Map<String, String>> enumVars = new ArrayList<>();
+        for (Object value : values) {
+            String wireValue = value.toString();
+            enumVars.add(Map.of("name", toEnumVarName(wireValue, "String"),
+                                "value", JavaStringLiterals.toJavaStringLiteral(wireValue)));
+        }
+        return Map.of("enumVars", enumVars);
+    }
+
     // -------------------------------------------------------------------------
     // Per-tag post-processing: compute paths, error model, optional-param flags
     // -------------------------------------------------------------------------
@@ -616,6 +789,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         boolean anyFormOperations = false;
         boolean anyMultipartOperations = false;
         String errorModel = null;
+        Map<String, Map<String, Object>> operationEnums = new LinkedHashMap<>();
 
         for (CodegenOperation op : opList) {
             // Sub-path (part after commonPath)
@@ -644,6 +818,11 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             }
             // Parameter-level validation annotations
             for (CodegenParameter param : op.allParams) {
+                prepareInlineRequestEntityEnum(op, param);
+                Map<String, Object> operationEnum = promoteInlineOperationEnum(ops.getClassname(), op, param);
+                if (operationEnum != null) {
+                    operationEnums.putIfAbsent(operationEnum.get("enumName").toString(), operationEnum);
+                }
                 List<Map<String, Object>> paramValidations = buildParamValidationAnnotations(param);
                 if (!paramValidations.isEmpty()) {
                     param.vendorExtensions.put("x-validation-annotations", paramValidations);
@@ -674,6 +853,13 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         result.put("hasParamValidation", anyParamValidation);
         result.put("hasFormOperations", anyFormOperations);
         result.put("hasMultipartOperations", anyMultipartOperations);
+        if (!operationEnums.isEmpty()) {
+            result.put("x-operation-string-enums", new ArrayList<>(operationEnums.values()));
+            result.put("x-has-operation-string-enums", Boolean.TRUE);
+            if (operationEnums.values().stream().anyMatch(enumDefinition -> enumDefinition.containsKey("httpMapper"))) {
+                result.put("x-has-http-enum-mappers", Boolean.TRUE);
+            }
+        }
         if (anyParamValidation) {
             // Needed by pom.xml.mustache when only parameters (not models) use @Validation.*
             additionalProperties.put("hasValidation", Boolean.TRUE);
@@ -717,6 +903,67 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         }
 
         return result;
+    }
+
+    private void prepareInlineRequestEntityEnum(CodegenOperation operation, CodegenParameter parameter) {
+        if (!parameter.isBodyParam) {
+            return;
+        }
+        List<String> values = inlineRequestEntityEnumValues.get(operation.operationId);
+        if (values == null || values.isEmpty()) {
+            return;
+        }
+        Map<String, Object> allowableValues = stringAllowableValues(values);
+        if (inlineRequestEntityEnumCollections.contains(operation.operationId) && parameter.items != null) {
+            parameter.items.isEnum = true;
+            parameter.items.isString = true;
+            parameter.items.allowableValues = allowableValues;
+        } else {
+            parameter.isEnum = true;
+            parameter.isString = true;
+            parameter.allowableValues = allowableValues;
+        }
+    }
+
+    private Map<String, Object> promoteInlineOperationEnum(String apiClassname,
+                                                           CodegenOperation operation,
+                                                           CodegenParameter parameter) {
+        CodegenProperty item = parameter.isArray ? parameter.items : null;
+        boolean itemEnum = item != null && item.isEnum && !item.isEnumRef && item.isString;
+        boolean directEnum = !parameter.isArray && parameter.isEnum && !parameter.isEnumRef && parameter.isString;
+        Map<String, Object> allowableValues = itemEnum ? item.allowableValues : parameter.allowableValues;
+        if ((!itemEnum && !directEnum) || enumValues(allowableValues).isEmpty()) {
+            return null;
+        }
+
+        String enumName = camelize(sanitizeName(operation.operationId))
+                + camelize(sanitizeName(parameter.paramName))
+                + "Enum";
+        String bareType = parameter.vendorExtensions.containsKey("x-bare-type")
+                ? parameter.vendorExtensions.get("x-bare-type").toString()
+                : parameter.dataType;
+        String promotedBareType;
+        if (parameter.isArray) {
+            String itemType = item.dataType == null ? "String" : item.dataType;
+            promotedBareType = bareType.replace(itemType, enumName);
+        } else {
+            promotedBareType = enumName;
+        }
+        if (parameter.vendorExtensions.containsKey("x-optional")) {
+            parameter.vendorExtensions.put("x-bare-type", promotedBareType);
+            parameter.dataType = "Optional<" + promotedBareType + ">";
+        } else {
+            parameter.dataType = promotedBareType;
+        }
+        parameter.datatypeWithEnum = parameter.dataType;
+
+        boolean httpMapper = parameter.isPathParam || parameter.isQueryParam
+                || parameter.isHeaderParam || parameter.isCookieParam;
+        return enumDefinition(enumName,
+                              apiClassname + "Api." + enumName,
+                              apiClassname + "Api" + enumName + "JsonConverter",
+                              allowableValues,
+                              httpMapper);
     }
 
     private void generateComputedHeaderFunctionFiles(String apiClassName, List<Map<String, String>> headerFunctions) {
@@ -827,6 +1074,22 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             ModelsMap modelsMap = entry.getValue();
             for (ModelMap modelContainer : modelsMap.getModels()) {
                 var model = modelContainer.getModel();
+                if (model.isEnum && model.isString) {
+                    Map<String, Object> enumDefinition = enumDefinition(model.classname,
+                                                                        model.classname,
+                                                                        model.classname + "JsonConverter",
+                                                                        model.allowableValues,
+                                                                        Boolean.TRUE.equals(model.vendorExtensions
+                                                                                                    .get("x-http-parameter-enum")));
+                    if (enumDefinition != null) {
+                        model.vendorExtensions.put("x-top-level-string-enum", enumDefinition);
+                        model.vendorExtensions.put("x-has-string-enums", Boolean.TRUE);
+                        if (enumDefinition.containsKey("httpMapper")) {
+                            model.vendorExtensions.put("x-has-http-enum-mappers", Boolean.TRUE);
+                        }
+                    }
+                    continue;
+                }
                 if (Boolean.TRUE.equals(model.vendorExtensions.get("x-is-union-interface"))) {
                     model.vendorExtensions.put("x-render-vars", List.of());
                     continue;
@@ -834,13 +1097,23 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
 
                 boolean modelHasValidation = false;
                 List<CodegenProperty> renderVars = renderVars(model);
+                List<Map<String, Object>> inlineEnums = new ArrayList<>();
 
                 for (CodegenProperty prop : renderVars) {
-                    if (prop.isEnum) {
-                        String enumName = prop.isArray && prop.items != null && prop.items.datatypeWithEnum != null
-                                ? prop.items.datatypeWithEnum : prop.datatypeWithEnum;
+                    CodegenProperty enumProperty = inlineStringEnumProperty(prop);
+                    if (enumProperty != null) {
+                        String enumName = enumProperty.datatypeWithEnum;
                         if (enumName != null && !enumName.isBlank()) {
                             prop.vendorExtensions.put("x-enum-name", enumName);
+                            Map<String, Object> enumDefinition = enumDefinition(
+                                    enumName,
+                                    model.classname + "." + enumName,
+                                    model.classname + enumName + "JsonConverter",
+                                    enumProperty.allowableValues,
+                                    false);
+                            if (enumDefinition != null) {
+                                inlineEnums.add(enumDefinition);
+                            }
                         }
                     }
 
@@ -875,10 +1148,60 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                     }
                     anyValidation = true;
                 }
+                if (!inlineEnums.isEmpty()) {
+                    model.vendorExtensions.put("x-inline-string-enums", inlineEnums);
+                    model.vendorExtensions.put("x-has-string-enums", Boolean.TRUE);
+                }
             }
         }
         if (anyValidation) {
             additionalProperties.put("hasValidation", Boolean.TRUE);
+        }
+        return result;
+    }
+
+    private CodegenProperty inlineStringEnumProperty(CodegenProperty property) {
+        CodegenProperty candidate = property.isArray ? property.items : property;
+        if (candidate == null || !candidate.isEnum || candidate.isEnumRef || !candidate.isString) {
+            return null;
+        }
+        return enumValues(candidate.allowableValues).isEmpty() ? null : candidate;
+    }
+
+    private Map<String, Object> enumDefinition(String enumName,
+                                               String qualifiedType,
+                                               String converterName,
+                                               Map<String, Object> allowableValues,
+                                               boolean httpMapper) {
+        List<Map<String, String>> values = enumValues(allowableValues);
+        if (values.isEmpty()) {
+            return null;
+        }
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("enumName", enumName);
+        result.put("qualifiedType", qualifiedType);
+        result.put("converterName", converterName);
+        result.put("values", values);
+        if (httpMapper) {
+            result.put("httpMapper", Boolean.TRUE);
+        }
+        return result;
+    }
+
+    private List<Map<String, String>> enumValues(Map<String, Object> allowableValues) {
+        if (allowableValues == null || !(allowableValues.get("enumVars") instanceof List<?> enumVars)) {
+            return List.of();
+        }
+        List<Map<String, String>> result = new ArrayList<>();
+        for (Object enumVar : enumVars) {
+            if (!(enumVar instanceof Map<?, ?> values)) {
+                continue;
+            }
+            Object name = values.get("name");
+            Object value = values.get("value");
+            if (name != null && value != null) {
+                result.add(Map.of("name", name.toString(), "value", value.toString()));
+            }
         }
         return result;
     }

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -112,7 +112,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             "RESPONSE",
             "RESPONSES");
 
-    private String helidonVersion = "4.4.1";
+    private String helidonVersion = "4.5.0";
     private String javaVersion = "21";
     private boolean generateClient = true;
     private boolean generateErrorHandler = true;

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/JsonStringEnumSupport.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/JsonStringEnumSupport.java
@@ -24,6 +24,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.UnaryOperator;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
 
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
@@ -41,15 +43,27 @@ import org.openapitools.codegen.model.OperationsMap;
  */
 final class JsonStringEnumSupport {
     private final BiFunction<String, String, String> enumVarNamer;
+    private final UnaryOperator<String> modelNamer;
+    private final Set<String> allocatedModelTypes = new LinkedHashSet<>();
+    private final Set<String> allocatedApiTypes = new LinkedHashSet<>();
     private Set<String> httpParameterEnumSchemas = Set.of();
     private Map<String, List<String>> inlineRequestEntityEnumValues = Map.of();
     private Set<String> inlineRequestEntityEnumCollections = Set.of();
 
-    JsonStringEnumSupport(BiFunction<String, String, String> enumVarNamer) {
+    JsonStringEnumSupport(BiFunction<String, String, String> enumVarNamer,
+                          UnaryOperator<String> modelNamer) {
         this.enumVarNamer = enumVarNamer;
+        this.modelNamer = modelNamer;
     }
 
     void preprocess(OpenAPI openAPI) {
+        allocatedModelTypes.clear();
+        allocatedApiTypes.clear();
+        if (openAPI.getComponents() != null && openAPI.getComponents().getSchemas() != null) {
+            openAPI.getComponents().getSchemas().keySet().stream()
+                    .map(modelNamer)
+                    .forEach(allocatedModelTypes::add);
+        }
         captureInlineRequestEntityEnums(openAPI);
         httpParameterEnumSchemas = findHttpParameterEnumSchemas(openAPI);
     }
@@ -106,6 +120,15 @@ final class JsonStringEnumSupport {
         boolean itemEnum = item != null && item.isEnum && !item.isEnumRef && item.isString;
         boolean directEnum = !parameter.isArray && parameter.isEnum && !parameter.isEnumRef && parameter.isString;
         Map<String, Object> allowableValues = itemEnum ? item.allowableValues : parameter.allowableValues;
+        if (!parameter.isArray && parameter.isEnumRef && parameter.isString) {
+            validateEnumWireValues("operation parameter '" + parameter.baseName + "'",
+                                   wireValues(parameter._enum, parameter.allowableValues),
+                                   parameter.minLength,
+                                   parameter.maxLength,
+                                   parameter.pattern);
+            parameter.vendorExtensions.put("x-enum-wire-constraints-validated", Boolean.TRUE);
+            return;
+        }
         if ((!itemEnum && !directEnum) || enumValues(allowableValues).isEmpty()) {
             return;
         }
@@ -113,6 +136,15 @@ final class JsonStringEnumSupport {
         String enumName = javaName.apply(operation.operationId)
                 + javaName.apply(parameter.paramName)
                 + "Enum";
+        CodegenProperty constraintSource = itemEnum ? item : null;
+        validateEnumWireValues("operation parameter '" + parameter.baseName + "'",
+                               constraintSource == null
+                                       ? wireValues(parameter._enum, allowableValues)
+                                       : wireValues(constraintSource._enum, allowableValues),
+                               constraintSource == null ? parameter.minLength : constraintSource.minLength,
+                               constraintSource == null ? parameter.maxLength : constraintSource.maxLength,
+                               constraintSource == null ? parameter.pattern : constraintSource.pattern);
+        parameter.vendorExtensions.put("x-enum-wire-constraints-validated", Boolean.TRUE);
         String bareType = parameter.vendorExtensions.containsKey("x-bare-type")
                 ? parameter.vendorExtensions.get("x-bare-type").toString()
                 : parameter.dataType;
@@ -132,9 +164,12 @@ final class JsonStringEnumSupport {
         parameter.datatypeWithEnum = parameter.dataType;
 
         boolean httpMapper = parameter.isPathParam || parameter.isQueryParam || parameter.isHeaderParam;
+        reserveApiTypes(apiClassname);
+        String converterName = allocateTypeName(allocatedApiTypes,
+                                                apiClassname + "Api" + enumName + "JsonConverter");
         Map<String, Object> definition = enumDefinition(enumName,
                                                         apiClassname + "Api." + enumName,
-                                                        apiClassname + "Api" + enumName + "JsonConverter",
+                                                        converterName,
                                                         allowableValues,
                                                         httpMapper);
         operationEnums.putIfAbsent(enumName, definition);
@@ -155,9 +190,15 @@ final class JsonStringEnumSupport {
         if (!model.isEnum || !model.isString) {
             return false;
         }
+        validateEnumWireValues("schema '" + model.schemaName + "'",
+                               wireValues(null, model.allowableValues),
+                               model.getMinLength(),
+                               model.getMaxLength(),
+                               model.getPattern());
         Map<String, Object> definition = enumDefinition(model.classname,
                                                         model.classname,
-                                                        model.classname + "JsonConverter",
+                                                        allocateTypeName(allocatedModelTypes,
+                                                                         model.classname + "JsonConverter"),
                                                         model.allowableValues,
                                                         Boolean.TRUE.equals(model.vendorExtensions
                                                                                     .get("x-http-parameter-enum")));
@@ -175,16 +216,33 @@ final class JsonStringEnumSupport {
         List<CodegenProperty> properties = renderVars(model);
         List<Map<String, Object>> definitions = new ArrayList<>();
         for (CodegenProperty property : properties) {
+            if (property.isEnumRef && property.isString) {
+                validateEnumWireValues("model property '" + model.classname + "." + property.baseName + "'",
+                                       wireValues(property._enum, property.allowableValues),
+                                       property.minLength,
+                                       property.maxLength,
+                                       property.pattern);
+                property.vendorExtensions.put("x-enum-wire-constraints-validated", Boolean.TRUE);
+                continue;
+            }
             CodegenProperty enumProperty = inlineStringEnumProperty(property);
             if (enumProperty == null || enumProperty.datatypeWithEnum == null
                     || enumProperty.datatypeWithEnum.isBlank()) {
                 continue;
             }
             String enumName = enumProperty.datatypeWithEnum;
+            validateEnumWireValues("model property '" + model.classname + "." + property.baseName + "'",
+                                   wireValues(enumProperty._enum, enumProperty.allowableValues),
+                                   enumProperty.minLength,
+                                   enumProperty.maxLength,
+                                   enumProperty.pattern);
             property.vendorExtensions.put("x-enum-name", enumName);
+            property.vendorExtensions.put("x-enum-wire-constraints-validated", Boolean.TRUE);
             Map<String, Object> definition = enumDefinition(enumName,
                                                             model.classname + "." + enumName,
-                                                            model.classname + enumName + "JsonConverter",
+                                                            allocateTypeName(allocatedModelTypes,
+                                                                             model.classname + enumName
+                                                                                     + "JsonConverter"),
                                                             enumProperty.allowableValues,
                                                             false);
             if (definition != null) {
@@ -294,21 +352,101 @@ final class JsonStringEnumSupport {
                 || operation.getRequestBody().getContent().isEmpty()) {
             return;
         }
-        Schema<?> schema = operation.getRequestBody().getContent().values().iterator().next().getSchema();
-        if (schema == null || schema.get$ref() != null) {
-            return;
+        List<String> capturedValues = null;
+        Boolean collection = null;
+        for (Map.Entry<String, io.swagger.v3.oas.models.media.MediaType> entry
+                : operation.getRequestBody().getContent().entrySet()) {
+            if (!isJsonMediaType(entry.getKey())) {
+                return;
+            }
+            if (entry.getValue() == null) {
+                return;
+            }
+            Schema<?> schema = entry.getValue().getSchema();
+            if (schema == null || schema.get$ref() != null) {
+                return;
+            }
+            boolean currentCollection = schema.getItems() != null;
+            Schema<?> enumSchema = currentCollection ? schema.getItems() : schema;
+            if (enumSchema.get$ref() != null || !"string".equals(enumSchema.getType())
+                    || enumSchema.getEnum() == null || enumSchema.getEnum().isEmpty()) {
+                return;
+            }
+            List<String> currentValues = enumSchema.getEnum().stream().map(Object::toString).toList();
+            if (capturedValues != null
+                    && (!capturedValues.equals(currentValues) || collection != currentCollection)) {
+                return;
+            }
+            capturedValues = currentValues;
+            collection = currentCollection;
         }
-        Schema<?> enumSchema = schema.getItems() == null ? schema : schema.getItems();
-        if (enumSchema.get$ref() == null && "string".equals(enumSchema.getType())
-                && enumSchema.getEnum() != null && !enumSchema.getEnum().isEmpty()) {
+        if (capturedValues != null) {
             String operationKey = operationKey(path, method.name());
-            valuesByOperation.put(operationKey, enumSchema.getEnum().stream()
-                    .map(Object::toString)
-                    .toList());
-            if (schema.getItems() != null) {
+            valuesByOperation.put(operationKey, capturedValues);
+            if (Boolean.TRUE.equals(collection)) {
                 collections.add(operationKey);
             }
         }
+    }
+
+    private boolean isJsonMediaType(String mediaType) {
+        if (mediaType == null) {
+            return false;
+        }
+        String normalized = mediaType.split(";", 2)[0].trim().toLowerCase(java.util.Locale.ROOT);
+        return "application/json".equals(normalized) || normalized.endsWith("+json");
+    }
+
+    private void reserveApiTypes(String apiClassname) {
+        allocatedApiTypes.add(apiClassname + "Api");
+        allocatedApiTypes.add(apiClassname + "Endpoint");
+        allocatedApiTypes.add(apiClassname + "Client");
+        allocatedApiTypes.add(apiClassname + "Exception");
+        allocatedApiTypes.add(apiClassname + "ErrorHandler");
+    }
+
+    private String allocateTypeName(Set<String> allocatedTypes, String preferredName) {
+        if (allocatedTypes.add(preferredName)) {
+            return preferredName;
+        }
+        int suffix = 2;
+        while (!allocatedTypes.add(preferredName + suffix)) {
+            suffix++;
+        }
+        return preferredName + suffix;
+    }
+
+    private void validateEnumWireValues(String location,
+                                        List<String> values,
+                                        Integer minLength,
+                                        Integer maxLength,
+                                        String pattern) {
+        Pattern compiledPattern = null;
+        if (pattern != null && !pattern.isEmpty()) {
+            try {
+                compiledPattern = Pattern.compile(pattern);
+            } catch (PatternSyntaxException e) {
+                throw new IllegalArgumentException("Invalid OpenAPI pattern on " + location + ": "
+                                                           + e.getMessage(), e);
+            }
+        }
+        for (String value : values) {
+            if (minLength != null && value.length() < minLength) {
+                throw invalidEnumConstraint(location, value, "minLength " + minLength);
+            }
+            if (maxLength != null && value.length() > maxLength) {
+                throw invalidEnumConstraint(location, value, "maxLength " + maxLength);
+            }
+            if (compiledPattern != null && !compiledPattern.matcher(value).find()) {
+                throw invalidEnumConstraint(location, value, "pattern '" + pattern + "'");
+            }
+        }
+    }
+
+    private IllegalArgumentException invalidEnumConstraint(String location, String value, String constraint) {
+        return new IllegalArgumentException("OpenAPI string enum wire value '" + value + "' on " + location
+                                                    + " does not satisfy " + constraint
+                                                    + "; generated enum validation cannot preserve this contradictory schema");
     }
 
     private void restoreInlineRequestEntityEnum(CodegenOperation codegenOperation,
@@ -343,7 +481,17 @@ final class JsonStringEnumSupport {
             enumVars.add(Map.of("name", enumVarNamer.apply(wireValue, "String"),
                                 "value", JavaStringLiterals.toJavaStringLiteral(wireValue)));
         }
-        return Map.of("enumVars", enumVars);
+        return Map.of("enumVars", enumVars, "values", List.copyOf(values));
+    }
+
+    private List<String> wireValues(List<String> declaredValues, Map<String, Object> allowableValues) {
+        if (declaredValues != null && !declaredValues.isEmpty()) {
+            return List.copyOf(declaredValues);
+        }
+        if (allowableValues != null && allowableValues.get("values") instanceof List<?> values) {
+            return values.stream().map(Object::toString).toList();
+        }
+        return List.of();
     }
 
     private CodegenProperty inlineStringEnumProperty(CodegenProperty property) {

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/JsonStringEnumSupport.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/JsonStringEnumSupport.java
@@ -216,6 +216,14 @@ final class JsonStringEnumSupport {
         List<CodegenProperty> properties = renderVars(model);
         List<Map<String, Object>> definitions = new ArrayList<>();
         for (CodegenProperty property : properties) {
+            if (property.isEnum) {
+                String enumName = property.isArray && property.items != null
+                        ? property.items.datatypeWithEnum
+                        : property.datatypeWithEnum;
+                if (enumName != null && !enumName.isBlank()) {
+                    property.vendorExtensions.put("x-enum-name", enumName);
+                }
+            }
             if (property.isEnumRef && property.isString) {
                 validateEnumWireValues("model property '" + model.classname + "." + property.baseName + "'",
                                        wireValues(property._enum, property.allowableValues),

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/JsonStringEnumSupport.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/JsonStringEnumSupport.java
@@ -36,6 +36,9 @@ import org.openapitools.codegen.CodegenParameter;
 import org.openapitools.codegen.CodegenProperty;
 import org.openapitools.codegen.model.OperationsMap;
 
+/**
+ * Prepares exact-wire-value string enums and their Helidon JSON and HTTP mappings.
+ */
 final class JsonStringEnumSupport {
     private final BiFunction<String, String, String> enumVarNamer;
     private Set<String> httpParameterEnumSchemas = Set.of();
@@ -128,8 +131,7 @@ final class JsonStringEnumSupport {
         }
         parameter.datatypeWithEnum = parameter.dataType;
 
-        boolean httpMapper = parameter.isPathParam || parameter.isQueryParam
-                || parameter.isHeaderParam || parameter.isCookieParam;
+        boolean httpMapper = parameter.isPathParam || parameter.isQueryParam || parameter.isHeaderParam;
         Map<String, Object> definition = enumDefinition(enumName,
                                                         apiClassname + "Api." + enumName,
                                                         apiClassname + "Api" + enumName + "JsonConverter",
@@ -222,11 +224,38 @@ final class JsonStringEnumSupport {
                 String parameterName = refName(parameter.get$ref());
                 resolved = openAPI.getComponents().getParameters().getOrDefault(parameterName, parameter);
             }
+            if ("cookie".equals(resolved.getIn()) && isStringEnumSchema(openAPI, resolved.getSchema())) {
+                throw unsupportedCookieEnum(resolved);
+            }
             collectEnumSchemaRefs(resolved.getSchema(), result);
             if (resolved.getContent() != null) {
+                if ("cookie".equals(resolved.getIn()) && resolved.getContent().values().stream()
+                        .anyMatch(mediaType -> isStringEnumSchema(openAPI, mediaType.getSchema()))) {
+                    throw unsupportedCookieEnum(resolved);
+                }
                 resolved.getContent().values().forEach(mediaType -> collectEnumSchemaRefs(mediaType.getSchema(), result));
             }
         }
+    }
+
+    private boolean isStringEnumSchema(OpenAPI openAPI, Schema<?> schema) {
+        if (schema == null) {
+            return false;
+        }
+        if (schema.get$ref() != null && schema.get$ref().startsWith("#/components/schemas/")
+                && openAPI.getComponents() != null && openAPI.getComponents().getSchemas() != null) {
+            return isStringEnumSchema(openAPI, openAPI.getComponents().getSchemas().get(refName(schema.get$ref())));
+        }
+        return schema.getItems() == null
+                ? "string".equals(schema.getType()) && schema.getEnum() != null && !schema.getEnum().isEmpty()
+                : isStringEnumSchema(openAPI, schema.getItems());
+    }
+
+    private IllegalArgumentException unsupportedCookieEnum(Parameter parameter) {
+        return new IllegalArgumentException("Unsupported OpenAPI string enum cookie parameter '"
+                + parameter.getName() + "'. Helidon declarative HTTP does not provide a cookie parameter "
+                + "annotation. Read the Cookie header in endpoint code or map the value to a supported path, "
+                + "query, or header parameter.");
     }
 
     private void collectEnumSchemaRefs(Schema<?> schema, Set<String> result) {

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/JsonStringEnumSupport.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/JsonStringEnumSupport.java
@@ -1,0 +1,417 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.openapi.generator;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.UnaryOperator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Yaml;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.parameters.Parameter;
+import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenOperation;
+import org.openapitools.codegen.CodegenParameter;
+import org.openapitools.codegen.CodegenProperty;
+import org.openapitools.codegen.model.OperationsMap;
+
+final class JsonStringEnumSupport {
+    private final BiFunction<String, String, String> enumVarNamer;
+    private Set<String> httpParameterEnumSchemas = Set.of();
+    private Map<String, List<String>> inlineRequestEntityEnumValues = Map.of();
+    private Set<String> inlineRequestEntityEnumCollections = Set.of();
+
+    JsonStringEnumSupport(BiFunction<String, String, String> enumVarNamer) {
+        this.enumVarNamer = enumVarNamer;
+    }
+
+    void preprocess(OpenAPI openAPI, String inputSpec) {
+        captureInlineRequestEntityEnums(openAPI, inputSpec);
+        httpParameterEnumSchemas = findHttpParameterEnumSchemas(openAPI);
+    }
+
+    void markHttpParameterEnum(String schemaName, CodegenModel model) {
+        if (httpParameterEnumSchemas.contains(schemaName)) {
+            model.vendorExtensions.put("x-http-parameter-enum", Boolean.TRUE);
+        }
+    }
+
+    void restoreInlineRequestEntityEnum(String operationId, CodegenOperation codegenOperation) {
+        if (operationId == null) {
+            return;
+        }
+        List<String> enumValues = inlineRequestEntityEnumValues.getOrDefault(operationId, List.of());
+        if (enumValues.isEmpty()) {
+            return;
+        }
+        restoreInlineRequestEntityEnum(codegenOperation,
+                                       enumValues,
+                                       inlineRequestEntityEnumCollections.contains(operationId));
+    }
+
+    void prepareInlineRequestEntityEnum(CodegenOperation operation, CodegenParameter parameter) {
+        if (!parameter.isBodyParam) {
+            return;
+        }
+        List<String> values = inlineRequestEntityEnumValues.get(operation.operationId);
+        if (values == null || values.isEmpty()) {
+            return;
+        }
+        Map<String, Object> allowableValues = stringAllowableValues(values);
+        if (inlineRequestEntityEnumCollections.contains(operation.operationId) && parameter.items != null) {
+            parameter.items.isEnum = true;
+            parameter.items.isString = true;
+            parameter.items.allowableValues = allowableValues;
+        } else {
+            parameter.isEnum = true;
+            parameter.isString = true;
+            parameter.allowableValues = allowableValues;
+        }
+    }
+
+    void promoteInlineOperationEnum(Map<String, Map<String, Object>> operationEnums,
+                                    String apiClassname,
+                                    CodegenOperation operation,
+                                    CodegenParameter parameter,
+                                    UnaryOperator<String> javaName) {
+        CodegenProperty item = parameter.isArray ? parameter.items : null;
+        boolean itemEnum = item != null && item.isEnum && !item.isEnumRef && item.isString;
+        boolean directEnum = !parameter.isArray && parameter.isEnum && !parameter.isEnumRef && parameter.isString;
+        Map<String, Object> allowableValues = itemEnum ? item.allowableValues : parameter.allowableValues;
+        if ((!itemEnum && !directEnum) || enumValues(allowableValues).isEmpty()) {
+            return;
+        }
+
+        String enumName = javaName.apply(operation.operationId)
+                + javaName.apply(parameter.paramName)
+                + "Enum";
+        String bareType = parameter.vendorExtensions.containsKey("x-bare-type")
+                ? parameter.vendorExtensions.get("x-bare-type").toString()
+                : parameter.dataType;
+        String promotedBareType;
+        if (parameter.isArray) {
+            String itemType = item.dataType == null ? "String" : item.dataType;
+            promotedBareType = bareType.replace(itemType, enumName);
+        } else {
+            promotedBareType = enumName;
+        }
+        if (parameter.vendorExtensions.containsKey("x-optional")) {
+            parameter.vendorExtensions.put("x-bare-type", promotedBareType);
+            parameter.dataType = "Optional<" + promotedBareType + ">";
+        } else {
+            parameter.dataType = promotedBareType;
+        }
+        parameter.datatypeWithEnum = parameter.dataType;
+
+        boolean httpMapper = parameter.isPathParam || parameter.isQueryParam
+                || parameter.isHeaderParam || parameter.isCookieParam;
+        Map<String, Object> definition = enumDefinition(enumName,
+                                                        apiClassname + "Api." + enumName,
+                                                        apiClassname + "Api" + enumName + "JsonConverter",
+                                                        allowableValues,
+                                                        httpMapper);
+        operationEnums.putIfAbsent(enumName, definition);
+    }
+
+    void applyOperationEnums(OperationsMap result, Map<String, Map<String, Object>> operationEnums) {
+        if (operationEnums.isEmpty()) {
+            return;
+        }
+        result.put("x-operation-string-enums", new ArrayList<>(operationEnums.values()));
+        result.put("x-has-operation-string-enums", Boolean.TRUE);
+        if (operationEnums.values().stream().anyMatch(definition -> definition.containsKey("httpMapper"))) {
+            result.put("x-has-http-enum-mappers", Boolean.TRUE);
+        }
+    }
+
+    boolean prepareTopLevelModel(CodegenModel model) {
+        if (!model.isEnum || !model.isString) {
+            return false;
+        }
+        Map<String, Object> definition = enumDefinition(model.classname,
+                                                        model.classname,
+                                                        model.classname + "JsonConverter",
+                                                        model.allowableValues,
+                                                        Boolean.TRUE.equals(model.vendorExtensions
+                                                                                    .get("x-http-parameter-enum")));
+        if (definition != null) {
+            model.vendorExtensions.put("x-top-level-string-enum", definition);
+            model.vendorExtensions.put("x-has-string-enums", Boolean.TRUE);
+            if (definition.containsKey("httpMapper")) {
+                model.vendorExtensions.put("x-has-http-enum-mappers", Boolean.TRUE);
+            }
+        }
+        return true;
+    }
+
+    List<CodegenProperty> prepareInlineModelEnums(CodegenModel model) {
+        List<CodegenProperty> properties = renderVars(model);
+        List<Map<String, Object>> definitions = new ArrayList<>();
+        for (CodegenProperty property : properties) {
+            CodegenProperty enumProperty = inlineStringEnumProperty(property);
+            if (enumProperty == null || enumProperty.datatypeWithEnum == null
+                    || enumProperty.datatypeWithEnum.isBlank()) {
+                continue;
+            }
+            String enumName = enumProperty.datatypeWithEnum;
+            property.vendorExtensions.put("x-enum-name", enumName);
+            Map<String, Object> definition = enumDefinition(enumName,
+                                                            model.classname + "." + enumName,
+                                                            model.classname + enumName + "JsonConverter",
+                                                            enumProperty.allowableValues,
+                                                            false);
+            if (definition != null) {
+                definitions.add(definition);
+            }
+        }
+        if (!definitions.isEmpty()) {
+            model.vendorExtensions.put("x-inline-string-enums", definitions);
+            model.vendorExtensions.put("x-has-string-enums", Boolean.TRUE);
+        }
+        return properties;
+    }
+
+    private Set<String> findHttpParameterEnumSchemas(OpenAPI openAPI) {
+        if (openAPI.getPaths() == null) {
+            return Set.of();
+        }
+        Set<String> result = new LinkedHashSet<>();
+        openAPI.getPaths().values().forEach(pathItem -> {
+            collectHttpParameterEnumSchemas(openAPI, pathItem.getParameters(), result);
+            pathItem.readOperations().forEach(operation ->
+                    collectHttpParameterEnumSchemas(openAPI, operation.getParameters(), result));
+        });
+        return Set.copyOf(result);
+    }
+
+    private void collectHttpParameterEnumSchemas(OpenAPI openAPI,
+                                                 List<Parameter> parameters,
+                                                 Set<String> result) {
+        if (parameters == null) {
+            return;
+        }
+        for (Parameter parameter : parameters) {
+            Parameter resolved = parameter;
+            if (parameter.get$ref() != null && parameter.get$ref().startsWith("#/components/parameters/")
+                    && openAPI.getComponents() != null && openAPI.getComponents().getParameters() != null) {
+                String parameterName = refName(parameter.get$ref());
+                resolved = openAPI.getComponents().getParameters().getOrDefault(parameterName, parameter);
+            }
+            collectEnumSchemaRefs(resolved.getSchema(), result);
+            if (resolved.getContent() != null) {
+                resolved.getContent().values().forEach(mediaType -> collectEnumSchemaRefs(mediaType.getSchema(), result));
+            }
+        }
+    }
+
+    private void collectEnumSchemaRefs(Schema<?> schema, Set<String> result) {
+        if (schema == null) {
+            return;
+        }
+        if (schema.get$ref() != null && schema.get$ref().startsWith("#/components/schemas/")) {
+            result.add(refName(schema.get$ref()));
+        }
+        collectEnumSchemaRefs(schema.getItems(), result);
+        if (schema.getAdditionalProperties() instanceof Schema<?> additionalProperties) {
+            collectEnumSchemaRefs(additionalProperties, result);
+        }
+    }
+
+    private void captureInlineRequestEntityEnums(OpenAPI openAPI, String inputSpec) {
+        if (openAPI.getPaths() == null) {
+            inlineRequestEntityEnumValues = Map.of();
+            inlineRequestEntityEnumCollections = Set.of();
+            return;
+        }
+        Map<String, List<String>> valuesByOperation = new LinkedHashMap<>();
+        Set<String> collections = new LinkedHashSet<>();
+        openAPI.getPaths().values().forEach(pathItem -> pathItem.readOperations().forEach(operation ->
+                captureInlineRequestEntityEnum(operation, valuesByOperation, collections)));
+        captureRawInlineRequestEntityEnums(inputSpec, valuesByOperation, collections);
+        inlineRequestEntityEnumValues = Map.copyOf(valuesByOperation);
+        inlineRequestEntityEnumCollections = Set.copyOf(collections);
+    }
+
+    private void captureInlineRequestEntityEnum(Operation operation,
+                                                Map<String, List<String>> valuesByOperation,
+                                                Set<String> collections) {
+        if (operation.getOperationId() == null || operation.getRequestBody() == null
+                || operation.getRequestBody().getContent() == null
+                || operation.getRequestBody().getContent().isEmpty()) {
+            return;
+        }
+        Schema<?> schema = operation.getRequestBody().getContent().values().iterator().next().getSchema();
+        if (schema == null || schema.get$ref() != null) {
+            return;
+        }
+        Schema<?> enumSchema = schema.getItems() == null ? schema : schema.getItems();
+        if (enumSchema.get$ref() == null && enumSchema.getEnum() != null && !enumSchema.getEnum().isEmpty()) {
+            valuesByOperation.put(operation.getOperationId(), enumSchema.getEnum().stream()
+                    .map(Object::toString)
+                    .toList());
+            if (schema.getItems() != null) {
+                collections.add(operation.getOperationId());
+            }
+        }
+    }
+
+    private void captureRawInlineRequestEntityEnums(String inputSpec,
+                                                     Map<String, List<String>> valuesByOperation,
+                                                     Set<String> collections) {
+        if (inputSpec == null || inputSpec.isBlank()) {
+            return;
+        }
+        try {
+            String specContent = InputSpecContentReader.read(inputSpec);
+            ObjectMapper mapper = looksLikeJson(inputSpec, specContent) ? Json.mapper() : Yaml.mapper();
+            JsonNode paths = mapper.readTree(specContent).path("paths");
+            paths.fields().forEachRemaining(pathEntry -> pathEntry.getValue().fields().forEachRemaining(methodEntry ->
+                    captureRawInlineRequestEntityEnum(methodEntry.getValue(), valuesByOperation, collections)));
+        } catch (IOException | RuntimeException ignored) {
+            // The parsed OpenAPI model remains the source of truth when raw input cannot be read.
+        }
+    }
+
+    private void captureRawInlineRequestEntityEnum(JsonNode operation,
+                                                   Map<String, List<String>> valuesByOperation,
+                                                   Set<String> collections) {
+        String operationId = operation.path("operationId").asText(null);
+        JsonNode content = operation.path("requestBody").path("content");
+        if (operationId == null || !content.isObject() || content.isEmpty()) {
+            return;
+        }
+        JsonNode schema = content.elements().next().path("schema");
+        JsonNode enumSchema = schema.has("items") ? schema.path("items") : schema;
+        JsonNode enumNode = enumSchema.path("enum");
+        if (!enumNode.isArray() || enumNode.isEmpty()) {
+            return;
+        }
+        List<String> values = new ArrayList<>();
+        enumNode.forEach(value -> values.add(value.asText()));
+        valuesByOperation.put(operationId, List.copyOf(values));
+        if (schema.has("items")) {
+            collections.add(operationId);
+        }
+    }
+
+    private void restoreInlineRequestEntityEnum(CodegenOperation codegenOperation,
+                                                List<String> enumValues,
+                                                boolean collection) {
+        Map<String, Object> allowableValues = stringAllowableValues(enumValues);
+        List<CodegenParameter> bodyParameters = new ArrayList<>();
+        if (codegenOperation.bodyParam != null) {
+            bodyParameters.add(codegenOperation.bodyParam);
+        }
+        if (codegenOperation.allParams != null) {
+            codegenOperation.allParams.stream()
+                    .filter(parameter -> parameter.isBodyParam && parameter != codegenOperation.bodyParam)
+                    .forEach(bodyParameters::add);
+        }
+        for (CodegenParameter bodyParameter : bodyParameters) {
+            if (!collection) {
+                bodyParameter.isEnum = true;
+                bodyParameter.isString = true;
+                bodyParameter.allowableValues = allowableValues;
+            } else if (bodyParameter.items != null) {
+                bodyParameter.items.isEnum = true;
+                bodyParameter.items.isString = true;
+                bodyParameter.items.allowableValues = allowableValues;
+            }
+        }
+    }
+
+    private Map<String, Object> stringAllowableValues(List<String> values) {
+        List<Map<String, String>> enumVars = new ArrayList<>();
+        for (String wireValue : values) {
+            enumVars.add(Map.of("name", enumVarNamer.apply(wireValue, "String"),
+                                "value", JavaStringLiterals.toJavaStringLiteral(wireValue)));
+        }
+        return Map.of("enumVars", enumVars);
+    }
+
+    private CodegenProperty inlineStringEnumProperty(CodegenProperty property) {
+        CodegenProperty candidate = property.isArray ? property.items : property;
+        if (candidate == null || !candidate.isEnum || candidate.isEnumRef || !candidate.isString) {
+            return null;
+        }
+        return enumValues(candidate.allowableValues).isEmpty() ? null : candidate;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<CodegenProperty> renderVars(CodegenModel model) {
+        Object renderVars = model.vendorExtensions.get("x-render-vars");
+        return renderVars instanceof List<?> vars ? (List<CodegenProperty>) vars : model.vars;
+    }
+
+    private Map<String, Object> enumDefinition(String enumName,
+                                               String qualifiedType,
+                                               String converterName,
+                                               Map<String, Object> allowableValues,
+                                               boolean httpMapper) {
+        List<Map<String, String>> values = enumValues(allowableValues);
+        if (values.isEmpty()) {
+            return null;
+        }
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("enumName", enumName);
+        result.put("qualifiedType", qualifiedType);
+        result.put("converterName", converterName);
+        result.put("values", values);
+        if (httpMapper) {
+            result.put("httpMapper", Boolean.TRUE);
+        }
+        return result;
+    }
+
+    private List<Map<String, String>> enumValues(Map<String, Object> allowableValues) {
+        if (allowableValues == null || !(allowableValues.get("enumVars") instanceof List<?> enumVars)) {
+            return List.of();
+        }
+        List<Map<String, String>> result = new ArrayList<>();
+        for (Object enumVar : enumVars) {
+            if (!(enumVar instanceof Map<?, ?> values)) {
+                continue;
+            }
+            Object name = values.get("name");
+            Object value = values.get("value");
+            if (name != null && value != null) {
+                result.add(Map.of("name", name.toString(), "value", value.toString()));
+            }
+        }
+        return result;
+    }
+
+    private String refName(String ref) {
+        return ref.substring(ref.lastIndexOf('/') + 1);
+    }
+
+    private boolean looksLikeJson(String specLocation, String specContent) {
+        String trimmed = specContent.stripLeading();
+        return specLocation.endsWith(".json") || trimmed.startsWith("{") || trimmed.startsWith("[");
+    }
+}

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/JsonStringEnumSupport.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/JsonStringEnumSupport.java
@@ -16,7 +16,6 @@
 
 package io.helidon.openapi.generator;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -26,12 +25,9 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.UnaryOperator;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.swagger.v3.core.util.Json;
-import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.PathItem;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.parameters.Parameter;
 import org.openapitools.codegen.CodegenModel;
@@ -50,8 +46,8 @@ final class JsonStringEnumSupport {
         this.enumVarNamer = enumVarNamer;
     }
 
-    void preprocess(OpenAPI openAPI, String inputSpec) {
-        captureInlineRequestEntityEnums(openAPI, inputSpec);
+    void preprocess(OpenAPI openAPI) {
+        captureInlineRequestEntityEnums(openAPI);
         httpParameterEnumSchemas = findHttpParameterEnumSchemas(openAPI);
     }
 
@@ -61,29 +57,33 @@ final class JsonStringEnumSupport {
         }
     }
 
-    void restoreInlineRequestEntityEnum(String operationId, CodegenOperation codegenOperation) {
-        if (operationId == null) {
-            return;
-        }
-        List<String> enumValues = inlineRequestEntityEnumValues.getOrDefault(operationId, List.of());
+    void restoreInlineRequestEntityEnum(String path, String httpMethod, CodegenOperation codegenOperation) {
+        String operationKey = operationKey(path, httpMethod);
+        List<String> enumValues = inlineRequestEntityEnumValues.getOrDefault(operationKey, List.of());
         if (enumValues.isEmpty()) {
             return;
         }
         restoreInlineRequestEntityEnum(codegenOperation,
                                        enumValues,
-                                       inlineRequestEntityEnumCollections.contains(operationId));
+                                       inlineRequestEntityEnumCollections.contains(operationKey));
+        codegenOperation.vendorExtensions.put("x-inline-request-entity-enum-values", enumValues);
+        if (inlineRequestEntityEnumCollections.contains(operationKey)) {
+            codegenOperation.vendorExtensions.put("x-inline-request-entity-enum-collection", Boolean.TRUE);
+        }
     }
 
     void prepareInlineRequestEntityEnum(CodegenOperation operation, CodegenParameter parameter) {
         if (!parameter.isBodyParam) {
             return;
         }
-        List<String> values = inlineRequestEntityEnumValues.get(operation.operationId);
-        if (values == null || values.isEmpty()) {
+        Object capturedValues = operation.vendorExtensions.get("x-inline-request-entity-enum-values");
+        if (!(capturedValues instanceof List<?> values) || values.isEmpty()) {
             return;
         }
-        Map<String, Object> allowableValues = stringAllowableValues(values);
-        if (inlineRequestEntityEnumCollections.contains(operation.operationId) && parameter.items != null) {
+        List<String> enumValues = values.stream().map(Object::toString).toList();
+        Map<String, Object> allowableValues = stringAllowableValues(enumValues);
+        if (operation.vendorExtensions.containsKey("x-inline-request-entity-enum-collection")
+                && parameter.items != null) {
             parameter.items.isEnum = true;
             parameter.items.isString = true;
             parameter.items.allowableValues = allowableValues;
@@ -242,7 +242,7 @@ final class JsonStringEnumSupport {
         }
     }
 
-    private void captureInlineRequestEntityEnums(OpenAPI openAPI, String inputSpec) {
+    private void captureInlineRequestEntityEnums(OpenAPI openAPI) {
         if (openAPI.getPaths() == null) {
             inlineRequestEntityEnumValues = Map.of();
             inlineRequestEntityEnumCollections = Set.of();
@@ -250,18 +250,18 @@ final class JsonStringEnumSupport {
         }
         Map<String, List<String>> valuesByOperation = new LinkedHashMap<>();
         Set<String> collections = new LinkedHashSet<>();
-        openAPI.getPaths().values().forEach(pathItem -> pathItem.readOperations().forEach(operation ->
-                captureInlineRequestEntityEnum(operation, valuesByOperation, collections)));
-        captureRawInlineRequestEntityEnums(inputSpec, valuesByOperation, collections);
+        openAPI.getPaths().forEach((path, pathItem) -> pathItem.readOperationsMap().forEach((method, operation) ->
+                captureInlineRequestEntityEnum(path, method, operation, valuesByOperation, collections)));
         inlineRequestEntityEnumValues = Map.copyOf(valuesByOperation);
         inlineRequestEntityEnumCollections = Set.copyOf(collections);
     }
 
-    private void captureInlineRequestEntityEnum(Operation operation,
+    private void captureInlineRequestEntityEnum(String path,
+                                                PathItem.HttpMethod method,
+                                                Operation operation,
                                                 Map<String, List<String>> valuesByOperation,
                                                 Set<String> collections) {
-        if (operation.getOperationId() == null || operation.getRequestBody() == null
-                || operation.getRequestBody().getContent() == null
+        if (operation.getRequestBody() == null || operation.getRequestBody().getContent() == null
                 || operation.getRequestBody().getContent().isEmpty()) {
             return;
         }
@@ -270,52 +270,15 @@ final class JsonStringEnumSupport {
             return;
         }
         Schema<?> enumSchema = schema.getItems() == null ? schema : schema.getItems();
-        if (enumSchema.get$ref() == null && enumSchema.getEnum() != null && !enumSchema.getEnum().isEmpty()) {
-            valuesByOperation.put(operation.getOperationId(), enumSchema.getEnum().stream()
+        if (enumSchema.get$ref() == null && "string".equals(enumSchema.getType())
+                && enumSchema.getEnum() != null && !enumSchema.getEnum().isEmpty()) {
+            String operationKey = operationKey(path, method.name());
+            valuesByOperation.put(operationKey, enumSchema.getEnum().stream()
                     .map(Object::toString)
                     .toList());
             if (schema.getItems() != null) {
-                collections.add(operation.getOperationId());
+                collections.add(operationKey);
             }
-        }
-    }
-
-    private void captureRawInlineRequestEntityEnums(String inputSpec,
-                                                     Map<String, List<String>> valuesByOperation,
-                                                     Set<String> collections) {
-        if (inputSpec == null || inputSpec.isBlank()) {
-            return;
-        }
-        try {
-            String specContent = InputSpecContentReader.read(inputSpec);
-            ObjectMapper mapper = looksLikeJson(inputSpec, specContent) ? Json.mapper() : Yaml.mapper();
-            JsonNode paths = mapper.readTree(specContent).path("paths");
-            paths.fields().forEachRemaining(pathEntry -> pathEntry.getValue().fields().forEachRemaining(methodEntry ->
-                    captureRawInlineRequestEntityEnum(methodEntry.getValue(), valuesByOperation, collections)));
-        } catch (IOException | RuntimeException ignored) {
-            // The parsed OpenAPI model remains the source of truth when raw input cannot be read.
-        }
-    }
-
-    private void captureRawInlineRequestEntityEnum(JsonNode operation,
-                                                   Map<String, List<String>> valuesByOperation,
-                                                   Set<String> collections) {
-        String operationId = operation.path("operationId").asText(null);
-        JsonNode content = operation.path("requestBody").path("content");
-        if (operationId == null || !content.isObject() || content.isEmpty()) {
-            return;
-        }
-        JsonNode schema = content.elements().next().path("schema");
-        JsonNode enumSchema = schema.has("items") ? schema.path("items") : schema;
-        JsonNode enumNode = enumSchema.path("enum");
-        if (!enumNode.isArray() || enumNode.isEmpty()) {
-            return;
-        }
-        List<String> values = new ArrayList<>();
-        enumNode.forEach(value -> values.add(value.asText()));
-        valuesByOperation.put(operationId, List.copyOf(values));
-        if (schema.has("items")) {
-            collections.add(operationId);
         }
     }
 
@@ -373,7 +336,7 @@ final class JsonStringEnumSupport {
                                                String converterName,
                                                Map<String, Object> allowableValues,
                                                boolean httpMapper) {
-        List<Map<String, String>> values = enumValues(allowableValues);
+        List<Map<String, String>> values = uniqueEnumValues(enumName, enumValues(allowableValues));
         if (values.isEmpty()) {
             return null;
         }
@@ -406,12 +369,31 @@ final class JsonStringEnumSupport {
         return result;
     }
 
+    private List<Map<String, String>> uniqueEnumValues(String enumName, List<Map<String, String>> values) {
+        Set<String> wireValues = new LinkedHashSet<>();
+        Set<String> constantNames = new LinkedHashSet<>();
+        List<Map<String, String>> result = new ArrayList<>();
+        for (Map<String, String> value : values) {
+            String wireValue = value.get("value");
+            if (!wireValues.add(wireValue)) {
+                throw new IllegalArgumentException("OpenAPI string enum '" + enumName
+                                                           + "' declares duplicate wire value " + wireValue);
+            }
+            String baseName = value.get("name");
+            String constantName = baseName;
+            for (int suffix = 2; !constantNames.add(constantName); suffix++) {
+                constantName = baseName + "_" + suffix;
+            }
+            result.add(Map.of("name", constantName, "value", wireValue));
+        }
+        return List.copyOf(result);
+    }
+
     private String refName(String ref) {
         return ref.substring(ref.lastIndexOf('/') + 1);
     }
 
-    private boolean looksLikeJson(String specLocation, String specContent) {
-        String trimmed = specContent.stripLeading();
-        return specLocation.endsWith(".json") || trimmed.startsWith("{") || trimmed.startsWith("[");
+    private String operationKey(String path, String httpMethod) {
+        return httpMethod.toUpperCase() + " " + path;
     }
 }

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/api-interface.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/api-interface.mustache
@@ -20,6 +20,13 @@ import io.helidon.common.media.type.MediaTypes;
 import io.helidon.http.Http;
 import io.helidon.service.registry.Service;
 import io.helidon.webserver.http.RestServer;
+{{#x-has-operation-string-enums}}import io.helidon.common.GenericType;
+import io.helidon.json.JsonGenerator;
+import io.helidon.json.JsonParser;
+import io.helidon.json.binding.Json;
+import io.helidon.json.binding.JsonConverter;
+{{#x-has-http-enum-mappers}}import io.helidon.common.mapper.Mapper;
+{{/x-has-http-enum-mappers}}{{/x-has-operation-string-enums}}
 {{#imports}}
 import {{import}};
 {{/imports}}
@@ -68,5 +75,13 @@ public interface {{classname}}Api {
     {{/vendorExtensions.x-has-security-roles}}{{{returnType}}} {{operationId}}({{#allParams}}{{#isPathParam}}{{#vendorExtensions.x-validation-annotations}}{{{annotation}}} {{/vendorExtensions.x-validation-annotations}}@Http.PathParam("{{baseName}}") {{{dataType}}} {{paramName}}{{/isPathParam}}{{#isQueryParam}}{{#vendorExtensions.x-validation-annotations}}{{{annotation}}} {{/vendorExtensions.x-validation-annotations}}@Http.QueryParam("{{baseName}}") {{{dataType}}} {{paramName}}{{/isQueryParam}}{{#isHeaderParam}}{{#vendorExtensions.x-validation-annotations}}{{{annotation}}} {{/vendorExtensions.x-validation-annotations}}@Http.HeaderParam("{{baseName}}") {{{dataType}}} {{paramName}}{{/isHeaderParam}}{{#isBodyParam}}@Http.Entity {{{dataType}}} {{paramName}}{{/isBodyParam}}{{^-last}}, {{/-last}}{{/allParams}});
 
 {{/operation}}
+{{#x-operation-string-enums}}
+{{>nestedStringEnum}}
+
+{{/x-operation-string-enums}}
 }
+{{#x-operation-string-enums}}
+
+{{>stringEnumConverter}}
+{{/x-operation-string-enums}}
 {{/operations}}

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
@@ -581,6 +581,13 @@ public class {{classname}}{{#vendorExtensions.x-extends-model}} extends {{vendor
 {{>nestedStringEnum}}
 
 {{/vendorExtensions.x-inline-string-enums}}
+{{#vendorExtensions.x-render-vars}}{{#isEnum}}{{^vendorExtensions.x-enum-wire-constraints-validated}}
+    public enum {{vendorExtensions.x-enum-name}} {
+        {{#allowableValues}}{{#enumVars}}{{name}}{{^-last}},
+        {{/-last}}{{/enumVars}};{{/allowableValues}}
+    }
+
+{{/vendorExtensions.x-enum-wire-constraints-validated}}{{/isEnum}}{{/vendorExtensions.x-render-vars}}
 }
 {{#vendorExtensions.x-inline-string-enums}}
 

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
@@ -18,6 +18,13 @@ limitations under the License.
 package {{modelPackage}};
 
 import io.helidon.json.binding.Json;
+{{#model}}{{#vendorExtensions.x-has-string-enums}}import io.helidon.common.GenericType;
+import io.helidon.json.JsonGenerator;
+import io.helidon.json.JsonParser;
+import io.helidon.json.binding.JsonConverter;
+import io.helidon.service.registry.Service;
+{{#vendorExtensions.x-has-http-enum-mappers}}import io.helidon.common.mapper.Mapper;
+{{/vendorExtensions.x-has-http-enum-mappers}}{{/vendorExtensions.x-has-string-enums}}{{/model}}
 {{#model}}{{#vendorExtensions.x-is-union-interface}}import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -45,7 +52,10 @@ import {{import}};
 /**
  * {{description}}{{^description}}{{classname}} model.{{/description}}
  */
-{{#vendorExtensions.x-is-union-interface}}@Json.Converter({{classname}}.{{classname}}JsonConverter.class)
+{{#vendorExtensions.x-top-level-string-enum}}{{>stringEnum}}
+
+{{>stringEnumConverter}}
+{{/vendorExtensions.x-top-level-string-enum}}{{^vendorExtensions.x-top-level-string-enum}}{{#vendorExtensions.x-is-union-interface}}@Json.Converter({{classname}}.{{classname}}JsonConverter.class)
 {{#isDeprecated}}@Deprecated
 {{/isDeprecated}}public interface {{classname}} {
 
@@ -567,14 +577,16 @@ public class {{classname}}{{#vendorExtensions.x-extends-model}} extends {{vendor
     }
 
 {{/vendorExtensions.x-extends-model}}
-{{#vendorExtensions.x-render-vars}}{{#isEnum}}
-    public enum {{vendorExtensions.x-enum-name}} {
-        {{#allowableValues}}{{#enumVars}}{{name}}{{^-last}},
-        {{/-last}}{{/enumVars}};{{/allowableValues}}
-    }
+{{#vendorExtensions.x-inline-string-enums}}
+{{>nestedStringEnum}}
 
-{{/isEnum}}{{/vendorExtensions.x-render-vars}}
+{{/vendorExtensions.x-inline-string-enums}}
 }
+{{#vendorExtensions.x-inline-string-enums}}
+
+{{>stringEnumConverter}}
+{{/vendorExtensions.x-inline-string-enums}}
 {{/vendorExtensions.x-is-union-interface}}
+{{/vendorExtensions.x-top-level-string-enum}}
 {{/model}}
 {{/models}}

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/nestedStringEnum.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/nestedStringEnum.mustache
@@ -1,0 +1,45 @@
+    @Json.Converter({{converterName}}.class)
+    public enum {{enumName}} {
+{{#values}}
+        {{name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+{{/values}}
+
+        private final String value;
+
+        {{enumName}}(String value) {
+            this.value = value;
+        }
+
+        /**
+         * OpenAPI wire value.
+         *
+         * @return exact value declared in the OpenAPI document
+         */
+        public String value() {
+            return value;
+        }
+
+        /**
+         * Resolve an exact OpenAPI wire value.
+         *
+         * @param value wire value
+         * @return matching enum constant, or {@code null} when the value is {@code null}
+         * @throws IllegalArgumentException when the value is not declared by the OpenAPI enum
+         */
+        public static {{enumName}} fromValue(String value) {
+            if (value == null) {
+                return null;
+            }
+            return switch (value) {
+{{#values}}
+                case {{{value}}} -> {{name}};
+{{/values}}
+                default -> throw new IllegalArgumentException("Unexpected {{enumName}} value '" + value + "'");
+            };
+        }
+
+        @Override
+        public String toString() {
+            return value;
+        }
+    }

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/nestedStringEnum.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/nestedStringEnum.mustache
@@ -38,13 +38,12 @@ limitations under the License.
          * Resolve an exact OpenAPI wire value.
          *
          * @param value wire value
-         * @return matching enum constant, or {@code null} when the value is {@code null}
+         * @return matching enum constant
+         * @throws NullPointerException when the value is {@code null}
          * @throws IllegalArgumentException when the value is not declared by the OpenAPI enum
          */
         public static {{enumName}} fromValue(String value) {
-            if (value == null) {
-                return null;
-            }
+            java.util.Objects.requireNonNull(value, "value");
             return switch (value) {
 {{#values}}
                 case {{{value}}} -> {{name}};

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/nestedStringEnum.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/nestedStringEnum.mustache
@@ -14,6 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 }}
 
+    /**
+     * Exact string values declared by the OpenAPI schema.
+     */
     @Json.Converter({{converterName}}.class)
     public enum {{enumName}} {
 {{#values}}

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/nestedStringEnum.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/nestedStringEnum.mustache
@@ -1,9 +1,24 @@
+{{!
+Copyright (c) 2026 Oracle and/or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+
     @Json.Converter({{converterName}}.class)
     public enum {{enumName}} {
 {{#values}}
         {{name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
 {{/values}}
-
         private final String value;
 
         {{enumName}}(String value) {

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/stringEnum.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/stringEnum.mustache
@@ -38,13 +38,12 @@ public enum {{enumName}} {
      * Resolve an exact OpenAPI wire value.
      *
      * @param value wire value
-     * @return matching enum constant, or {@code null} when the value is {@code null}
+     * @return matching enum constant
+     * @throws NullPointerException when the value is {@code null}
      * @throws IllegalArgumentException when the value is not declared by the OpenAPI enum
      */
     public static {{enumName}} fromValue(String value) {
-        if (value == null) {
-            return null;
-        }
+        java.util.Objects.requireNonNull(value, "value");
         return switch (value) {
 {{#values}}
             case {{{value}}} -> {{name}};

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/stringEnum.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/stringEnum.mustache
@@ -1,9 +1,24 @@
+{{!
+Copyright (c) 2026 Oracle and/or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+
 @Json.Converter({{converterName}}.class)
 public enum {{enumName}} {
 {{#values}}
     {{name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
 {{/values}}
-
     private final String value;
 
     {{enumName}}(String value) {

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/stringEnum.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/stringEnum.mustache
@@ -1,0 +1,45 @@
+@Json.Converter({{converterName}}.class)
+public enum {{enumName}} {
+{{#values}}
+    {{name}}({{{value}}}){{^-last}},{{/-last}}{{#-last}};{{/-last}}
+{{/values}}
+
+    private final String value;
+
+    {{enumName}}(String value) {
+        this.value = value;
+    }
+
+    /**
+     * OpenAPI wire value.
+     *
+     * @return exact value declared in the OpenAPI document
+     */
+    public String value() {
+        return value;
+    }
+
+    /**
+     * Resolve an exact OpenAPI wire value.
+     *
+     * @param value wire value
+     * @return matching enum constant, or {@code null} when the value is {@code null}
+     * @throws IllegalArgumentException when the value is not declared by the OpenAPI enum
+     */
+    public static {{enumName}} fromValue(String value) {
+        if (value == null) {
+            return null;
+        }
+        return switch (value) {
+{{#values}}
+            case {{{value}}} -> {{name}};
+{{/values}}
+            default -> throw new IllegalArgumentException("Unexpected {{enumName}} value '" + value + "'");
+        };
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+}

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/stringEnumConverter.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/stringEnumConverter.mustache
@@ -28,11 +28,18 @@ final class {{converterName}} implements JsonConverter<{{qualifiedType}}>{{#http
 
     @Override
     public {{qualifiedType}} deserialize(JsonParser parser) {
+        if (parser.checkNull()) {
+            return null;
+        }
         return {{qualifiedType}}.fromValue(parser.readString());
     }
 
     @Override
     public void serialize(JsonGenerator generator, {{qualifiedType}} instance, boolean writeNulls) {
+        if (instance == null) {
+            generator.writeNull();
+            return;
+        }
         generator.write(instance.value());
     }
 {{#httpMapper}}

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/stringEnumConverter.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/stringEnumConverter.mustache
@@ -1,0 +1,40 @@
+@Service.Singleton
+final class {{converterName}} implements JsonConverter<{{qualifiedType}}>{{#httpMapper}}, Mapper<String, {{qualifiedType}}>{{/httpMapper}} {
+
+    private static final GenericType<{{qualifiedType}}> TYPE = GenericType.create({{qualifiedType}}.class);
+{{#httpMapper}}
+    private static final GenericType<String> SOURCE_TYPE = GenericType.create(String.class);
+{{/httpMapper}}
+
+    @Override
+    public GenericType<{{qualifiedType}}> type() {
+        return TYPE;
+    }
+
+    @Override
+    public {{qualifiedType}} deserialize(JsonParser parser) {
+        return {{qualifiedType}}.fromValue(parser.readString());
+    }
+
+    @Override
+    public void serialize(JsonGenerator generator, {{qualifiedType}} instance, boolean writeNulls) {
+        generator.write(instance.value());
+    }
+{{#httpMapper}}
+
+    @Override
+    public {{qualifiedType}} map(String source) {
+        return {{qualifiedType}}.fromValue(source);
+    }
+
+    @Override
+    public GenericType<String> sourceType() {
+        return SOURCE_TYPE;
+    }
+
+    @Override
+    public GenericType<{{qualifiedType}}> targetType() {
+        return TYPE;
+    }
+{{/httpMapper}}
+}

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/stringEnumConverter.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/stringEnumConverter.mustache
@@ -1,6 +1,21 @@
+{{!
+Copyright (c) 2026 Oracle and/or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+
 @Service.Singleton
 final class {{converterName}} implements JsonConverter<{{qualifiedType}}>{{#httpMapper}}, Mapper<String, {{qualifiedType}}>{{/httpMapper}} {
-
     private static final GenericType<{{qualifiedType}}> TYPE = GenericType.create({{qualifiedType}}.class);
 {{#httpMapper}}
     private static final GenericType<String> SOURCE_TYPE = GenericType.create(String.class);

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/JsonStringEnumGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/JsonStringEnumGenerationIT.java
@@ -75,6 +75,25 @@ class JsonStringEnumGenerationIT {
     }
 
     @Test
+    void converterNamesDoNotCollideWithGeneratedSchemaTypes() throws IOException {
+        String mode = read(outputDir.resolve("src/main/java/io/helidon/example/model/Mode.java"));
+        assertThat(mode, containsString("@Json.Converter(ModeJsonConverter2.class)"));
+        assertThat(mode, containsString("final class ModeJsonConverter2 implements JsonConverter<Mode>"));
+
+        String reserved = read(outputDir.resolve(
+                "src/main/java/io/helidon/example/model/ModeJsonConverter.java"));
+        assertThat(reserved, containsString("public enum ModeJsonConverter"));
+
+        String envelope = read(outputDir.resolve("src/main/java/io/helidon/example/model/EnumEnvelope.java"));
+        assertThat(envelope, containsString("EnumEnvelopeInlineModeEnumJsonConverter2.class"));
+
+        String firstApi = read(outputDir.resolve("src/main/java/io/helidon/example/api/FooApi.java"));
+        String secondApi = read(outputDir.resolve("src/main/java/io/helidon/example/api/FooApiBarApi.java"));
+        assertThat(firstApi, containsString("FooApiBarApiBazModeEnumJsonConverter"));
+        assertThat(secondApi, containsString("FooApiBarApiBazModeEnumJsonConverter2"));
+    }
+
+    @Test
     void inlineReferencedAndCollectionEnumsRemainTyped() throws IOException {
         String envelope = read(outputDir.resolve("src/main/java/io/helidon/example/model/EnumEnvelope.java"));
 
@@ -112,6 +131,28 @@ class JsonStringEnumGenerationIT {
         assertThat(api, not(containsString("enum NumericEnumBodyBodyEnum")));
         assertThat(api, containsString("@Http.Entity Boolean body"));
         assertThat(api, not(containsString("enum BooleanEnumBodyBodyEnum")));
+        assertThat(api, containsString("@Http.QueryParam(\"mode\") ValidatedEnumModeEnum mode"));
+        assertThat(api, not(containsString("@Validation.String.Length(min = 4)")));
+        assertThat(api, containsString("@Http.Entity String body"));
+        assertThat(api, not(containsString("enum TextEnumBodyBodyEnum")));
+        assertThat(api, not(containsString("enum MixedEnumBodyBodyEnum")));
+    }
+
+    @Test
+    void rejectsEnumValuesThatContradictStringConstraints() throws Exception {
+        Path invalidOutput = tempDir.resolve("invalid-constraints");
+        URL resource = JsonStringEnumGenerationIT.class.getClassLoader()
+                .getResource("invalid-string-enum-constraints.yaml");
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("helidon-declarative")
+                .setInputSpec(Paths.get(resource.toURI()).toAbsolutePath().toString())
+                .setOutputDir(invalidOutput.toString());
+
+        RuntimeException error = org.junit.jupiter.api.Assertions.assertThrows(
+                RuntimeException.class,
+                () -> new DefaultGenerator().opts(configurator.toClientOptInput()).generate());
+        assertThat(rootMessage(error), containsString("wire value 'unsafe'"));
+        assertThat(rootMessage(error), containsString("does not satisfy maxLength 4"));
     }
 
     @Test
@@ -174,5 +215,13 @@ class JsonStringEnumGenerationIT {
 
     private static String read(Path file) throws IOException {
         return Files.readString(file).replace("\r\n", "\n");
+    }
+
+    private static String rootMessage(Throwable throwable) {
+        Throwable current = throwable;
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current.getMessage();
     }
 }

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/JsonStringEnumGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/JsonStringEnumGenerationIT.java
@@ -66,6 +66,15 @@ class JsonStringEnumGenerationIT {
     }
 
     @Test
+    void collidingJavaConstantNamesAreDisambiguated() throws IOException {
+        String mode = read(outputDir.resolve("src/main/java/io/helidon/example/model/CollidingMode.java"));
+
+        assertThat(mode, containsString("FOO_BAR(\"foo-bar\")"));
+        assertThat(mode, containsString("FOO_BAR2(\"foo_bar\")"));
+        assertThat(mode, containsString("FOO_BAR3(\"FOO-BAR\")"));
+    }
+
+    @Test
     void inlineReferencedAndCollectionEnumsRemainTyped() throws IOException {
         String envelope = read(outputDir.resolve("src/main/java/io/helidon/example/model/EnumEnvelope.java"));
 
@@ -94,6 +103,11 @@ class JsonStringEnumGenerationIT {
                                                + "Mapper<String, EnumsApi.InspectModeRouteModeEnum>"));
         assertThat(api, containsString("implements JsonConverter<EnumsApi.InspectModeBodyEnum>"));
         assertThat(api, not(containsString("Mapper<String, EnumsApi.InspectModeBodyEnum>")));
+        assertThat(api, containsString("enum EnumNoIdPostBodyEnum"));
+        assertThat(api, containsString("FOO_BAR(\"foo-bar\")"));
+        assertThat(api, containsString("FOO_BAR_2(\"foo_bar\")"));
+        assertThat(api, containsString("@Http.Entity Integer body"));
+        assertThat(api, not(containsString("enum NumericEnumBodyBodyEnum")));
     }
 
     @Test
@@ -125,7 +139,7 @@ class JsonStringEnumGenerationIT {
                 .setGeneratorName("helidon-declarative")
                 .setInputSpec(specPath)
                 .setOutputDir(destination.toString())
-                .addAdditionalProperty("helidonVersion", "4.4.1")
+                .addAdditionalProperty("helidonVersion", "4.5.0")
                 .addAdditionalProperty("apiPackage", "io.helidon.example.api")
                 .addAdditionalProperty("modelPackage", "io.helidon.example.model")
                 .addAdditionalProperty("invokerPackage", "io.helidon.example");

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/JsonStringEnumGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/JsonStringEnumGenerationIT.java
@@ -83,6 +83,7 @@ class JsonStringEnumGenerationIT {
         assertThat(envelope, containsString("private List<Mode> modes"));
         assertThat(envelope, containsString("private List<InlineModesEnum> inlineModes"));
         assertThat(envelope, containsString("public enum InlineModeEnum"));
+        assertThat(envelope, containsString("Exact string values declared by the OpenAPI schema."));
         assertThat(envelope, containsString("(\"on-hold\")"));
         assertThat(envelope, containsString("public enum InlineModesEnum"));
         assertThat(envelope, containsString("(\"batchAuthZ\")"));
@@ -104,10 +105,13 @@ class JsonStringEnumGenerationIT {
         assertThat(api, containsString("implements JsonConverter<EnumsApi.InspectModeBodyEnum>"));
         assertThat(api, not(containsString("Mapper<String, EnumsApi.InspectModeBodyEnum>")));
         assertThat(api, containsString("enum EnumNoIdPostBodyEnum"));
+        assertThat(api, containsString("Exact string values declared by the OpenAPI schema."));
         assertThat(api, containsString("FOO_BAR(\"foo-bar\")"));
         assertThat(api, containsString("FOO_BAR_2(\"foo_bar\")"));
         assertThat(api, containsString("@Http.Entity Integer body"));
         assertThat(api, not(containsString("enum NumericEnumBodyBodyEnum")));
+        assertThat(api, containsString("@Http.Entity Boolean body"));
+        assertThat(api, not(containsString("enum BooleanEnumBodyBodyEnum")));
     }
 
     @Test
@@ -132,6 +136,29 @@ class JsonStringEnumGenerationIT {
         }
     }
 
+    @Test
+    void generatedProjectUsesRequiredHelidonBaselineByDefault() throws IOException {
+        assertThat(read(outputDir.resolve("pom.xml")), containsString("<helidon.version>4.5.0</helidon.version>"));
+    }
+
+    @Test
+    void rejectsStringEnumCookieParametersBeforeRendering() throws Exception {
+        Path cookieOutput = tempDir.resolve("cookie");
+        URL resource = JsonStringEnumGenerationIT.class.getClassLoader()
+                .getResource("cookie-string-enum-parameter.yaml");
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("helidon-declarative")
+                .setInputSpec(Paths.get(resource.toURI()).toAbsolutePath().toString())
+                .setOutputDir(cookieOutput.toString());
+
+        IllegalArgumentException error = org.junit.jupiter.api.Assertions.assertThrows(
+                IllegalArgumentException.class,
+                () -> new DefaultGenerator().opts(configurator.toClientOptInput()).generate());
+        assertThat(error.getMessage(), containsString("string enum cookie parameter 'mode'"));
+        assertThat(error.getMessage(), containsString("does not provide a cookie parameter annotation"));
+        assertThat(Files.exists(cookieOutput.resolve("src/main/java")), org.hamcrest.CoreMatchers.is(false));
+    }
+
     private static void generate(Path destination) throws Exception {
         URL resource = JsonStringEnumGenerationIT.class.getClassLoader().getResource("json-string-enums.yaml");
         String specPath = Paths.get(resource.toURI()).toAbsolutePath().toString();
@@ -139,7 +166,6 @@ class JsonStringEnumGenerationIT {
                 .setGeneratorName("helidon-declarative")
                 .setInputSpec(specPath)
                 .setOutputDir(destination.toString())
-                .addAdditionalProperty("helidonVersion", "4.5.0")
                 .addAdditionalProperty("apiPackage", "io.helidon.example.api")
                 .addAdditionalProperty("modelPackage", "io.helidon.example.model")
                 .addAdditionalProperty("invokerPackage", "io.helidon.example");

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/JsonStringEnumGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/JsonStringEnumGenerationIT.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.openapi.generator;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.config.CodegenConfigurator;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JsonStringEnumGenerationIT {
+
+    @TempDir
+    static Path tempDir;
+
+    private static Path outputDir;
+    private static Path regeneratedDir;
+
+    @BeforeAll
+    static void generate() throws Exception {
+        outputDir = tempDir.resolve("generated");
+        regeneratedDir = tempDir.resolve("regenerated");
+        generate(outputDir);
+        generate(regeneratedDir);
+    }
+
+    @Test
+    void topLevelEnumPreservesWireValuesAndRegistersExactServices() throws IOException {
+        String mode = read(outputDir.resolve("src/main/java/io/helidon/example/model/Mode.java"));
+
+        assertThat(mode, containsString("public enum Mode"));
+        assertThat(mode, containsString("(\"fast-mode\")"));
+        assertThat(mode, containsString("(\"authZ\")"));
+        assertThat(mode, containsString("(\"legacy.value\")"));
+        assertThat(mode, containsString("public String value()"));
+        assertThat(mode, containsString("public static Mode fromValue(String value)"));
+        assertThat(mode, containsString("implements JsonConverter<Mode>, Mapper<String, Mode>"));
+        assertThat(mode, not(containsString("MapperProvider")));
+    }
+
+    @Test
+    void inlineReferencedAndCollectionEnumsRemainTyped() throws IOException {
+        String envelope = read(outputDir.resolve("src/main/java/io/helidon/example/model/EnumEnvelope.java"));
+
+        assertThat(envelope, containsString("private InlineModeEnum inlineMode"));
+        assertThat(envelope, containsString("private Mode mode"));
+        assertThat(envelope, containsString("private List<Mode> modes"));
+        assertThat(envelope, containsString("private List<InlineModesEnum> inlineModes"));
+        assertThat(envelope, containsString("public enum InlineModeEnum"));
+        assertThat(envelope, containsString("(\"on-hold\")"));
+        assertThat(envelope, containsString("public enum InlineModesEnum"));
+        assertThat(envelope, containsString("(\"batchAuthZ\")"));
+        assertThat(envelope, containsString("implements JsonConverter<EnumEnvelope.InlineModeEnum>"));
+        assertThat(envelope, containsString("implements JsonConverter<EnumEnvelope.InlineModesEnum>"));
+    }
+
+    @Test
+    void operationParametersAndRequestEntityUseGeneratedEnums() throws IOException {
+        String api = read(outputDir.resolve("src/main/java/io/helidon/example/api/EnumsApi.java"));
+
+        assertThat(api, containsString("InspectModeRouteModeEnum routeMode"));
+        assertThat(api, containsString("Optional<Mode> mode"));
+        assertThat(api, containsString("Optional<List<Mode>> modes"));
+        assertThat(api, containsString("InspectModeXTraceModeEnum xTraceMode"));
+        assertThat(api, containsString("@Http.Entity InspectModeBodyEnum body"));
+        assertThat(api, containsString("implements JsonConverter<EnumsApi.InspectModeRouteModeEnum>, "
+                                               + "Mapper<String, EnumsApi.InspectModeRouteModeEnum>"));
+        assertThat(api, containsString("implements JsonConverter<EnumsApi.InspectModeBodyEnum>"));
+        assertThat(api, not(containsString("Mapper<String, EnumsApi.InspectModeBodyEnum>")));
+    }
+
+    @Test
+    void regenerationIsByteStable() throws IOException {
+        Path sourceRoot = outputDir.resolve("src/main/java");
+        Path regeneratedRoot = regeneratedDir.resolve("src/main/java");
+        List<Path> sources;
+        try (var stream = Files.walk(sourceRoot)) {
+            sources = stream.filter(Files::isRegularFile).sorted().toList();
+        }
+
+        List<Path> regeneratedSources;
+        try (var stream = Files.walk(regeneratedRoot)) {
+            regeneratedSources = stream.filter(Files::isRegularFile).sorted().toList();
+        }
+        assertEquals(sources.stream().map(sourceRoot::relativize).toList(),
+                     regeneratedSources.stream().map(regeneratedRoot::relativize).toList());
+        for (Path source : sources) {
+            Path relative = sourceRoot.relativize(source);
+            assertArrayEquals(Files.readAllBytes(source), Files.readAllBytes(regeneratedRoot.resolve(relative)),
+                              relative.toString());
+        }
+    }
+
+    private static void generate(Path destination) throws Exception {
+        URL resource = JsonStringEnumGenerationIT.class.getClassLoader().getResource("json-string-enums.yaml");
+        String specPath = Paths.get(resource.toURI()).toAbsolutePath().toString();
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("helidon-declarative")
+                .setInputSpec(specPath)
+                .setOutputDir(destination.toString())
+                .addAdditionalProperty("helidonVersion", "4.4.1")
+                .addAdditionalProperty("apiPackage", "io.helidon.example.api")
+                .addAdditionalProperty("modelPackage", "io.helidon.example.model")
+                .addAdditionalProperty("invokerPackage", "io.helidon.example");
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+    }
+
+    private static String read(Path file) throws IOException {
+        return Files.readString(file).replace("\r\n", "\n");
+    }
+}

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/JsonStringEnumGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/JsonStringEnumGenerationIT.java
@@ -108,6 +108,10 @@ class JsonStringEnumGenerationIT {
         assertThat(envelope, containsString("(\"batchAuthZ\")"));
         assertThat(envelope, containsString("implements JsonConverter<EnumEnvelope.InlineModeEnum>"));
         assertThat(envelope, containsString("implements JsonConverter<EnumEnvelope.InlineModesEnum>"));
+        assertThat(envelope, containsString("private NumericPriorityEnum numericPriority"));
+        assertThat(envelope, containsString("public enum NumericPriorityEnum"));
+        assertThat(envelope, containsString("NUMBER_1"));
+        assertThat(envelope, containsString("NUMBER_2"));
     }
 
     @Test

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/JsonStringEnumGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/JsonStringEnumGenerationIT.java
@@ -131,7 +131,7 @@ class JsonStringEnumGenerationIT {
         assertThat(api, not(containsString("enum NumericEnumBodyBodyEnum")));
         assertThat(api, containsString("@Http.Entity Boolean body"));
         assertThat(api, not(containsString("enum BooleanEnumBodyBodyEnum")));
-        assertThat(api, containsString("@Http.QueryParam(\"mode\") ValidatedEnumModeEnum mode"));
+        assertThat(api, containsString("@Http.PathParam(\"mode\") ValidatedEnumModeEnum mode"));
         assertThat(api, not(containsString("@Validation.String.Length(min = 4)")));
         assertThat(api, containsString("@Http.Entity String body"));
         assertThat(api, not(containsString("enum TextEnumBodyBodyEnum")));

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/cookie-string-enum-parameter.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/cookie-string-enum-parameter.yaml
@@ -1,0 +1,33 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+openapi: 3.0.3
+info:
+  title: Cookie string enum parameter
+  version: "1.0"
+paths:
+  /cookie:
+    get:
+      operationId: readCookie
+      parameters:
+        - name: mode
+          in: cookie
+          required: false
+          schema:
+            type: string
+            enum: [fast, safe]
+      responses:
+        "204":
+          description: Accepted

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/invalid-string-enum-constraints.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/invalid-string-enum-constraints.yaml
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+openapi: 3.0.3
+info:
+  title: Invalid constrained enum
+  version: 1.0.0
+paths:
+  /invalid:
+    get:
+      operationId: invalidEnum
+      parameters:
+        - name: mode
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [unsafe]
+            maxLength: 4
+      responses:
+        '204':
+          description: Accepted

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/json-string-enums.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/json-string-enums.yaml
@@ -216,3 +216,6 @@ components:
           enum: [safe]
           minLength: 4
           pattern: ^safe$
+        numericPriority:
+          type: integer
+          enum: [1, 2]

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/json-string-enums.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/json-string-enums.yaml
@@ -1,0 +1,87 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+openapi: 3.0.3
+info:
+  title: JSON String Enum Test
+  version: 1.0.0
+paths:
+  /enum/{routeMode}:
+    post:
+      tags: [enums]
+      operationId: inspectMode
+      parameters:
+        - name: routeMode
+          in: path
+          required: true
+          schema:
+            type: string
+            enum: [fast-mode, authZ]
+        - name: mode
+          in: query
+          required: false
+          schema:
+            $ref: '#/components/schemas/Mode'
+        - name: modes
+          in: query
+          required: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Mode'
+        - name: X-Trace-Mode
+          in: header
+          required: true
+          schema:
+            type: string
+            enum: [trace.on, trace-OFF]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: string
+              enum: [request-quick, requestAuthZ]
+      responses:
+        '200':
+          description: Exact enum response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Mode'
+components:
+  schemas:
+    Mode:
+      type: string
+      nullable: true
+      enum: [fast-mode, authZ, legacy.value]
+    EnumEnvelope:
+      type: object
+      properties:
+        inlineMode:
+          type: string
+          nullable: true
+          enum: [on-hold, authZ]
+        mode:
+          $ref: '#/components/schemas/Mode'
+        modes:
+          type: array
+          items:
+            $ref: '#/components/schemas/Mode'
+        inlineModes:
+          type: array
+          items:
+            type: string
+            enum: [batch-fast, batchAuthZ]

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/json-string-enums.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/json-string-enums.yaml
@@ -102,13 +102,13 @@ paths:
       responses:
         '204':
           description: Accepted
-  /validated-enum:
+  /validated-enum/{mode}:
     get:
       tags: [enums]
       operationId: validatedEnum
       parameters:
         - name: mode
-          in: query
+          in: path
           required: true
           schema:
             type: string
@@ -157,7 +157,7 @@ paths:
       parameters:
         - name: apiBazMode
           in: query
-          required: true
+          required: false
           schema:
             type: string
             enum: [a]
@@ -171,7 +171,7 @@ paths:
       parameters:
         - name: mode
           in: query
-          required: true
+          required: false
           schema:
             type: string
             enum: [b]

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/json-string-enums.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/json-string-enums.yaml
@@ -88,6 +88,20 @@ paths:
       responses:
         '204':
           description: Accepted
+  /boolean-enum-body:
+    post:
+      tags: [enums]
+      operationId: booleanEnumBody
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: boolean
+              enum: [true, false]
+      responses:
+        '204':
+          description: Accepted
 components:
   schemas:
     Mode:

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/json-string-enums.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/json-string-enums.yaml
@@ -102,6 +102,82 @@ paths:
       responses:
         '204':
           description: Accepted
+  /validated-enum:
+    get:
+      tags: [enums]
+      operationId: validatedEnum
+      parameters:
+        - name: mode
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [safe]
+            minLength: 4
+            pattern: ^safe$
+      responses:
+        '204':
+          description: Accepted
+  /text-enum-body:
+    post:
+      tags: [enums]
+      operationId: textEnumBody
+      requestBody:
+        required: true
+        content:
+          text/plain:
+            schema:
+              type: string
+              enum: [one]
+      responses:
+        '204':
+          description: Accepted
+  /mixed-enum-body:
+    post:
+      tags: [enums]
+      operationId: mixedEnumBody
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: string
+              enum: [one]
+          text/plain:
+            schema:
+              type: string
+              enum: [one]
+      responses:
+        '204':
+          description: Accepted
+  /helper-name-a:
+    get:
+      tags: [foo]
+      operationId: bar
+      parameters:
+        - name: apiBazMode
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [a]
+      responses:
+        '204':
+          description: Accepted
+  /helper-name-b:
+    get:
+      tags: [foo-api-bar]
+      operationId: baz
+      parameters:
+        - name: mode
+          in: query
+          required: true
+          schema:
+            type: string
+            enum: [b]
+      responses:
+        '204':
+          description: Accepted
 components:
   schemas:
     Mode:
@@ -111,6 +187,12 @@ components:
     CollidingMode:
       type: string
       enum: [foo-bar, foo_bar, FOO-BAR]
+    ModeJsonConverter:
+      type: string
+      enum: [slow]
+    EnumEnvelopeInlineModeEnumJsonConverter:
+      type: string
+      enum: [reserved]
     EnumEnvelope:
       type: object
       properties:
@@ -129,3 +211,8 @@ components:
           items:
             type: string
             enum: [batch-fast, batchAuthZ]
+        validatedInline:
+          type: string
+          enum: [safe]
+          minLength: 4
+          pattern: ^safe$

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/json-string-enums.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/json-string-enums.yaml
@@ -61,12 +61,42 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Mode'
+  /enum-no-id:
+    post:
+      tags: [enums]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: string
+              enum: [foo-bar, foo_bar]
+      responses:
+        '204':
+          description: Accepted
+  /numeric-enum-body:
+    post:
+      tags: [enums]
+      operationId: numericEnumBody
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: integer
+              enum: [1, 2]
+      responses:
+        '204':
+          description: Accepted
 components:
   schemas:
     Mode:
       type: string
       nullable: true
       enum: [fast-mode, authZ, legacy.value]
+    CollidingMode:
+      type: string
+      enum: [foo-bar, foo_bar, FOO-BAR]
     EnumEnvelope:
       type: object
       properties:


### PR DESCRIPTION
## Summary

- generate exact-wire-value Java enums for supported OpenAPI string enum shapes;
- register stateless Helidon JSON converters and exact typed HTTP mappers only at path/query/header parameter boundaries;
- keep numeric and boolean inline request-enum wire types unchanged and support missing operationId;
- disambiguate Java constant-name collisions and reject null/unknown values strictly;
- default generated projects to Helidon 4.5.0 and reject unsupported string-enum cookie parameters before rendering;
- document the generated API, JSON/HTTP split, and supported shapes.

## Verification

- 217 generator tests
- complete 15-module generated-project invoker suite
- JSON-enum generated-runtime suite: 11 tests, including a real WebServer HTTP 400 mapper-path probe and concurrent shared-binding coverage
- byte-stable regeneration, Javadoc, checkstyle, and copyright checks
- Linux and Windows OpenAPI Generator CI

Fixes #107