### PR TITLE
Generate one authoritative JSON discriminator for polymorphic OpenAPI models

### DIFF
--- a/extensions/openapi-generator/docs/ARCHITECTURE.md
+++ b/extensions/openapi-generator/docs/ARCHITECTURE.md
@@ -166,8 +166,9 @@ Notable behavior:
   - `x-helidon-discriminator-representation` overrides the global
     `discriminatorRepresentation` option for one schema
   - `allOf` prefers Java inheritance when there is a single referenced parent
-  - non-discriminated `oneOf` and `anyOf` generate model interfaces annotated
-    with a generated `@Json.Converter`
+  - `oneOf` and `anyOf` generate model interfaces annotated with a generated
+    `@Json.Converter`; discriminated converters buffer the complete object before
+    exact-alias dispatch, making lookup independent of property order
   - union member models implement the generated interface(s)
   - generated converters for non-discriminated unions use structural matching
     by declared properties
@@ -258,8 +259,8 @@ existing Helidon-oriented templates:
   - when exactly one referenced component schema participates, the generated model
     extends that parent and emits only locally owned properties
   - when that parent schema declares a discriminator, the base model is annotated
-    with generated Helidon polymorphism metadata and child models can initialize
-    inherited discriminator values from `x-discriminator-value`
+    with generated Helidon polymorphism metadata and exact mapping aliases become
+    derived subtype accessors instead of stored JSON properties
   - otherwise the generator falls back to a flattened model containing the merged
     properties exposed by `openapi-generator`
 - `oneOf`
@@ -267,7 +268,9 @@ existing Helidon-oriented templates:
     `@Json.Converter`
   - each referenced member model implements that interface
   - generated deserialization requires exactly one matching subtype
-  - when a discriminator is present, converter dispatch prefers discriminator aliases
+  - when a discriminator is present, converter dispatch uses exact mapping aliases
+    from the buffered object, rejects missing and unknown values, and writes one
+    canonical discriminator value
   - primitive, array, map, and inline members are rejected with a clear
     unsupported-shape message instead of generating invalid Java
 - `anyOf`

--- a/extensions/openapi-generator/docs/ARCHITECTURE.md
+++ b/extensions/openapi-generator/docs/ARCHITECTURE.md
@@ -89,6 +89,7 @@ Important option constants currently supported:
 - `tracingEnabled`
 - `metricsEnabled`
 - `avoidOptionalListParams`
+- `discriminatorRepresentation`
 
 Compatibility aliases:
 
@@ -158,12 +159,18 @@ Notable behavior:
   parent model builder base so inherited and local properties can be set in one
   fluent chain
 - composed schemas are normalized into template-friendly flags:
+  - discriminated bases use Helidon `@Json.Polymorphic` and `@Json.Subtype` as the
+    sole JSON discriminator owner
+  - declared discriminator properties become derived read-only accessors by default;
+    metadata-only discriminators do not add a Java accessor
+  - `x-helidon-discriminator-representation` overrides the global
+    `discriminatorRepresentation` option for one schema
   - `allOf` prefers Java inheritance when there is a single referenced parent
-  - `oneOf` and `anyOf` generate model interfaces annotated with a generated
-    `@Json.Converter`
+  - non-discriminated `oneOf` and `anyOf` generate model interfaces annotated
+    with a generated `@Json.Converter`
   - union member models implement the generated interface(s)
-  - generated converters deserialize using discriminator aliases when present,
-    then fall back to structural matching by declared properties
+  - generated converters for non-discriminated unions use structural matching
+    by declared properties
   - union interface generation is limited to referenced object model members;
     primitive, array, map, and inline members fail generation with a clear
     unsupported-shape message

--- a/extensions/openapi-generator/docs/README.md
+++ b/extensions/openapi-generator/docs/README.md
@@ -171,8 +171,14 @@ Set these under Maven `<configOptions>` or CLI `--additional-properties`.
 | `tracingEnabled` | `false` | Add `@Tracing.Traced` to generated endpoint classes |
 | `metricsEnabled` | `false` | Add `@Metrics.Timed` to generated endpoint methods |
 | `avoidOptionalListParams` | `false` | Generate `List<T>` instead of `Optional<List<T>>` for optional query list params |
+| `discriminatorRepresentation` | schema-driven | Use `metadata` or `readOnlyProperty` for every discriminator unless a schema overrides it |
 
 Legacy aliases `serveOpenApi` and `serveBasePath` are still accepted for compatibility.
+
+The schema extension `x-helidon-discriminator-representation` accepts `metadata` or
+`readOnlyProperty` and takes precedence over the global option. Without either setting,
+an explicitly declared discriminator property becomes a derived read-only accessor;
+a discriminator used only for polymorphic routing remains metadata-only.
 
 ## What Gets Generated
 

--- a/extensions/openapi-generator/docs/README.md
+++ b/extensions/openapi-generator/docs/README.md
@@ -242,7 +242,14 @@ The generator supports these schema-composition keywords:
   schema declares a discriminator, the generator also emits `@Json.Polymorphic`
   and `@Json.Subtype` metadata on the base model and derives exact subtype values
   from the declared discriminator mapping. The discriminator is omitted from
-  stored model state so Helidon JSON writes it exactly once.
+  stored model state so Helidon JSON writes it exactly once. Helidon JSON processes
+  `allOf` polymorphism as a stream, so the discriminator must be the first property
+  in JSON input deserialized through the polymorphic base type. This ordering
+  requirement does not apply to the generated `oneOf` and `anyOf` converters,
+  which buffer each complete JSON object before selecting a member.
+  In a multi-level hierarchy, each ancestor routes a concrete descendant using
+  the canonical alias declared by that descendant's nearest discriminator-owning
+  parent; duplicate descendant aliases fail generation as ambiguous.
 - `oneOf`: generates a Java interface for the composed schema, attaches a
   generated `@Json.Converter`, makes member models implement it, and requires
   exactly one matching subtype during deserialization. Members must be referenced

--- a/extensions/openapi-generator/docs/README.md
+++ b/extensions/openapi-generator/docs/README.md
@@ -240,8 +240,9 @@ The generator supports these schema-composition keywords:
 - `allOf`: generates an inherited model when there is a single referenced parent
   component; otherwise falls back to a flattened merged model. When the parent
   schema declares a discriminator, the generator also emits `@Json.Polymorphic`
-  and `@Json.Subtype` metadata on the base model and initializes discriminator
-  values for `allOf` subtypes that provide `x-discriminator-value`
+  and `@Json.Subtype` metadata on the base model and derives exact subtype values
+  from the declared discriminator mapping. The discriminator is omitted from
+  stored model state so Helidon JSON writes it exactly once.
 - `oneOf`: generates a Java interface for the composed schema, attaches a
   generated `@Json.Converter`, makes member models implement it, and requires
   exactly one matching subtype during deserialization. Members must be referenced
@@ -253,9 +254,13 @@ The generator supports these schema-composition keywords:
   object model schemas; primitive, array, map, and inline members fail generation
   with a clear unsupported-shape message.
 
-For union schemas, generated converters use the OpenAPI discriminator when one is
-present. Without a discriminator, they fall back to structural matching based on
-the member models' required and declared properties.
+For union schemas, generated converters buffer the JSON object and use the OpenAPI
+discriminator when one is present, so the discriminator can appear anywhere in
+the object. The converter accepts the declared mapping value, writes one canonical
+discriminator, and rejects missing or unknown values. A mapping with multiple
+aliases for one subtype is rejected because no single canonical output value is
+defined. Without a discriminator, converters fall back to structural matching
+based on the member models' required and declared properties.
 
 ### Model API
 

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/composed-schemas/src/test/java/io/helidon/example/model/ComposedJsonBindingTest.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/composed-schemas/src/test/java/io/helidon/example/model/ComposedJsonBindingTest.java
@@ -46,6 +46,74 @@ class ComposedJsonBindingTest {
     }
 
     @Test
+    void directMemberBindingPreservesDiscriminator() {
+        Cat cat = new Cat();
+        cat.whiskers(7);
+
+        String json = jsonBinding.serialize(cat, Cat.class);
+        assertThat(occurrences(json, "\"kind\""), is(1));
+        assertThat(json, containsString("\"kind\":\"cat$special\""));
+
+        Cat restored = jsonBinding.deserialize("{\"kind\":\"cat$special\",\"whiskers\":7}", Cat.class);
+        assertThat(restored.kind(), is("cat$special"));
+        assertThat(restored.whiskers(), is(7));
+
+        assertThrows(RuntimeException.class,
+                     () -> jsonBinding.deserialize("{\"kind\":\"dog\",\"whiskers\":7}", Cat.class));
+    }
+
+    @Test
+    void everyOneOfMemberRoundTripsWithItsCanonicalAlias() {
+        Dog dog = new Dog();
+        dog.bark(true);
+
+        String json = jsonBinding.serialize((Pet) dog, Pet.class);
+        assertThat(occurrences(json, "\"kind\""), is(1));
+        assertThat(json, containsString("\"kind\":\"dog\""));
+
+        Pet restored = jsonBinding.deserialize(json, Pet.class);
+        assertThat(restored, instanceOf(Dog.class));
+        assertThat(((Dog) restored).bark(), is(true));
+    }
+
+    @Test
+    void metadataDiscriminatorIsRequired() {
+        assertThrows(RuntimeException.class,
+                     () -> jsonBinding.deserialize("{\"alpha\":\"value\"}", MetadataChoice.class));
+    }
+
+    @Test
+    void everyMetadataMemberRoundTripsWithItsCanonicalAlias() {
+        MetadataAlpha alpha = new MetadataAlpha();
+        alpha.alpha("a");
+        String alphaJson = jsonBinding.serialize((MetadataChoice) alpha, MetadataChoice.class);
+        assertThat(alphaJson, containsString("\"category\":\"alpha.v1\""));
+        assertThat(jsonBinding.deserialize(alphaJson, MetadataChoice.class), instanceOf(MetadataAlpha.class));
+
+        MetadataBeta beta = new MetadataBeta();
+        beta.beta("b");
+        String betaJson = jsonBinding.serialize((MetadataChoice) beta, MetadataChoice.class);
+        assertThat(betaJson, containsString("\"category\":\"MetadataBeta\""));
+        assertThat(jsonBinding.deserialize(betaJson, MetadataChoice.class), instanceOf(MetadataBeta.class));
+    }
+
+    @Test
+    void layeredAllOfRoundTripsThroughRootBase() {
+        LayeredLeaf leaf = new LayeredLeaf();
+        leaf.middle("middle");
+        leaf.leaf("leaf-value");
+
+        String json = jsonBinding.serialize((LayeredBase) leaf, LayeredBase.class);
+        assertThat(occurrences(json, "\"kind\""), is(1));
+        assertThat(json, containsString("\"kind\":\"leaf\""));
+
+        LayeredBase restored = jsonBinding.deserialize(json, LayeredBase.class);
+        assertThat(restored, instanceOf(LayeredLeaf.class));
+        assertThat(((LayeredLeaf) restored).middle(), is("middle"));
+        assertThat(((LayeredLeaf) restored).leaf(), is("leaf-value"));
+    }
+
+    @Test
     void oneOfRejectsMissingAndUnknownDiscriminators() {
         assertThrows(RuntimeException.class, () -> jsonBinding.deserialize("{\"whiskers\":7}", Pet.class));
         assertThrows(RuntimeException.class,

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/composed-schemas/src/test/java/io/helidon/example/model/ComposedJsonBindingTest.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/composed-schemas/src/test/java/io/helidon/example/model/ComposedJsonBindingTest.java
@@ -40,7 +40,7 @@ class ComposedJsonBindingTest {
         assertThat(json, containsString("\"whiskers\":7"));
         assertThat(cat.kind(), is("cat$special"));
 
-        Pet pet = jsonBinding.deserialize("{\"kind\":\"cat$special\",\"whiskers\":7}", Pet.class);
+        Pet pet = jsonBinding.deserialize("{\"whiskers\":7,\"kind\":\"cat$special\"}", Pet.class);
         assertThat(pet, instanceOf(Cat.class));
         assertThat(((Cat) pet).whiskers(), is(7));
     }

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/composed-schemas/src/test/java/io/helidon/example/model/ComposedJsonBindingTest.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/composed-schemas/src/test/java/io/helidon/example/model/ComposedJsonBindingTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ComposedJsonBindingTest {
 
@@ -31,16 +32,24 @@ class ComposedJsonBindingTest {
     @Test
     void oneOfDiscriminatorRoundTrip() {
         Cat cat = new Cat();
-        cat.kind("cat&special");
         cat.whiskers(7);
 
         String json = jsonBinding.serialize((Pet) cat, Pet.class);
-        assertThat(json, containsString("\"kind\":\"cat&special\""));
+        assertThat(occurrences(json, "\"kind\""), is(1));
+        assertThat(json, containsString("\"kind\":\"cat$special\""));
         assertThat(json, containsString("\"whiskers\":7"));
+        assertThat(cat.kind(), is("cat$special"));
 
-        Pet pet = jsonBinding.deserialize("{\"kind\":\"cat&special\",\"whiskers\":7}", Pet.class);
+        Pet pet = jsonBinding.deserialize("{\"kind\":\"cat$special\",\"whiskers\":7}", Pet.class);
         assertThat(pet, instanceOf(Cat.class));
         assertThat(((Cat) pet).whiskers(), is(7));
+    }
+
+    @Test
+    void oneOfRejectsMissingAndUnknownDiscriminators() {
+        assertThrows(RuntimeException.class, () -> jsonBinding.deserialize("{\"whiskers\":7}", Pet.class));
+        assertThrows(RuntimeException.class,
+                     () -> jsonBinding.deserialize("{\"kind\":\"unknown\",\"whiskers\":7}", Pet.class));
     }
 
     @Test
@@ -78,5 +87,9 @@ class ComposedJsonBindingTest {
 
         PatternChoice numericCode = jsonBinding.deserialize("{\"code\":\"123\"}", PatternChoice.class);
         assertThat(numericCode, instanceOf(NumericCode.class));
+    }
+
+    private int occurrences(String value, String token) {
+        return (value.length() - value.replace(token, "").length()) / token.length();
     }
 }

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/discriminator-enum-mapping-repro/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/discriminator-enum-mapping-repro/pom.xml
@@ -31,5 +31,6 @@
 
     <properties>
         <inputSpec>${project.basedir}/../../specs/discriminator-enum-mapping-repro.yaml</inputSpec>
+        <skipGeneratedTests>false</skipGeneratedTests>
     </properties>
 </project>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/discriminator-enum-mapping-repro/src/test/java/io/helidon/example/model/AuthoritativeAllOfDiscriminatorTest.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/discriminator-enum-mapping-repro/src/test/java/io/helidon/example/model/AuthoritativeAllOfDiscriminatorTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.example.model;
+
+import io.helidon.json.binding.JsonBinding;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AuthoritativeAllOfDiscriminatorTest {
+
+    private final JsonBinding jsonBinding = JsonBinding.create();
+
+    @Test
+    void exactAliasIsTheOnlySerializedDiscriminator() {
+        ChangeFreezeConditionShape changeFreeze = new ChangeFreezeConditionShape();
+        changeFreeze.changeFreezeDetails("scheduled");
+
+        String json = jsonBinding.serialize((ConditionShapeDetails) changeFreeze, ConditionShapeDetails.class);
+        assertThat(occurrences(json, "\"conditionShape\""), is(1));
+        assertThat(json.contains("\"conditionShape\":\"CHANGE_FREEZE\""), is(true));
+        assertThat(changeFreeze.conditionShape(), is(ConditionShapeDetails.ConditionShapeEnum.CHANGE_FREEZE));
+
+        ConditionShapeDetails restored = jsonBinding.deserialize(json, ConditionShapeDetails.class);
+        assertThat(restored, instanceOf(ChangeFreezeConditionShape.class));
+        assertThat(restored.conditionShape(), is(ConditionShapeDetails.ConditionShapeEnum.CHANGE_FREEZE));
+    }
+
+    @Test
+    void missingAndUnknownAliasesAreRejected() {
+        assertThrows(RuntimeException.class,
+                     () -> jsonBinding.deserialize("{\"changeFreezeDetails\":\"scheduled\"}",
+                                                   ConditionShapeDetails.class));
+        assertThrows(RuntimeException.class,
+                     () -> jsonBinding.deserialize("{\"conditionShape\":\"UNKNOWN\"}",
+                                                   ConditionShapeDetails.class));
+    }
+
+    private int occurrences(String value, String token) {
+        return (value.length() - value.replace(token, "").length()) / token.length();
+    }
+}

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/discriminator-enum-mapping-repro/src/test/java/io/helidon/example/model/AuthoritativeAllOfDiscriminatorTest.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/discriminator-enum-mapping-repro/src/test/java/io/helidon/example/model/AuthoritativeAllOfDiscriminatorTest.java
@@ -53,6 +53,35 @@ class AuthoritativeAllOfDiscriminatorTest {
                                                    ConditionShapeDetails.class));
     }
 
+    @Test
+    void explicitExtensionValueRoundTrips() {
+        String json = jsonBinding.serialize((ExtensionBase) new ExtensionCat(), ExtensionBase.class);
+
+        assertThat(occurrences(json, "\"kind\""), is(1));
+        assertThat(json.contains("\"kind\":\"WIRE_CAT\""), is(true));
+        assertThat(jsonBinding.deserialize(json, ExtensionBase.class), instanceOf(ExtensionCat.class));
+    }
+
+    @Test
+    void inheritedEnumDiscriminatorRoundTripsThroughUnion() {
+        String json = jsonBinding.serialize((EnumPet) new UnionCat(), EnumPet.class);
+
+        assertThat(occurrences(json, "\"kind\""), is(1));
+        assertThat(json.contains("\"kind\":\"cat\""), is(true));
+        EnumPet restored = jsonBinding.deserialize(json, EnumPet.class);
+        assertThat(restored, instanceOf(UnionCat.class));
+        assertThat(restored.kind(), is(KindHolder.KindEnum.CAT));
+    }
+
+    @Test
+    void directMappingToTransitiveLeafRoundTrips() {
+        String json = jsonBinding.serialize((TransitiveBase) new TransitiveLeaf(), TransitiveBase.class);
+
+        assertThat(occurrences(json, "\"kind\""), is(1));
+        assertThat(json.contains("\"kind\":\"leaf\""), is(true));
+        assertThat(jsonBinding.deserialize(json, TransitiveBase.class), instanceOf(TransitiveLeaf.class));
+    }
+
     private int occurrences(String value, String token) {
         return (value.length() - value.replace(token, "").length()) / token.length();
     }

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/discriminator-enum-mapping-repro/src/test/java/io/helidon/example/model/AuthoritativeAllOfDiscriminatorTest.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/discriminator-enum-mapping-repro/src/test/java/io/helidon/example/model/AuthoritativeAllOfDiscriminatorTest.java
@@ -35,12 +35,27 @@ class AuthoritativeAllOfDiscriminatorTest {
 
         String json = jsonBinding.serialize((ConditionShapeDetails) changeFreeze, ConditionShapeDetails.class);
         assertThat(occurrences(json, "\"conditionShape\""), is(1));
-        assertThat(json.contains("\"conditionShape\":\"CHANGE_FREEZE\""), is(true));
+        assertThat(json.contains("\"conditionShape\":\"CHANGE.FREEZE\""), is(true));
         assertThat(changeFreeze.conditionShape(), is(ConditionShapeDetails.ConditionShapeEnum.CHANGE_FREEZE));
 
         ConditionShapeDetails restored = jsonBinding.deserialize(json, ConditionShapeDetails.class);
         assertThat(restored, instanceOf(ChangeFreezeConditionShape.class));
         assertThat(restored.conditionShape(), is(ConditionShapeDetails.ConditionShapeEnum.CHANGE_FREEZE));
+    }
+
+    @Test
+    void hyphenatedAliasRoundTrips() {
+        TimeWindowConstraintsConditionShape timeWindow = new TimeWindowConstraintsConditionShape();
+        timeWindow.timeWindowDetails("weekday");
+
+        String json = jsonBinding.serialize((ConditionShapeDetails) timeWindow, ConditionShapeDetails.class);
+        assertThat(occurrences(json, "\"conditionShape\""), is(1));
+        assertThat(json.contains("\"conditionShape\":\"TIME-WINDOW-CONSTRAINTS\""), is(true));
+
+        ConditionShapeDetails restored = jsonBinding.deserialize(json, ConditionShapeDetails.class);
+        assertThat(restored, instanceOf(TimeWindowConstraintsConditionShape.class));
+        assertThat(restored.conditionShape(),
+                   is(ConditionShapeDetails.ConditionShapeEnum.TIME_WINDOW_CONSTRAINTS));
     }
 
     @Test

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/composed-schemas.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/composed-schemas.yaml
@@ -135,6 +135,33 @@ components:
             name:
               type: string
               description: Extended name
+    LayeredBase:
+      type: object
+      discriminator:
+        propertyName: kind
+        mapping:
+          intermediate: '#/components/schemas/LayeredIntermediate'
+      properties:
+        kind:
+          type: string
+    LayeredIntermediate:
+      discriminator:
+        propertyName: kind
+        mapping:
+          leaf: '#/components/schemas/LayeredLeaf'
+      allOf:
+        - $ref: '#/components/schemas/LayeredBase'
+        - type: object
+          properties:
+            middle:
+              type: string
+    LayeredLeaf:
+      allOf:
+        - $ref: '#/components/schemas/LayeredIntermediate'
+        - type: object
+          properties:
+            leaf:
+              type: string
     Cat:
       type: object
       required:

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/composed-schemas.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/composed-schemas.yaml
@@ -173,6 +173,24 @@ components:
         whiskers:
           type: integer
           format: int32
+    MetadataAlpha:
+      type: object
+      properties:
+        alpha:
+          type: string
+    MetadataBeta:
+      type: object
+      properties:
+        beta:
+          type: string
+    MetadataChoice:
+      oneOf:
+        - $ref: '#/components/schemas/MetadataAlpha'
+        - $ref: '#/components/schemas/MetadataBeta'
+      discriminator:
+        propertyName: category
+        mapping:
+          alpha.v1: '#/components/schemas/MetadataAlpha'
     Dog:
       type: object
       required:

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/composed-schemas.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/composed-schemas.yaml
@@ -140,7 +140,7 @@ components:
       discriminator:
         propertyName: kind
         mapping:
-          intermediate: '#/components/schemas/LayeredIntermediate'
+          leaf: '#/components/schemas/LayeredIntermediate'
       properties:
         kind:
           type: string

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/composed-schemas.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/composed-schemas.yaml
@@ -163,7 +163,7 @@ components:
       discriminator:
         propertyName: kind
         mapping:
-          cat&special: '#/components/schemas/Cat'
+          cat$special: '#/components/schemas/Cat'
           dog: '#/components/schemas/Dog'
     NullablePet:
       nullable: true
@@ -173,7 +173,7 @@ components:
       discriminator:
         propertyName: kind
         mapping:
-          cat&special: '#/components/schemas/Cat'
+          cat$special: '#/components/schemas/Cat'
           dog: '#/components/schemas/Dog'
     EmailContact:
       type: object

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/discriminator-enum-mapping-repro-2.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/discriminator-enum-mapping-repro-2.yaml
@@ -28,8 +28,8 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          UserConfigStringValue: '#/components/schemas/UserConfigStringValue'
-          UserConfigInstantValue: '#/components/schemas/UserConfigInstantValue'
+          STRING: '#/components/schemas/UserConfigStringValue'
+          INSTANT: '#/components/schemas/UserConfigInstantValue'
       properties:
         type:
           type: string

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/discriminator-enum-mapping-repro.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/discriminator-enum-mapping-repro.yaml
@@ -28,14 +28,14 @@ components:
       discriminator:
         propertyName: conditionShape
         mapping:
-          CHANGE_FREEZE: '#/components/schemas/ChangeFreezeConditionShape'
-          TIME_WINDOW_CONSTRAINTS: '#/components/schemas/TimeWindowConstraintsConditionShape'
+          CHANGE.FREEZE: '#/components/schemas/ChangeFreezeConditionShape'
+          TIME-WINDOW-CONSTRAINTS: '#/components/schemas/TimeWindowConstraintsConditionShape'
       properties:
         conditionShape:
           type: string
           enum:
-            - CHANGE_FREEZE
-            - TIME_WINDOW_CONSTRAINTS
+            - CHANGE.FREEZE
+            - TIME-WINDOW-CONSTRAINTS
 
     ChangeFreezeConditionShape:
       allOf:

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/discriminator-enum-mapping-repro.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/specs/discriminator-enum-mapping-repro.yaml
@@ -28,8 +28,8 @@ components:
       discriminator:
         propertyName: conditionShape
         mapping:
-          ChangeFreezeConditionShape: '#/components/schemas/ChangeFreezeConditionShape'
-          TimeWindowConstraintsConditionShape: '#/components/schemas/TimeWindowConstraintsConditionShape'
+          CHANGE_FREEZE: '#/components/schemas/ChangeFreezeConditionShape'
+          TIME_WINDOW_CONSTRAINTS: '#/components/schemas/TimeWindowConstraintsConditionShape'
       properties:
         conditionShape:
           type: string

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/DiscriminatorSupport.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/DiscriminatorSupport.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.openapi.generator;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenProperty;
+
+final class DiscriminatorSupport {
+    private DiscriminatorSupport() {
+    }
+
+    static Property inheritedProperty(CodegenModel model,
+                                      String discriminatorKey,
+                                      Map<String, CodegenModel> modelsByClassname,
+                                      Function<CodegenModel, List<CodegenProperty>> renderVars,
+                                      BiFunction<List<CodegenProperty>, String, CodegenProperty> propertyFinder) {
+        Set<String> visited = new LinkedHashSet<>();
+        CodegenModel current = model;
+        while (current != null && visited.add(current.classname)) {
+            CodegenProperty local = propertyFinder.apply(renderVars.apply(current), discriminatorKey);
+            if (local != null) {
+                return new Property(current, local);
+            }
+            Object parent = current.vendorExtensions.get("x-extends-model");
+            current = parent instanceof String parentName ? modelsByClassname.get(parentName) : null;
+        }
+        List<CodegenProperty> inheritedProperties = model.allVars == null || model.allVars.isEmpty()
+                ? model.vars
+                : model.allVars;
+        CodegenProperty inherited = propertyFinder.apply(inheritedProperties, discriminatorKey);
+        return inherited == null ? null : new Property(model, inherited);
+    }
+
+    static Property commonProperty(String discriminatorKey,
+                                   List<Property> properties,
+                                   Function<String, IllegalStateException> failure) {
+        if (properties.isEmpty()) {
+            return null;
+        }
+        Property first = properties.getFirst();
+        String expectedType = qualifiedType(first);
+        for (Property candidate : properties) {
+            if (!expectedType.equals(qualifiedType(candidate))) {
+                throw failure.apply("members expose incompatible Java types for discriminator property '"
+                                            + discriminatorKey + "': '" + expectedType + "' and '"
+                                            + qualifiedType(candidate) + "'");
+            }
+        }
+        return first;
+    }
+
+    static String qualifiedType(Property discriminatorProperty) {
+        CodegenProperty property = discriminatorProperty.property();
+        String type = property.datatypeWithEnum == null ? property.dataType : property.datatypeWithEnum;
+        return property.isEnum ? discriminatorProperty.owner().classname + "." + type : type;
+    }
+
+    static String sanitizeDiagnosticReference(String value) {
+        if (value == null || value.isBlank() || value.startsWith("#/")) {
+            return value;
+        }
+        URI uri;
+        try {
+            uri = URI.create(value);
+        } catch (IllegalArgumentException ignored) {
+            return value.contains("://") ? "<redacted URI>" : value;
+        }
+        if (uri.getScheme() == null) {
+            return value;
+        }
+        if (uri.isOpaque()) {
+            return uri.getScheme() + ":<redacted>";
+        }
+        try {
+            return new URI(uri.getScheme(), null, uri.getHost(), uri.getPort(), uri.getPath(), null, uri.getFragment())
+                    .toString();
+        } catch (Exception ignored) {
+            return uri.getScheme() + ":<redacted>";
+        }
+    }
+
+    record Property(CodegenModel owner, CodegenProperty property) {
+    }
+
+    static final class Hierarchy {
+        private final Map<String, List<String>> subtypeNamesByParent;
+        private final Map<String, CodegenModel> modelsByClassname;
+        private final Function<CodegenModel, String> discriminatorKey;
+
+        Hierarchy(Map<String, List<String>> subtypeNamesByParent,
+                  Map<String, CodegenModel> modelsByClassname,
+                  Function<CodegenModel, String> discriminatorKey) {
+            this.subtypeNamesByParent = subtypeNamesByParent;
+            this.modelsByClassname = modelsByClassname;
+            this.discriminatorKey = discriminatorKey;
+        }
+
+        List<String> concreteSubtypeNames(String parentType) {
+            LinkedHashSet<String> result = new LinkedHashSet<>();
+            collectConcreteSubtypeNames(parentType, new LinkedHashSet<>(), result);
+            return new ArrayList<>(result);
+        }
+
+        List<String> descendantNames(String parentType) {
+            LinkedHashSet<String> result = new LinkedHashSet<>();
+            collectDescendantNames(parentType, new LinkedHashSet<>(), result);
+            return new ArrayList<>(result);
+        }
+
+        int depth(String parentType) {
+            return depth(parentType, new LinkedHashSet<>());
+        }
+
+        Map<String, String> descendantAliases(String parentType,
+                                              List<String> concreteSubtypeNames,
+                                              Map<String, Map<String, String>> aliasesByParent) {
+            String key = discriminatorKey.apply(modelsByClassname.get(parentType));
+            Map<String, String> result = new LinkedHashMap<>();
+            List<String> descendants = descendantNames(parentType);
+            for (String concreteSubtypeName : concreteSubtypeNames) {
+                String selectedAlias = null;
+                int selectedDepth = -1;
+                for (String descendant : descendants) {
+                    Map<String, String> aliases = aliasesByParent.get(descendant);
+                    if (aliases == null
+                            || !key.equals(discriminatorKey.apply(modelsByClassname.get(descendant)))
+                            || !aliases.containsKey(concreteSubtypeName)) {
+                        continue;
+                    }
+                    int depth = depth(descendant);
+                    if (depth > selectedDepth) {
+                        selectedAlias = aliases.get(concreteSubtypeName);
+                        selectedDepth = depth;
+                    }
+                }
+                if (selectedAlias != null) {
+                    result.put(concreteSubtypeName, selectedAlias);
+                }
+            }
+            return result;
+        }
+
+        List<String> mappingTargets(String target, List<String> concreteSubtypeNames) {
+            if (target == null || !modelsByClassname.containsKey(target)) {
+                return List.of();
+            }
+            if (concreteSubtypeNames.contains(target)) {
+                return List.of(target);
+            }
+            if (!subtypeNamesByParent.containsKey(target)) {
+                return List.of();
+            }
+            List<String> descendants = concreteSubtypeNames(target);
+            return concreteSubtypeNames.containsAll(descendants) ? descendants : List.of();
+        }
+
+        private int depth(String parentType, Set<String> visiting) {
+            checkCycle(parentType, visiting);
+            int depth = 0;
+            for (String subtypeName : subtypeNamesByParent.getOrDefault(parentType, List.of())) {
+                depth = Math.max(depth, 1 + depth(subtypeName, visiting));
+            }
+            visiting.remove(parentType);
+            return depth;
+        }
+
+        private void collectDescendantNames(String parentType, Set<String> visiting, Set<String> result) {
+            checkCycle(parentType, visiting);
+            for (String subtypeName : subtypeNamesByParent.getOrDefault(parentType, List.of())) {
+                result.add(subtypeName);
+                collectDescendantNames(subtypeName, visiting, result);
+            }
+            visiting.remove(parentType);
+        }
+
+        private void collectConcreteSubtypeNames(String parentType, Set<String> visiting, Set<String> result) {
+            checkCycle(parentType, visiting);
+            for (String subtypeName : subtypeNamesByParent.getOrDefault(parentType, List.of())) {
+                if (subtypeNamesByParent.containsKey(subtypeName)) {
+                    collectConcreteSubtypeNames(subtypeName, visiting, result);
+                } else {
+                    result.add(subtypeName);
+                }
+            }
+            visiting.remove(parentType);
+        }
+
+        private void checkCycle(String modelName, Set<String> visiting) {
+            if (!visiting.add(modelName)) {
+                throw new IllegalStateException("Cyclic allOf discriminator hierarchy involving model '"
+                                                        + modelName + "'");
+            }
+        }
+    }
+}

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/DiscriminatorSupport.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/DiscriminatorSupport.java
@@ -35,6 +35,12 @@ final class DiscriminatorSupport {
     private DiscriminatorSupport() {
     }
 
+    @SuppressWarnings("unchecked")
+    static List<CodegenProperty> renderVars(CodegenModel model) {
+        Object renderVars = model.vendorExtensions.get("x-render-vars");
+        return renderVars instanceof List<?> vars ? (List<CodegenProperty>) vars : model.vars;
+    }
+
     static Property inheritedProperty(CodegenModel model,
                                       String discriminatorKey,
                                       Map<String, CodegenModel> modelsByClassname,
@@ -108,6 +114,72 @@ final class DiscriminatorSupport {
                 && candidate != null
                 && !candidate.toString().isBlank()
                 && enumValues.apply(property).contains(candidate.toString());
+    }
+
+    @SuppressWarnings("unchecked")
+    static List<String> enumValues(CodegenProperty property) {
+        if (property == null) {
+            return List.of();
+        }
+        if (property._enum != null && !property._enum.isEmpty()) {
+            return property._enum;
+        }
+        if (property.allowableValues == null) {
+            return List.of();
+        }
+        Object values = property.allowableValues.get("values");
+        if (values instanceof List<?> enumValues) {
+            return enumValues.stream()
+                    .filter(String.class::isInstance)
+                    .map(String.class::cast)
+                    .toList();
+        }
+        return List.of();
+    }
+
+    static CodegenProperty property(CodegenModel model, String discriminatorKey) {
+        if (model == null) {
+            return null;
+        }
+        List<CodegenProperty> properties = model.allVars != null && !model.allVars.isEmpty()
+                ? model.allVars
+                : model.vars;
+        return property(properties, discriminatorKey);
+    }
+
+    static CodegenProperty property(List<CodegenProperty> properties, String discriminatorKey) {
+        if (properties == null || discriminatorKey == null) {
+            return null;
+        }
+        return properties.stream()
+                .filter(candidate -> isProperty(candidate, discriminatorKey))
+                .findFirst()
+                .orElse(null);
+    }
+
+    static boolean isProperty(CodegenProperty property, String discriminatorKey) {
+        return property != null
+                && (discriminatorKey.equals(property.baseName) || discriminatorKey.equals(property.name));
+    }
+
+    @SuppressWarnings("unchecked")
+    static void addAccessor(CodegenModel model, String extensionName, Map<String, Object> accessor) {
+        if (model == null) {
+            return;
+        }
+        List<Map<String, Object>> accessors = (List<Map<String, Object>>) model.vendorExtensions
+                .computeIfAbsent(extensionName, ignored -> new ArrayList<>());
+        for (Map<String, Object> existing : accessors) {
+            if (!existing.get("name").equals(accessor.get("name"))) {
+                continue;
+            }
+            if (existing.equals(accessor)) {
+                return;
+            }
+            throw new IllegalStateException("Contradictory discriminator accessor '" + accessor.get("name")
+                    + "' on model '" + model.classname + "': " + existing + " versus " + accessor);
+        }
+        accessors.add(accessor);
     }
 
     static String sanitizeDiagnosticReference(String value) {

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/DiscriminatorSupport.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/DiscriminatorSupport.java
@@ -162,6 +162,10 @@ final class DiscriminatorSupport {
                 && (discriminatorKey.equals(property.baseName) || discriminatorKey.equals(property.name));
     }
 
+    static boolean requiresCustomConverter(String alias) {
+        return alias.codePoints().anyMatch(codePoint -> !Character.isJavaIdentifierPart(codePoint));
+    }
+
     @SuppressWarnings("unchecked")
     static void addAccessor(CodegenModel model, String extensionName, Map<String, Object> accessor) {
         if (model == null) {

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/DiscriminatorSupport.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/DiscriminatorSupport.java
@@ -26,6 +26,8 @@ import java.util.Set;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import io.swagger.v3.oas.models.media.Discriminator;
+import io.swagger.v3.oas.models.media.Schema;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
 
@@ -77,6 +79,35 @@ final class DiscriminatorSupport {
         CodegenProperty property = discriminatorProperty.property();
         String type = property.datatypeWithEnum == null ? property.dataType : property.datatypeWithEnum;
         return property.isEnum ? discriminatorProperty.owner().classname + "." + type : type;
+    }
+
+    static String inlineShorthand(Schema<?> schema) {
+        if (schema == null || schema.getAllOf() == null) {
+            return null;
+        }
+        for (Schema<?> member : schema.getAllOf()) {
+            if (member == null || member.getDiscriminator() == null) {
+                continue;
+            }
+            Discriminator discriminator = member.getDiscriminator();
+            String value = discriminator.getPropertyName();
+            if (value != null && !value.isBlank()
+                    && (discriminator.getMapping() == null || discriminator.getMapping().isEmpty())
+                    && (member.getProperties() == null || !member.getProperties().containsKey(value))) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    static boolean isDeclaredEnumValue(CodegenProperty property,
+                                       Object candidate,
+                                       Function<CodegenProperty, List<String>> enumValues) {
+        return property != null
+                && property.isEnum
+                && candidate != null
+                && !candidate.toString().isBlank()
+                && enumValues.apply(property).contains(candidate.toString());
     }
 
     static String sanitizeDiagnosticReference(String value) {

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -17,7 +17,6 @@
 package io.helidon.openapi.generator;
 
 import java.io.File;
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.net.URI;
@@ -26,6 +25,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -35,10 +35,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import io.swagger.v3.core.util.Json;
-import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
@@ -112,6 +108,9 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             "RESPONSE",
             "RESPONSES");
 
+    static final String OPT_DISCRIMINATOR_REPRESENTATION = "discriminatorRepresentation";
+    private static final String EXT_DISCRIMINATOR_REPRESENTATION =
+            "x-helidon-discriminator-representation";
     private String helidonVersion = "4.5.0";
     private String javaVersion = "21";
     private boolean generateClient = true;
@@ -123,9 +122,11 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
     private boolean tracingEnabled = false;
     private boolean metricsEnabled = false;
     private boolean avoidOptionalListParams = false;
+    private DiscriminatorRepresentation discriminatorRepresentation;
     private List<SecurityRequirement> globalSecurityRequirements = List.of();
     private Map<String, String> rawAllOfDiscriminatorValuesBySchema = Map.of();
     private final JsonStringEnumSupport jsonStringEnums;
+    private Map<String, Map<String, String>> rawDiscriminatorMappingsBySchema = Map.of();
 
     /**
      * Creates a new generator with default options and template mappings.
@@ -207,6 +208,9 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         addOption(OPT_AVOID_OPTIONAL_LIST_PARAMS,
                 "Use bare List<T> instead of Optional<List<T>> for optional query list parameters",
                 String.valueOf(avoidOptionalListParams));
+        addOption(OPT_DISCRIMINATOR_REPRESENTATION,
+                "Represent discriminators as metadata or a derived read-only property",
+                "schema-driven");
     }
 
     // -------------------------------------------------------------------------
@@ -282,6 +286,11 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             avoidOptionalListParams = Boolean.parseBoolean(
                     additionalProperties.get(OPT_AVOID_OPTIONAL_LIST_PARAMS).toString());
         }
+        if (additionalProperties.containsKey(OPT_DISCRIMINATOR_REPRESENTATION)) {
+            discriminatorRepresentation = parseDiscriminatorRepresentation(
+                    additionalProperties.get(OPT_DISCRIMINATOR_REPRESENTATION),
+                    "generator option '" + OPT_DISCRIMINATOR_REPRESENTATION + "'");
+        }
 
         // Expose options to all templates via additionalProperties
         additionalProperties.put("helidonVersion", helidonVersion);
@@ -295,6 +304,10 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         additionalProperties.put("tracingEnabled", tracingEnabled);
         additionalProperties.put("metricsEnabled", metricsEnabled);
         additionalProperties.put("avoidOptionalListParams", avoidOptionalListParams);
+        if (discriminatorRepresentation != null) {
+            additionalProperties.put(OPT_DISCRIMINATOR_REPRESENTATION,
+                                     discriminatorRepresentation.optionValue);
+        }
 
         // Conditionally add per-tag template files
         if (generateClient) {
@@ -376,11 +389,11 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
     @Override
     public void preprocessOpenAPI(io.swagger.v3.oas.models.OpenAPI openAPI) {
         jsonStringEnums.preprocess(openAPI);
+        captureRawDiscriminatorMappings(openAPI);
         super.preprocessOpenAPI(openAPI);
         globalSecurityRequirements = openAPI.getSecurity() == null
                 ? List.of()
                 : new ArrayList<>(openAPI.getSecurity());
-        rawAllOfDiscriminatorValuesBySchema = loadRawAllOfDiscriminatorValues();
 
         if (openAPI.getServers() != null && !openAPI.getServers().isEmpty()) {
             String serverUrl = openAPI.getServers().get(0).getUrl();
@@ -411,6 +424,48 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         }
     }
 
+    private void captureRawDiscriminatorMappings(io.swagger.v3.oas.models.OpenAPI openAPI) {
+        if (openAPI.getComponents() == null || openAPI.getComponents().getSchemas() == null) {
+            rawDiscriminatorMappingsBySchema = Map.of();
+            return;
+        }
+        Map<String, Map<String, String>> result = new LinkedHashMap<>();
+        openAPI.getComponents().getSchemas().forEach((name, schema) -> {
+            if (schema.getDiscriminator() != null && schema.getDiscriminator().getMapping() != null) {
+                schema.getDiscriminator().getMapping().forEach((alias, targetRef) -> {
+                    if (name.equals(schemaNameFromRef(targetRef))) {
+                        throw unsupportedSelfMapping(name,
+                                                     schema.getDiscriminator().getPropertyName(),
+                                                     alias,
+                                                     targetRef);
+                    }
+                });
+                result.put(name, Collections.unmodifiableMap(new LinkedHashMap<>(schema.getDiscriminator().getMapping())));
+            }
+        });
+        rawDiscriminatorMappingsBySchema = Map.copyOf(result);
+    }
+
+    private IllegalStateException unsupportedSelfMapping(String schemaName,
+                                                         String propertyName,
+                                                         String alias,
+                                                         String targetRef) {
+        return new IllegalStateException("Unsupported discriminator self-mapping for schema '" + schemaName
+                + "' at #/components/schemas/" + schemaName + " in input specification '" + inputSpec
+                + "': discriminator property '" + propertyName + "', alias '" + alias + "', target '" + targetRef
+                + "'. The current Helidon JSON polymorphic runtime cannot safely route a base alias to the abstract "
+                + "owning model. Define a concrete subtype for this alias, or remove the self-mapping when the base "
+                + "is intended to be abstract.");
+    }
+
+    private String schemaNameFromRef(String schemaRef) {
+        if (schemaRef == null || schemaRef.isBlank()) {
+            return null;
+        }
+        int slash = schemaRef.lastIndexOf('/');
+        return slash >= 0 ? schemaRef.substring(slash + 1) : schemaRef;
+    }
+
     // -------------------------------------------------------------------------
     // Per-model: strip swagger 1.x annotation imports (not on Helidon SE classpath)
     // -------------------------------------------------------------------------
@@ -431,12 +486,17 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         boolean hasDeclaredProperties = hasDeclaredProperties(schema);
         model.vendorExtensions.put("x-has-declared-properties", hasDeclaredProperties);
         model.vendorExtensions.put("x-schema-nullable", Boolean.TRUE.equals(schema.getNullable()));
-        String allOfDiscriminatorValue = extractAllOfDiscriminatorValue(schema);
-        if (allOfDiscriminatorValue == null) {
-            allOfDiscriminatorValue = rawAllOfDiscriminatorValuesBySchema.get(name);
-        }
-        if (allOfDiscriminatorValue != null) {
-            model.vendorExtensions.put("x-allof-discriminator-value", allOfDiscriminatorValue);
+        Object representation = extensionValue(schema, EXT_DISCRIMINATOR_REPRESENTATION);
+        if (representation != null) {
+            DiscriminatorRepresentation parsed = parseDiscriminatorRepresentation(representation,
+                    "schema extension '" + EXT_DISCRIMINATOR_REPRESENTATION
+                            + "' on schema '" + name + "'");
+            if (parsed == null) {
+                throw new IllegalArgumentException("schema extension '" + EXT_DISCRIMINATOR_REPRESENTATION
+                        + "' on schema '" + name + "' must be 'metadata' or 'readOnlyProperty'");
+            }
+            model.vendorExtensions.put("x-discriminator-representation",
+                                       parsed.optionValue);
         }
         jsonStringEnums.markHttpParameterEnum(name, model);
         return model;
@@ -896,7 +956,8 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                                          Map<String, LinkedHashSet<String>> unionInterfacesByMember) {
         for (CodegenModel model : models) {
             model.vendorExtensions.put("x-render-vars", model.vars);
-
+        }
+        for (CodegenModel model : models) {
             if ((!model.oneOf.isEmpty() || !model.anyOf.isEmpty()) && shouldRenderAsUnionInterface(model)) {
                 normalizeUnionModel(model, modelsByClassname, unionInterfacesByMember);
             } else if (!model.allOf.isEmpty()) {
@@ -931,13 +992,25 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         model.vendorExtensions.put("x-is-union-interface", Boolean.TRUE);
         model.vendorExtensions.put("x-composition-kind", kind);
         assertSupportedUnionMembers(model, kind, members, modelsByClassname);
-        model.vendorExtensions.put("x-union-members", buildUnionMembers(model, members, modelsByClassname));
+        List<Map<String, Object>> unionMembers = buildUnionMembers(model, members, modelsByClassname);
+        model.vendorExtensions.put("x-union-members", unionMembers);
         String discriminatorKey = model.discriminator != null ? model.discriminator.getPropertyBaseName() : null;
+        if ((discriminatorKey == null || discriminatorKey.isBlank()) && model.discriminator != null) {
+            discriminatorKey = model.discriminator.getPropertyName();
+        }
         if (discriminatorKey != null && !discriminatorKey.isBlank()) {
             model.vendorExtensions.put("x-union-discriminator-key", discriminatorKey);
             model.vendorExtensions.put("x-union-discriminator-key-literal",
                                        JavaStringLiterals.toJavaStringLiteral(discriminatorKey));
             model.vendorExtensions.put("x-has-union-discriminator", Boolean.TRUE);
+            model.vendorExtensions.put("x-use-polymorphic-union", Boolean.TRUE);
+            model.vendorExtensions.put("x-has-polymorphic-subtypes", Boolean.TRUE);
+            model.vendorExtensions.put("x-polymorphic-key-literal",
+                                       JavaStringLiterals.toJavaStringLiteral(discriminatorKey));
+            model.vendorExtensions.put("x-polymorphic-subtypes", unionMembers);
+            applyUnionDiscriminatorRepresentation(model, members, modelsByClassname, discriminatorKey, unionMembers);
+        } else {
+            model.vendorExtensions.put("x-use-union-converter", Boolean.TRUE);
         }
         model.vendorExtensions.put("x-render-vars", List.of());
         model.vendorExtensions.put("x-union-requires-exactly-one", "oneOf".equals(kind));
@@ -1026,7 +1099,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
 
     private void applyAllOfDiscriminatorHierarchy(List<CodegenModel> models,
                                                   Map<String, CodegenModel> modelsByClassname) {
-        Map<String, List<Map<String, Object>>> subtypesByParent = new LinkedHashMap<>();
+        Map<String, List<String>> subtypeNamesByParent = new LinkedHashMap<>();
 
         for (CodegenModel model : models) {
             String parentType = (String) model.vendorExtensions.get("x-extends-model");
@@ -1038,49 +1111,28 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             if (parentModel == null || parentModel.discriminator == null) {
                 continue;
             }
-
-            String discriminatorKey = parentModel.discriminator.getPropertyBaseName();
-            if (discriminatorKey == null || discriminatorKey.isBlank()) {
-                discriminatorKey = parentModel.discriminator.getPropertyName();
-            }
-            if (discriminatorKey == null || discriminatorKey.isBlank()) {
-                continue;
-            }
-
-            String discriminatorValue = resolvedDiscriminatorValue(model, parentModel, discriminatorKey);
-            String discriminatorSetter = discriminatorSetter(parentModel, discriminatorKey);
-            String discriminatorValueExpression = discriminatorValueExpression(parentModel, discriminatorKey, discriminatorValue);
-
-            model.vendorExtensions.put("x-allof-discriminator-key", discriminatorKey);
-            model.vendorExtensions.put("x-allof-discriminator-value", discriminatorValue);
-            model.vendorExtensions.put("x-allof-discriminator-value-expression", discriminatorValueExpression);
-            if (discriminatorSetter != null) {
-                model.vendorExtensions.put("x-allof-discriminator-setter", discriminatorSetter);
-                model.vendorExtensions.put("x-has-allof-discriminator-setter", Boolean.TRUE);
-            }
-
-            subtypesByParent.computeIfAbsent(parentType, ignored -> new ArrayList<>())
-                    .add(new LinkedHashMap<>(Map.of(
-                            "alias", discriminatorValue,
-                            "aliasLiteral", JavaStringLiterals.toJavaStringLiteral(discriminatorValue),
-                            "name", model.classname)));
+            subtypeNamesByParent.computeIfAbsent(parentType, ignored -> new ArrayList<>()).add(model.classname);
         }
 
-        subtypesByParent.forEach((parentType, subtypes) -> {
+        subtypeNamesByParent.forEach((parentType, subtypeNames) -> {
             CodegenModel parentModel = modelsByClassname.get(parentType);
-            if (parentModel == null || parentModel.discriminator == null || subtypes.isEmpty()) {
+            if (parentModel == null || parentModel.discriminator == null || subtypeNames.isEmpty()) {
                 return;
             }
 
-            String discriminatorKey = parentModel.discriminator.getPropertyBaseName();
-            if (discriminatorKey == null || discriminatorKey.isBlank()) {
-                discriminatorKey = parentModel.discriminator.getPropertyName();
-            }
+            String discriminatorKey = discriminatorKey(parentModel);
             if (discriminatorKey == null || discriminatorKey.isBlank()) {
                 return;
             }
 
-            List<Map<String, Object>> sortedSubtypes = subtypes.stream()
+            Map<String, String> aliasesBySubtype = validateAndResolveAliases(parentModel,
+                                                                              subtypeNames,
+                                                                              modelsByClassname);
+            List<Map<String, Object>> sortedSubtypes = subtypeNames.stream()
+                    .map(name -> new LinkedHashMap<String, Object>(Map.of(
+                            "alias", aliasesBySubtype.get(name),
+                            "aliasLiteral", JavaStringLiterals.toJavaStringLiteral(aliasesBySubtype.get(name)),
+                            "name", name)))
                     .sorted((left, right) -> left.get("alias").toString().compareTo(right.get("alias").toString()))
                     .collect(Collectors.toCollection(ArrayList::new));
             for (int i = 0; i < sortedSubtypes.size(); i++) {
@@ -1092,7 +1144,210 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             parentModel.vendorExtensions.put("x-polymorphic-key-literal",
                                              JavaStringLiterals.toJavaStringLiteral(discriminatorKey));
             parentModel.vendorExtensions.put("x-polymorphic-subtypes", sortedSubtypes);
+            parentModel.vendorExtensions.put("x-abstract-polymorphic-base", Boolean.TRUE);
+
+            CodegenProperty discriminatorProperty = discriminatorProperty(parentModel, discriminatorKey);
+            removeRenderedDiscriminatorProperty(parentModel, discriminatorKey);
+            DiscriminatorRepresentation representation = discriminatorRepresentation(parentModel,
+                                                                                        discriminatorProperty != null);
+            if (representation == DiscriminatorRepresentation.READ_ONLY_PROPERTY) {
+                Map<String, Object> abstractAccessor = discriminatorAccessor(discriminatorKey,
+                                                                              discriminatorProperty,
+                                                                              null);
+                addDiscriminatorAccessor(parentModel, "x-abstract-discriminator-accessors", abstractAccessor);
+                if (discriminatorProperty != null && discriminatorProperty.isEnum) {
+                    parentModel.vendorExtensions.put("x-discriminator-enum-properties",
+                                                     List.of(discriminatorProperty));
+                }
+                for (String subtypeName : subtypeNames) {
+                    CodegenModel subtype = modelsByClassname.get(subtypeName);
+                    String alias = aliasesBySubtype.get(subtypeName);
+                    String valueExpression = discriminatorValueExpression(parentModel,
+                                                                          discriminatorKey,
+                                                                          alias);
+                    addDiscriminatorAccessor(subtype,
+                                             "x-concrete-discriminator-accessors",
+                                             discriminatorAccessor(discriminatorKey,
+                                                                   discriminatorProperty,
+                                                                   valueExpression));
+                }
+            }
         });
+    }
+
+    private void applyUnionDiscriminatorRepresentation(CodegenModel unionModel,
+                                                        List<String> members,
+                                                        Map<String, CodegenModel> modelsByClassname,
+                                                        String discriminatorKey,
+                                                        List<Map<String, Object>> unionMembers) {
+        boolean declared = members.stream()
+                .map(modelsByClassname::get)
+                .anyMatch(model -> discriminatorProperty(model, discriminatorKey) != null);
+        for (String member : members) {
+            removeRenderedDiscriminatorProperty(modelsByClassname.get(member), discriminatorKey);
+        }
+
+        if (discriminatorRepresentation(unionModel, declared) != DiscriminatorRepresentation.READ_ONLY_PROPERTY) {
+            return;
+        }
+
+        Map<String, Object> abstractAccessor = discriminatorAccessor(discriminatorKey,
+                                                                      null,
+                                                                      null);
+        addDiscriminatorAccessor(unionModel, "x-abstract-discriminator-accessors", abstractAccessor);
+        for (Map<String, Object> unionMember : unionMembers) {
+            CodegenModel member = modelsByClassname.get(unionMember.get("name").toString());
+            addDiscriminatorAccessor(member,
+                                     "x-concrete-discriminator-accessors",
+                                     discriminatorAccessor(discriminatorKey,
+                                                           null,
+                                                           unionMember.get("aliasLiteral").toString()));
+        }
+    }
+
+    private Map<String, String> validateAndResolveAliases(CodegenModel owner,
+                                                          List<String> subtypeNames,
+                                                          Map<String, CodegenModel> modelsByClassname) {
+        Map<String, List<String>> explicitAliasesBySubtype = new LinkedHashMap<>();
+        Map<String, String> mapping = rawDiscriminatorMappingsBySchema.get(owner.schemaName);
+        if (mapping == null) {
+            mapping = owner.discriminator.getMapping();
+        }
+        if (mapping != null) {
+            for (Map.Entry<String, String> entry : mapping.entrySet()) {
+                String alias = entry.getKey();
+                String targetRef = entry.getValue();
+                String target = modelNameFromSchemaRef(targetRef);
+                if (owner.classname.equals(target)) {
+                    throw unsupportedSelfMapping(owner, alias, targetRef);
+                }
+                if (target == null || !subtypeNames.contains(target) || !modelsByClassname.containsKey(target)) {
+                    throw discriminatorMappingFailure(owner,
+                                                      "alias '" + alias + "' targets '" + targetRef
+                                                              + "', which does not resolve to exactly one concrete subtype");
+                }
+                explicitAliasesBySubtype.computeIfAbsent(target, ignored -> new ArrayList<>()).add(alias);
+            }
+        }
+
+        Map<String, String> result = new LinkedHashMap<>();
+        for (String subtypeName : subtypeNames) {
+            List<String> aliases = explicitAliasesBySubtype.getOrDefault(subtypeName, List.of());
+            if (aliases.size() > 1) {
+                throw discriminatorMappingFailure(owner,
+                                                  "concrete subtype '" + subtypeName + "' has multiple explicit aliases "
+                                                          + aliases + "; one canonical serialized alias is required");
+            }
+            if (aliases.size() == 1) {
+                result.put(subtypeName, aliases.get(0));
+                continue;
+            }
+            CodegenModel subtype = modelsByClassname.get(subtypeName);
+            String implicitAlias = subtype.schemaName == null || subtype.schemaName.isBlank()
+                    ? subtypeName
+                    : subtype.schemaName;
+            result.put(subtypeName, implicitAlias);
+        }
+        return result;
+    }
+
+    private IllegalStateException unsupportedSelfMapping(CodegenModel owner, String alias, String targetRef) {
+        return new IllegalStateException("Unsupported discriminator self-mapping for schema '" + owner.schemaName
+                + "' at " + schemaLocation(owner) + " in input specification '" + inputSpec + "': discriminator property '"
+                + discriminatorKey(owner) + "', alias '" + alias + "', target '" + targetRef + "'. "
+                + "The current Helidon JSON polymorphic runtime cannot safely route a base alias to the abstract "
+                + "owning model. Define a concrete subtype for this alias, or remove the self-mapping when the base "
+                + "is intended to be abstract.");
+    }
+
+    private IllegalStateException discriminatorMappingFailure(CodegenModel owner, String reason) {
+        return new IllegalStateException("Invalid discriminator mapping for schema '" + owner.schemaName + "' at "
+                + schemaLocation(owner) + " in input specification '" + inputSpec + "', discriminator property '"
+                + discriminatorKey(owner) + "': " + reason + ".");
+    }
+
+    private String schemaLocation(CodegenModel model) {
+        return "#/components/schemas/" + (model.schemaName == null ? model.classname : model.schemaName);
+    }
+
+    private String discriminatorKey(CodegenModel model) {
+        if (model == null || model.discriminator == null) {
+            return null;
+        }
+        String result = model.discriminator.getPropertyBaseName();
+        return result == null || result.isBlank() ? model.discriminator.getPropertyName() : result;
+    }
+
+    private DiscriminatorRepresentation discriminatorRepresentation(CodegenModel owner, boolean declared) {
+        Object schemaOverride = owner.vendorExtensions.get("x-discriminator-representation");
+        if (schemaOverride != null) {
+            return parseDiscriminatorRepresentation(schemaOverride,
+                    "schema extension '" + EXT_DISCRIMINATOR_REPRESENTATION + "' on schema '" + owner.schemaName + "'");
+        }
+        if (discriminatorRepresentation != null) {
+            return discriminatorRepresentation;
+        }
+        return declared ? DiscriminatorRepresentation.READ_ONLY_PROPERTY : DiscriminatorRepresentation.METADATA;
+    }
+
+    private DiscriminatorRepresentation parseDiscriminatorRepresentation(Object value, String source) {
+        String normalized = String.valueOf(value).trim();
+        if ("schema-driven".equals(normalized)) {
+            return null;
+        }
+        for (DiscriminatorRepresentation candidate : DiscriminatorRepresentation.values()) {
+            if (candidate.optionValue.equals(normalized)) {
+                return candidate;
+            }
+        }
+        throw new IllegalArgumentException(source + " must be 'metadata' or 'readOnlyProperty', but was '"
+                + normalized + "'");
+    }
+
+    private void removeRenderedDiscriminatorProperty(CodegenModel model, String discriminatorKey) {
+        if (model == null) {
+            return;
+        }
+        List<CodegenProperty> filtered = renderVars(model).stream()
+                .filter(property -> !isDiscriminatorProperty(property, discriminatorKey))
+                .toList();
+        model.vendorExtensions.put("x-render-vars", filtered);
+    }
+
+    private boolean isDiscriminatorProperty(CodegenProperty property, String discriminatorKey) {
+        return property != null && (discriminatorKey.equals(property.baseName) || discriminatorKey.equals(property.name));
+    }
+
+    private Map<String, Object> discriminatorAccessor(String discriminatorKey,
+                                                      CodegenProperty property,
+                                                      String valueExpression) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("name", property == null ? toVarName(discriminatorKey) : property.name);
+        result.put("type", property == null ? "String" : property.datatypeWithEnum);
+        if (valueExpression != null) {
+            result.put("valueExpression", valueExpression);
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void addDiscriminatorAccessor(CodegenModel model, String extensionName, Map<String, Object> accessor) {
+        if (model == null) {
+            return;
+        }
+        List<Map<String, Object>> accessors = (List<Map<String, Object>>) model.vendorExtensions
+                .computeIfAbsent(extensionName, ignored -> new ArrayList<>());
+        for (Map<String, Object> existing : accessors) {
+            if (!existing.get("name").equals(accessor.get("name"))) {
+                continue;
+            }
+            if (existing.equals(accessor)) {
+                return;
+            }
+            throw new IllegalStateException("Contradictory discriminator accessor '" + accessor.get("name")
+                    + "' on model '" + model.classname + "'");
+        }
+        accessors.add(accessor);
     }
 
     private Set<String> localAllOfPropertyNames(List<CodegenProperty> allOfSchemas,
@@ -1187,22 +1442,8 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                                                     List<String> members,
                                                     Map<String, CodegenModel> modelsByClassname) {
         Map<String, String> aliasesByModel = new LinkedHashMap<>();
-        String discriminatorKey = unionModel.discriminator != null
-                ? unionModel.discriminator.getPropertyBaseName()
-                : null;
-        if (discriminatorKey == null || discriminatorKey.isBlank()) {
-            discriminatorKey = unionModel.discriminator != null ? unionModel.discriminator.getPropertyName() : null;
-        }
-
-        for (String member : members) {
-            CodegenModel memberModel = modelsByClassname.get(member);
-            if (memberModel == null) {
-                continue;
-            }
-            String alias = resolvedDiscriminatorValue(memberModel, unionModel, discriminatorKey);
-            if (alias != null && !alias.isBlank()) {
-                aliasesByModel.putIfAbsent(member, alias);
-            }
+        if (unionModel.discriminator != null) {
+            aliasesByModel.putAll(validateAndResolveAliases(unionModel, members, modelsByClassname));
         }
 
         for (String member : members) {
@@ -1246,105 +1487,6 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                 + "}";
     }
 
-    private String extractAllOfDiscriminatorValue(Schema<?> schema) {
-        if (schema == null) {
-            return null;
-        }
-
-        Object topLevel = extensionValue(schema, "x-discriminator-value");
-        if (topLevel != null) {
-            return topLevel.toString();
-        }
-
-        if (schema.getAllOf() != null) {
-            for (Schema<?> member : schema.getAllOf()) {
-                Object value = extensionValue(member, "x-discriminator-value");
-                if (value != null) {
-                    return value.toString();
-                }
-            }
-        }
-        return null;
-    }
-
-    private Map<String, String> loadRawAllOfDiscriminatorValues() {
-        if (inputSpec == null || inputSpec.isBlank()) {
-            return Map.of();
-        }
-
-        try {
-            String specContent = InputSpecContentReader.read(inputSpec);
-            ObjectMapper mapper = looksLikeJson(inputSpec, specContent) ? Json.mapper() : Yaml.mapper();
-            JsonNode root = mapper.readTree(specContent);
-            Map<String, String> result = new LinkedHashMap<>();
-            collectRawAllOfDiscriminatorValues(root.path("components").path("schemas"), result);
-            collectRawAllOfDiscriminatorValues(root.path("definitions"), result);
-            if (result.isEmpty()) {
-                return Map.of();
-            }
-            return result;
-        } catch (IOException | RuntimeException ignored) {
-            return Map.of();
-        }
-    }
-
-    private void collectRawAllOfDiscriminatorValues(JsonNode schemasNode, Map<String, String> result) {
-        if (schemasNode == null || !schemasNode.isObject()) {
-            return;
-        }
-
-        schemasNode.fields().forEachRemaining(entry -> {
-            String discriminatorValue = rawAllOfDiscriminatorValue(entry.getValue());
-            if (discriminatorValue != null && !discriminatorValue.isBlank()) {
-                result.putIfAbsent(entry.getKey(), discriminatorValue);
-            }
-        });
-    }
-
-    private boolean looksLikeJson(String specLocation, String specContent) {
-        String filename = "";
-        if (specLocation != null) {
-            int slash = Math.max(specLocation.lastIndexOf('/'), specLocation.lastIndexOf('\\'));
-            filename = (slash >= 0 ? specLocation.substring(slash + 1) : specLocation).toLowerCase();
-        }
-        if (filename.endsWith(".json")) {
-            return true;
-        }
-        String trimmed = specContent == null ? "" : specContent.stripLeading();
-        return trimmed.startsWith("{");
-    }
-
-    private String rawAllOfDiscriminatorValue(JsonNode schemaNode) {
-        if (schemaNode == null || schemaNode.isMissingNode() || schemaNode.isNull()) {
-            return null;
-        }
-
-        JsonNode topLevel = schemaNode.get("x-discriminator-value");
-        if (topLevel != null && topLevel.isValueNode()) {
-            return topLevel.asText();
-        }
-
-        JsonNode allOf = schemaNode.get("allOf");
-        if (allOf == null || !allOf.isArray()) {
-            return null;
-        }
-
-        for (JsonNode member : allOf) {
-            if (member == null || !member.isObject()) {
-                continue;
-            }
-            JsonNode extensionValue = member.get("x-discriminator-value");
-            if (extensionValue != null && extensionValue.isValueNode()) {
-                return extensionValue.asText();
-            }
-            JsonNode shorthandValue = member.get("discriminator");
-            if (shorthandValue != null && shorthandValue.isTextual()) {
-                return shorthandValue.asText();
-            }
-        }
-        return null;
-    }
-
     private Object extensionValue(Schema<?> schema, String name) {
         if (schema == null || schema.getExtensions() == null) {
             return null;
@@ -1374,242 +1516,6 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         return false;
     }
 
-    private String resolvedDiscriminatorValue(CodegenModel model,
-                                              CodegenModel parentModel,
-                                              String discriminatorKey) {
-        Object explicitValue = model.vendorExtensions.get("x-allof-discriminator-value");
-        if (explicitValue instanceof String value && !value.isBlank()) {
-            return value;
-        }
-
-        String mappedAlias = mappedDiscriminatorAlias(model, parentModel);
-        String inferredEnumValue = inferEnumDiscriminatorValue(model, parentModel, discriminatorKey, mappedAlias);
-        if (inferredEnumValue != null) {
-            return inferredEnumValue;
-        }
-
-        if (mappedAlias != null) {
-            return mappedAlias;
-        }
-
-        return defaultDiscriminatorValue(model);
-    }
-
-    private String defaultDiscriminatorValue(CodegenModel model) {
-        if (model.schemaName != null && !model.schemaName.isBlank()) {
-            return model.schemaName;
-        }
-        return model.classname;
-    }
-
-    private String mappedDiscriminatorAlias(CodegenModel model, CodegenModel parentModel) {
-        if (parentModel.discriminator == null) {
-            return null;
-        }
-
-        Map<String, String> mapping = parentModel.discriminator.getMapping();
-        if (mapping != null) {
-            for (Map.Entry<String, String> entry : mapping.entrySet()) {
-                String modelName = modelNameFromSchemaRef(entry.getValue());
-                if (model.classname.equals(modelName)) {
-                    return entry.getKey();
-                }
-            }
-        }
-
-        if (parentModel.discriminator.getMappedModels() != null) {
-            for (var mappedModel : parentModel.discriminator.getMappedModels()) {
-                if (mappedModel == null) {
-                    continue;
-                }
-                String modelName = mappedModel.getModelName();
-                String alias = mappedModel.getMappingName();
-                if (model.classname.equals(modelName) && alias != null && !alias.isBlank()) {
-                    return alias;
-                }
-            }
-        }
-
-        return null;
-    }
-
-    private String inferEnumDiscriminatorValue(CodegenModel model,
-                                               CodegenModel parentModel,
-                                               String discriminatorKey,
-                                               String mappedAlias) {
-        if (discriminatorKey == null || discriminatorKey.isBlank()) {
-            return null;
-        }
-
-        CodegenProperty property = discriminatorProperty(parentModel, discriminatorKey);
-        if (property == null || !property.isEnum) {
-            return null;
-        }
-
-        List<String> enumValues = discriminatorEnumValues(property);
-        if (enumValues.isEmpty()) {
-            return null;
-        }
-
-        LinkedHashSet<String> discriminatorCandidates = discriminatorCandidates(model, parentModel, mappedAlias);
-        if (discriminatorCandidates.isEmpty()) {
-            return null;
-        }
-
-        for (String candidate : discriminatorCandidates) {
-            if (enumValues.contains(candidate)) {
-                return candidate;
-            }
-        }
-
-        String bestValue = null;
-        int bestScore = -1;
-        boolean ambiguous = false;
-        for (String enumValue : enumValues) {
-            int score = discriminatorMatchScore(enumValue, discriminatorCandidates);
-            if (score > bestScore) {
-                bestValue = enumValue;
-                bestScore = score;
-                ambiguous = false;
-            } else if (score > 0 && score == bestScore) {
-                ambiguous = true;
-            }
-        }
-
-        return ambiguous || bestScore <= 0 ? null : bestValue;
-    }
-
-    private LinkedHashSet<String> discriminatorCandidates(CodegenModel model,
-                                                           CodegenModel parentModel,
-                                                           String mappedAlias) {
-        LinkedHashSet<String> discriminatorCandidates = new LinkedHashSet<>();
-        if (mappedAlias != null && !mappedAlias.isBlank()) {
-            discriminatorCandidates.add(mappedAlias);
-        }
-        if (model.classname != null && !model.classname.isBlank()) {
-            discriminatorCandidates.add(model.classname);
-        }
-        if (model.schemaName != null && !model.schemaName.isBlank()) {
-            discriminatorCandidates.add(model.schemaName);
-        }
-
-        List<String> parentTokens = enumNameTokens(parentModel.classname);
-        for (String candidate : new ArrayList<>(discriminatorCandidates)) {
-            List<String> trimmedTokens = trimSharedBoundaryTokens(enumNameTokens(candidate), parentTokens);
-            trimmedTokens = trimModelSuffixTokens(trimmedTokens);
-            if (!trimmedTokens.isEmpty()) {
-                discriminatorCandidates.add(String.join("_", trimmedTokens));
-            }
-        }
-        return discriminatorCandidates;
-    }
-
-    private List<String> trimSharedBoundaryTokens(List<String> candidateTokens, List<String> parentTokens) {
-        if (candidateTokens.isEmpty() || parentTokens.isEmpty()) {
-            return candidateTokens;
-        }
-
-        int start = 0;
-        int end = candidateTokens.size();
-
-        int prefixLength = sharedPrefixLength(candidateTokens, parentTokens);
-        if (prefixLength > 0 && prefixLength < end) {
-            start = prefixLength;
-        }
-
-        int suffixLength = sharedSuffixLength(candidateTokens.subList(start, end), parentTokens);
-        if (suffixLength > 0 && start < end - suffixLength) {
-            end -= suffixLength;
-        }
-
-        return candidateTokens.subList(start, end);
-    }
-
-    private int sharedPrefixLength(List<String> left, List<String> right) {
-        int max = Math.min(left.size(), right.size());
-        int index = 0;
-        while (index < max && left.get(index).equals(right.get(index))) {
-            index++;
-        }
-        return index;
-    }
-
-    private int sharedSuffixLength(List<String> left, List<String> right) {
-        int max = Math.min(left.size(), right.size());
-        int index = 0;
-        while (index < max
-                && left.get(left.size() - 1 - index).equals(right.get(right.size() - 1 - index))) {
-            index++;
-        }
-        return index;
-    }
-
-    private List<String> trimModelSuffixTokens(List<String> tokens) {
-        int end = tokens.size();
-        while (end > 1 && MODEL_SUFFIX_TOKENS.contains(tokens.get(end - 1))) {
-            end--;
-        }
-        return tokens.subList(0, end);
-    }
-
-    private int discriminatorMatchScore(String enumValue, Collection<String> candidates) {
-        List<String> enumTokens = enumNameTokens(enumValue);
-        if (enumTokens.isEmpty()) {
-            return 0;
-        }
-
-        int bestScore = 0;
-        for (String candidate : candidates) {
-            List<String> candidateTokens = enumNameTokens(candidate);
-            if (candidateTokens.equals(enumTokens)) {
-                return 10_000 + enumTokens.size();
-            }
-
-            int subsequenceStart = tokenSubsequenceStart(candidateTokens, enumTokens);
-            if (subsequenceStart >= 0) {
-                int prefixBonus = subsequenceStart == 0 ? 100 : 0;
-                int exactBonus = candidateTokens.size() == enumTokens.size() ? 1_000 : 0;
-                bestScore = Math.max(bestScore, (enumTokens.size() * 10) + prefixBonus + exactBonus);
-            }
-        }
-        return bestScore;
-    }
-
-    private List<String> enumNameTokens(String value) {
-        if (value == null || value.isBlank()) {
-            return List.of();
-        }
-
-        String enumName = toEnumVarName(value, "String");
-        if (enumName == null || enumName.isBlank()) {
-            return List.of();
-        }
-
-        return List.of(enumName.split("_")).stream()
-                .filter(token -> !token.isBlank())
-                .toList();
-    }
-
-    private int tokenSubsequenceStart(List<String> candidateTokens, List<String> expectedTokens) {
-        if (candidateTokens.isEmpty() || expectedTokens.isEmpty() || expectedTokens.size() > candidateTokens.size()) {
-            return -1;
-        }
-
-        for (int start = 0; start <= candidateTokens.size() - expectedTokens.size(); start++) {
-            boolean matches = true;
-            for (int offset = 0; offset < expectedTokens.size(); offset++) {
-                if (!candidateTokens.get(start + offset).equals(expectedTokens.get(offset))) {
-                    matches = false;
-                    break;
-                }
-            }
-            if (matches) {
-                return start;
-            }
-        }
-        return -1;
-    }
-
     @SuppressWarnings("unchecked")
     private List<String> discriminatorEnumValues(CodegenProperty property) {
         if (property == null) {
@@ -1633,14 +1539,6 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         }
 
         return List.of();
-    }
-
-    private String discriminatorSetter(CodegenModel parentModel, String discriminatorKey) {
-        CodegenProperty property = discriminatorProperty(parentModel, discriminatorKey);
-        if (property == null) {
-            return null;
-        }
-        return property.name;
     }
 
     private String discriminatorValueExpression(CodegenModel parentModel,
@@ -1668,10 +1566,9 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             return null;
         }
 
-        String normalizedDiscriminatorValue = toEnumVarName(discriminatorValue, "String");
         for (String enumValue : discriminatorEnumValues(property)) {
             String enumConstant = toEnumVarName(enumValue, "String");
-            if (enumValue.equals(discriminatorValue) || enumConstant.equals(normalizedDiscriminatorValue)) {
+            if (enumValue.equals(discriminatorValue)) {
                 return enumConstant;
             }
         }
@@ -1993,6 +1890,17 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             return new BigDecimal(value.toString()).longValueExact();
         } catch (ArithmeticException | NumberFormatException ignored) {
             return null;
+        }
+    }
+
+    private enum DiscriminatorRepresentation {
+        METADATA("metadata"),
+        READ_ONLY_PROPERTY("readOnlyProperty");
+
+        private final String optionValue;
+
+        DiscriminatorRepresentation(String optionValue) {
+            this.optionValue = optionValue;
         }
     }
 }

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -1097,6 +1097,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
     private void applyAllOfDiscriminatorHierarchy(List<CodegenModel> models,
                                                   Map<String, CodegenModel> modelsByClassname) {
         Map<String, List<String>> subtypeNamesByParent = new LinkedHashMap<>();
+        Map<String, String> parentBySubtype = new LinkedHashMap<>();
 
         for (CodegenModel model : models) {
             String parentType = (String) model.vendorExtensions.get("x-extends-model");
@@ -1109,7 +1110,17 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                 continue;
             }
             subtypeNamesByParent.computeIfAbsent(parentType, ignored -> new ArrayList<>()).add(model.classname);
+            parentBySubtype.put(model.classname, parentType);
         }
+
+        Map<String, Map<String, String>> aliasesByParent = new LinkedHashMap<>();
+        subtypeNamesByParent.forEach((parentType, subtypeNames) -> {
+            CodegenModel parentModel = modelsByClassname.get(parentType);
+            if (parentModel != null && parentModel.discriminator != null) {
+                aliasesByParent.put(parentType,
+                                    validateAndResolveAliases(parentModel, subtypeNames, modelsByClassname));
+            }
+        });
 
         subtypeNamesByParent.forEach((parentType, subtypeNames) -> {
             CodegenModel parentModel = modelsByClassname.get(parentType);
@@ -1122,10 +1133,24 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                 return;
             }
 
-            Map<String, String> aliasesBySubtype = validateAndResolveAliases(parentModel,
-                                                                              subtypeNames,
-                                                                              modelsByClassname);
-            List<Map<String, Object>> sortedSubtypes = subtypeNames.stream()
+            List<String> concreteSubtypeNames = concreteSubtypeNames(parentType, subtypeNamesByParent);
+            Map<String, String> aliasesBySubtype = new LinkedHashMap<>();
+            for (String concreteSubtypeName : concreteSubtypeNames) {
+                String directParent = parentBySubtype.get(concreteSubtypeName);
+                aliasesBySubtype.put(concreteSubtypeName,
+                                     aliasesByParent.getOrDefault(directParent, Map.of())
+                                             .getOrDefault(concreteSubtypeName, concreteSubtypeName));
+            }
+            Map<String, String> subtypeByAlias = new LinkedHashMap<>();
+            aliasesBySubtype.forEach((subtype, alias) -> {
+                String previousSubtype = subtypeByAlias.putIfAbsent(alias, subtype);
+                if (previousSubtype != null && !previousSubtype.equals(subtype)) {
+                    throw discriminatorMappingFailure(parentModel,
+                                                      "concrete descendants '" + previousSubtype + "' and '"
+                                                              + subtype + "' share canonical alias '" + alias + "'");
+                }
+            });
+            List<Map<String, Object>> sortedSubtypes = concreteSubtypeNames.stream()
                     .map(name -> new LinkedHashMap<String, Object>(Map.of(
                             "alias", aliasesBySubtype.get(name),
                             "aliasLiteral", JavaStringLiterals.toJavaStringLiteral(aliasesBySubtype.get(name)),
@@ -1178,6 +1203,31 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                 }
             }
         });
+    }
+
+    private List<String> concreteSubtypeNames(String parentType,
+                                              Map<String, List<String>> subtypeNamesByParent) {
+        LinkedHashSet<String> result = new LinkedHashSet<>();
+        collectConcreteSubtypeNames(parentType, subtypeNamesByParent, new LinkedHashSet<>(), result);
+        return new ArrayList<>(result);
+    }
+
+    private void collectConcreteSubtypeNames(String parentType,
+                                             Map<String, List<String>> subtypeNamesByParent,
+                                             Set<String> visiting,
+                                             Set<String> result) {
+        if (!visiting.add(parentType)) {
+            throw new IllegalStateException("Cyclic allOf discriminator hierarchy involving model '"
+                                                    + parentType + "'");
+        }
+        for (String subtypeName : subtypeNamesByParent.getOrDefault(parentType, List.of())) {
+            if (subtypeNamesByParent.containsKey(subtypeName)) {
+                collectConcreteSubtypeNames(subtypeName, subtypeNamesByParent, visiting, result);
+            } else {
+                result.add(subtypeName);
+            }
+        }
+        visiting.remove(parentType);
     }
 
     private void applyUnionDiscriminatorRepresentation(CodegenModel unionModel,
@@ -1361,6 +1411,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                                                       String valueExpression) {
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("name", property == null ? toVarName(discriminatorKey) : property.name);
+        result.put("nameLiteral", JavaStringLiterals.toJavaStringLiteral(discriminatorKey));
         result.put("type", property == null ? "String" : property.datatypeWithEnum);
         if (valueExpression != null) {
             result.put("valueExpression", valueExpression);

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -1128,23 +1128,23 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         }
 
         Map<String, Map<String, String>> aliasesByParent = new LinkedHashMap<>();
+        DiscriminatorSupport.Hierarchy hierarchy = new DiscriminatorSupport.Hierarchy(subtypeNamesByParent,
+                                                                                       modelsByClassname,
+                                                                                       this::discriminatorKey);
         List<String> parentTypes = new ArrayList<>(subtypeNamesByParent.keySet());
-        parentTypes.sort((left, right) -> Integer.compare(hierarchyDepth(left, subtypeNamesByParent),
-                                                          hierarchyDepth(right, subtypeNamesByParent)));
+        parentTypes.sort((left, right) -> Integer.compare(hierarchy.depth(left), hierarchy.depth(right)));
         parentTypes.forEach(parentType -> {
             CodegenModel parentModel = modelsByClassname.get(parentType);
             if (parentModel != null && parentModel.discriminator != null) {
-                List<String> concreteSubtypeNames = concreteSubtypeNames(parentType, subtypeNamesByParent);
-                Map<String, String> descendantAliases = descendantAliases(parentType,
-                                                                           concreteSubtypeNames,
-                                                                           aliasesByParent,
-                                                                           subtypeNamesByParent,
-                                                                           modelsByClassname);
+                List<String> concreteSubtypeNames = hierarchy.concreteSubtypeNames(parentType);
+                Map<String, String> descendantAliases = hierarchy.descendantAliases(parentType,
+                                                                                      concreteSubtypeNames,
+                                                                                      aliasesByParent);
                 aliasesByParent.put(parentType,
                                     validateAndResolveAliases(parentModel,
                                                               concreteSubtypeNames,
                                                               descendantAliases,
-                                                              subtypeNamesByParent,
+                                                              hierarchy,
                                                               modelsByClassname));
             }
         });
@@ -1160,7 +1160,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                 return;
             }
 
-            List<String> concreteSubtypeNames = concreteSubtypeNames(parentType, subtypeNamesByParent);
+            List<String> concreteSubtypeNames = hierarchy.concreteSubtypeNames(parentType);
             Map<String, String> aliasesBySubtype = aliasesByParent.getOrDefault(parentType, Map.of());
             Map<String, String> subtypeByAlias = new LinkedHashMap<>();
             aliasesBySubtype.forEach((subtype, alias) -> {
@@ -1191,7 +1191,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
 
             CodegenProperty discriminatorProperty = discriminatorProperty(parentModel, discriminatorKey);
             removeRenderedDiscriminatorProperty(parentModel, discriminatorKey);
-            for (String subtypeName : descendantNames(parentType, subtypeNamesByParent)) {
+            for (String subtypeName : hierarchy.descendantNames(parentType)) {
                 removeRenderedDiscriminatorProperty(modelsByClassname.get(subtypeName), discriminatorKey);
             }
             DiscriminatorRepresentation representation = discriminatorRepresentation(parentModel,
@@ -1221,117 +1221,24 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         });
     }
 
-    private List<String> concreteSubtypeNames(String parentType,
-                                              Map<String, List<String>> subtypeNamesByParent) {
-        LinkedHashSet<String> result = new LinkedHashSet<>();
-        collectConcreteSubtypeNames(parentType, subtypeNamesByParent, new LinkedHashSet<>(), result);
-        return new ArrayList<>(result);
-    }
-
-    private List<String> descendantNames(String parentType,
-                                         Map<String, List<String>> subtypeNamesByParent) {
-        LinkedHashSet<String> result = new LinkedHashSet<>();
-        collectDescendantNames(parentType, subtypeNamesByParent, new LinkedHashSet<>(), result);
-        return new ArrayList<>(result);
-    }
-
-    private int hierarchyDepth(String parentType, Map<String, List<String>> subtypeNamesByParent) {
-        return hierarchyDepth(parentType, subtypeNamesByParent, new LinkedHashSet<>());
-    }
-
-    private int hierarchyDepth(String parentType,
-                               Map<String, List<String>> subtypeNamesByParent,
-                               Set<String> visiting) {
-        if (!visiting.add(parentType)) {
-            throw new IllegalStateException("Cyclic allOf discriminator hierarchy involving model '"
-                                                    + parentType + "'");
-        }
-        int depth = 0;
-        for (String subtypeName : subtypeNamesByParent.getOrDefault(parentType, List.of())) {
-            depth = Math.max(depth, 1 + hierarchyDepth(subtypeName, subtypeNamesByParent, visiting));
-        }
-        visiting.remove(parentType);
-        return depth;
-    }
-
-    private Map<String, String> descendantAliases(String parentType,
-                                                  List<String> concreteSubtypeNames,
-                                                  Map<String, Map<String, String>> aliasesByParent,
-                                                  Map<String, List<String>> subtypeNamesByParent,
-                                                  Map<String, CodegenModel> modelsByClassname) {
-        CodegenModel parent = modelsByClassname.get(parentType);
-        String discriminatorKey = discriminatorKey(parent);
-        Map<String, String> result = new LinkedHashMap<>();
-        List<String> descendants = descendantNames(parentType, subtypeNamesByParent);
-        for (String concreteSubtypeName : concreteSubtypeNames) {
-            String selectedAlias = null;
-            int selectedDepth = -1;
-            for (String descendant : descendants) {
-                CodegenModel descendantModel = modelsByClassname.get(descendant);
-                Map<String, String> aliases = aliasesByParent.get(descendant);
-                if (aliases == null || !discriminatorKey.equals(discriminatorKey(descendantModel))
-                        || !aliases.containsKey(concreteSubtypeName)) {
-                    continue;
-                }
-                int depth = hierarchyDepth(descendant, subtypeNamesByParent);
-                if (depth > selectedDepth) {
-                    selectedAlias = aliases.get(concreteSubtypeName);
-                    selectedDepth = depth;
-                }
-            }
-            if (selectedAlias != null) {
-                result.put(concreteSubtypeName, selectedAlias);
-            }
-        }
-        return result;
-    }
-
-    private void collectDescendantNames(String parentType,
-                                        Map<String, List<String>> subtypeNamesByParent,
-                                        Set<String> visiting,
-                                        Set<String> result) {
-        if (!visiting.add(parentType)) {
-            throw new IllegalStateException("Cyclic allOf discriminator hierarchy involving model '"
-                                                    + parentType + "'");
-        }
-        for (String subtypeName : subtypeNamesByParent.getOrDefault(parentType, List.of())) {
-            result.add(subtypeName);
-            collectDescendantNames(subtypeName, subtypeNamesByParent, visiting, result);
-        }
-        visiting.remove(parentType);
-    }
-
-    private void collectConcreteSubtypeNames(String parentType,
-                                             Map<String, List<String>> subtypeNamesByParent,
-                                             Set<String> visiting,
-                                             Set<String> result) {
-        if (!visiting.add(parentType)) {
-            throw new IllegalStateException("Cyclic allOf discriminator hierarchy involving model '"
-                                                    + parentType + "'");
-        }
-        for (String subtypeName : subtypeNamesByParent.getOrDefault(parentType, List.of())) {
-            if (subtypeNamesByParent.containsKey(subtypeName)) {
-                collectConcreteSubtypeNames(subtypeName, subtypeNamesByParent, visiting, result);
-            } else {
-                result.add(subtypeName);
-            }
-        }
-        visiting.remove(parentType);
-    }
-
     private void applyUnionDiscriminatorRepresentation(CodegenModel unionModel,
                                                         List<String> members,
                                                         Map<String, CodegenModel> modelsByClassname,
                                                         String discriminatorKey,
                                                         List<Map<String, Object>> unionMembers) {
-        List<DiscriminatorProperty> discriminatorProperties = members.stream()
+        List<DiscriminatorSupport.Property> discriminatorProperties = members.stream()
                 .map(modelsByClassname::get)
-                .map(model -> inheritedDiscriminatorProperty(model, discriminatorKey, modelsByClassname))
+                .map(model -> DiscriminatorSupport.inheritedProperty(model,
+                                                                      discriminatorKey,
+                                                                      modelsByClassname,
+                                                                      this::renderVars,
+                                                                      this::discriminatorProperty))
                 .filter(java.util.Objects::nonNull)
                 .toList();
-        DiscriminatorProperty discriminatorProperty = commonDiscriminatorProperty(unionModel,
-                                                                                    discriminatorKey,
-                                                                                    discriminatorProperties);
+        DiscriminatorSupport.Property discriminatorProperty = DiscriminatorSupport.commonProperty(
+                discriminatorKey,
+                discriminatorProperties,
+                reason -> discriminatorMappingFailure(unionModel, reason));
         boolean declared = discriminatorProperty != null;
         for (String member : members) {
             removeRenderedDiscriminatorProperty(modelsByClassname.get(member), discriminatorKey);
@@ -1360,44 +1267,8 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         }
     }
 
-    private DiscriminatorProperty commonDiscriminatorProperty(CodegenModel unionModel,
-                                                               String discriminatorKey,
-                                                               List<DiscriminatorProperty> properties) {
-        if (properties.isEmpty()) {
-            return null;
-        }
-        DiscriminatorProperty first = properties.getFirst();
-        String expectedType = qualifiedDiscriminatorType(first);
-        for (DiscriminatorProperty candidate : properties) {
-            if (!expectedType.equals(qualifiedDiscriminatorType(candidate))) {
-                throw discriminatorMappingFailure(unionModel,
-                                                   "members expose incompatible Java types for discriminator property '"
-                                                           + discriminatorKey + "': '" + expectedType + "' and '"
-                                                           + qualifiedDiscriminatorType(candidate) + "'");
-            }
-        }
-        return first;
-    }
-
-    private DiscriminatorProperty inheritedDiscriminatorProperty(CodegenModel model,
-                                                                  String discriminatorKey,
-                                                                  Map<String, CodegenModel> modelsByClassname) {
-        Set<String> visited = new LinkedHashSet<>();
-        CodegenModel current = model;
-        while (current != null && visited.add(current.classname)) {
-            CodegenProperty local = discriminatorProperty(renderVars(current), discriminatorKey);
-            if (local != null) {
-                return new DiscriminatorProperty(current, local);
-            }
-            Object parent = current.vendorExtensions.get("x-extends-model");
-            current = parent instanceof String parentName ? modelsByClassname.get(parentName) : null;
-        }
-        CodegenProperty inherited = discriminatorProperty(model, discriminatorKey);
-        return inherited == null ? null : new DiscriminatorProperty(model, inherited);
-    }
-
     private Map<String, Object> unionDiscriminatorAccessor(String discriminatorKey,
-                                                           DiscriminatorProperty discriminatorProperty,
+                                                           DiscriminatorSupport.Property discriminatorProperty,
                                                            String valueExpression) {
         if (discriminatorProperty == null) {
             return discriminatorAccessor(discriminatorKey, null, valueExpression);
@@ -1405,26 +1276,20 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         Map<String, Object> result = discriminatorAccessor(discriminatorKey,
                                                             discriminatorProperty.property(),
                                                             valueExpression);
-        result.put("type", qualifiedDiscriminatorType(discriminatorProperty));
+        result.put("type", DiscriminatorSupport.qualifiedType(discriminatorProperty));
         return result;
-    }
-
-    private String qualifiedDiscriminatorType(DiscriminatorProperty discriminatorProperty) {
-        CodegenProperty property = discriminatorProperty.property();
-        String type = property.datatypeWithEnum == null ? property.dataType : property.datatypeWithEnum;
-        return property.isEnum ? discriminatorProperty.owner().classname + "." + type : type;
     }
 
     private Map<String, String> validateAndResolveAliases(CodegenModel owner,
                                                           List<String> subtypeNames,
                                                           Map<String, CodegenModel> modelsByClassname) {
-        return validateAndResolveAliases(owner, subtypeNames, Map.of(), Map.of(), modelsByClassname);
+        return validateAndResolveAliases(owner, subtypeNames, Map.of(), null, modelsByClassname);
     }
 
     private Map<String, String> validateAndResolveAliases(CodegenModel owner,
                                                           List<String> concreteSubtypeNames,
                                                           Map<String, String> descendantAliases,
-                                                          Map<String, List<String>> subtypeNamesByParent,
+                                                          DiscriminatorSupport.Hierarchy hierarchy,
                                                           Map<String, CodegenModel> modelsByClassname) {
         Map<String, List<String>> explicitAliasesBySubtype = new LinkedHashMap<>();
         Map<String, String> mapping = rawDiscriminatorMappingsBySchema.get(owner.schemaName);
@@ -1439,10 +1304,9 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                 if (owner.classname.equals(target)) {
                     throw unsupportedSelfMapping(owner, alias, targetRef);
                 }
-                List<String> resolvedTargets = mappingTargets(target,
-                                                              concreteSubtypeNames,
-                                                              subtypeNamesByParent,
-                                                              modelsByClassname);
+                List<String> resolvedTargets = concreteSubtypeNames.contains(target)
+                        ? List.of(target)
+                        : hierarchy == null ? List.of() : hierarchy.mappingTargets(target, concreteSubtypeNames);
                 if (resolvedTargets.size() != 1) {
                     throw discriminatorMappingFailure(owner,
                                                       "alias '" + alias + "' targets '"
@@ -1477,23 +1341,6 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         return result;
     }
 
-    private List<String> mappingTargets(String target,
-                                        List<String> concreteSubtypeNames,
-                                        Map<String, List<String>> subtypeNamesByParent,
-                                        Map<String, CodegenModel> modelsByClassname) {
-        if (target == null || !modelsByClassname.containsKey(target)) {
-            return List.of();
-        }
-        if (concreteSubtypeNames.contains(target)) {
-            return List.of(target);
-        }
-        if (!subtypeNamesByParent.containsKey(target)) {
-            return List.of();
-        }
-        List<String> descendants = concreteSubtypeNames(target, subtypeNamesByParent);
-        return concreteSubtypeNames.containsAll(descendants) ? descendants : List.of();
-    }
-
     private IllegalStateException unsupportedSelfMapping(CodegenModel owner, String alias, String targetRef) {
         return new IllegalStateException("Unsupported discriminator self-mapping for schema '" + owner.schemaName
                 + "' at " + schemaLocation(owner) + " in input specification '"
@@ -1513,32 +1360,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
     }
 
     static String sanitizeDiagnosticReference(String value) {
-        if (value == null || value.isBlank() || value.startsWith("#/")) {
-            return value;
-        }
-        URI uri;
-        try {
-            uri = URI.create(value);
-        } catch (IllegalArgumentException ignored) {
-            return value.contains("://") ? "<redacted URI>" : value;
-        }
-        if (uri.getScheme() == null) {
-            return value;
-        }
-        if (uri.isOpaque()) {
-            return uri.getScheme() + ":<redacted>";
-        }
-        try {
-            return new URI(uri.getScheme(),
-                           null,
-                           uri.getHost(),
-                           uri.getPort(),
-                           uri.getPath(),
-                           null,
-                           uri.getFragment()).toString();
-        } catch (Exception ignored) {
-            return uri.getScheme() + ":<redacted>";
-        }
+        return DiscriminatorSupport.sanitizeDiagnosticReference(value);
     }
 
     private String schemaLocation(CodegenModel model) {
@@ -1874,9 +1696,6 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             }
         }
         return null;
-    }
-
-    private record DiscriminatorProperty(CodegenModel owner, CodegenProperty property) {
     }
 
     /**

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -451,8 +451,10 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                                                          String alias,
                                                          String targetRef) {
         return new IllegalStateException("Unsupported discriminator self-mapping for schema '" + schemaName
-                + "' at #/components/schemas/" + schemaName + " in input specification '" + inputSpec
-                + "': discriminator property '" + propertyName + "', alias '" + alias + "', target '" + targetRef
+                + "' at #/components/schemas/" + schemaName + " in input specification '"
+                + sanitizeDiagnosticReference(inputSpec)
+                + "': discriminator property '" + propertyName + "', alias '" + alias + "', target '"
+                + sanitizeDiagnosticReference(targetRef)
                 + "'. The current Helidon JSON polymorphic runtime cannot safely route a base alias to the abstract "
                 + "owning model. Define a concrete subtype for this alias, or remove the self-mapping when the base "
                 + "is intended to be abstract.");
@@ -1003,15 +1005,10 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             model.vendorExtensions.put("x-union-discriminator-key-literal",
                                        JavaStringLiterals.toJavaStringLiteral(discriminatorKey));
             model.vendorExtensions.put("x-has-union-discriminator", Boolean.TRUE);
-            model.vendorExtensions.put("x-use-polymorphic-union", Boolean.TRUE);
-            model.vendorExtensions.put("x-has-polymorphic-subtypes", Boolean.TRUE);
-            model.vendorExtensions.put("x-polymorphic-key-literal",
-                                       JavaStringLiterals.toJavaStringLiteral(discriminatorKey));
-            model.vendorExtensions.put("x-polymorphic-subtypes", unionMembers);
             applyUnionDiscriminatorRepresentation(model, members, modelsByClassname, discriminatorKey, unionMembers);
-        } else {
-            model.vendorExtensions.put("x-use-union-converter", Boolean.TRUE);
         }
+        // The converter buffers the complete object, so discriminator lookup is property-order independent.
+        model.vendorExtensions.put("x-use-union-converter", Boolean.TRUE);
         model.vendorExtensions.put("x-render-vars", List.of());
         model.vendorExtensions.put("x-union-requires-exactly-one", "oneOf".equals(kind));
         model.vendorExtensions.put("x-union-requires-unique-best-match", "anyOf".equals(kind));
@@ -1148,6 +1145,9 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
 
             CodegenProperty discriminatorProperty = discriminatorProperty(parentModel, discriminatorKey);
             removeRenderedDiscriminatorProperty(parentModel, discriminatorKey);
+            for (String subtypeName : subtypeNames) {
+                removeRenderedDiscriminatorProperty(modelsByClassname.get(subtypeName), discriminatorKey);
+            }
             DiscriminatorRepresentation representation = discriminatorRepresentation(parentModel,
                                                                                         discriminatorProperty != null);
             if (representation == DiscriminatorRepresentation.READ_ONLY_PROPERTY) {
@@ -1160,6 +1160,11 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                                                      List.of(discriminatorProperty));
                 }
                 for (String subtypeName : subtypeNames) {
+                    if (subtypeNamesByParent.containsKey(subtypeName)) {
+                        // An intermediate polymorphic parent remains abstract; its concrete descendants
+                        // supply the discriminator accessor.
+                        continue;
+                    }
                     CodegenModel subtype = modelsByClassname.get(subtypeName);
                     String alias = aliasesBySubtype.get(subtypeName);
                     String valueExpression = discriminatorValueExpression(parentModel,
@@ -1223,7 +1228,8 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                 }
                 if (target == null || !subtypeNames.contains(target) || !modelsByClassname.containsKey(target)) {
                     throw discriminatorMappingFailure(owner,
-                                                      "alias '" + alias + "' targets '" + targetRef
+                                                      "alias '" + alias + "' targets '"
+                                                              + sanitizeDiagnosticReference(targetRef)
                                                               + "', which does not resolve to exactly one concrete subtype");
                 }
                 explicitAliasesBySubtype.computeIfAbsent(target, ignored -> new ArrayList<>()).add(alias);
@@ -1253,8 +1259,10 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
 
     private IllegalStateException unsupportedSelfMapping(CodegenModel owner, String alias, String targetRef) {
         return new IllegalStateException("Unsupported discriminator self-mapping for schema '" + owner.schemaName
-                + "' at " + schemaLocation(owner) + " in input specification '" + inputSpec + "': discriminator property '"
-                + discriminatorKey(owner) + "', alias '" + alias + "', target '" + targetRef + "'. "
+                + "' at " + schemaLocation(owner) + " in input specification '"
+                + sanitizeDiagnosticReference(inputSpec) + "': discriminator property '"
+                + discriminatorKey(owner) + "', alias '" + alias + "', target '"
+                + sanitizeDiagnosticReference(targetRef) + "'. "
                 + "The current Helidon JSON polymorphic runtime cannot safely route a base alias to the abstract "
                 + "owning model. Define a concrete subtype for this alias, or remove the self-mapping when the base "
                 + "is intended to be abstract.");
@@ -1262,8 +1270,38 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
 
     private IllegalStateException discriminatorMappingFailure(CodegenModel owner, String reason) {
         return new IllegalStateException("Invalid discriminator mapping for schema '" + owner.schemaName + "' at "
-                + schemaLocation(owner) + " in input specification '" + inputSpec + "', discriminator property '"
+                + schemaLocation(owner) + " in input specification '" + sanitizeDiagnosticReference(inputSpec)
+                + "', discriminator property '"
                 + discriminatorKey(owner) + "': " + reason + ".");
+    }
+
+    static String sanitizeDiagnosticReference(String value) {
+        if (value == null || value.isBlank() || value.startsWith("#/")) {
+            return value;
+        }
+        URI uri;
+        try {
+            uri = URI.create(value);
+        } catch (IllegalArgumentException ignored) {
+            return value.contains("://") ? "<redacted URI>" : value;
+        }
+        if (uri.getScheme() == null) {
+            return value;
+        }
+        if (uri.isOpaque()) {
+            return uri.getScheme() + ":<redacted>";
+        }
+        try {
+            return new URI(uri.getScheme(),
+                           null,
+                           uri.getHost(),
+                           uri.getPort(),
+                           uri.getPath(),
+                           null,
+                           uri.getFragment()).toString();
+        } catch (Exception ignored) {
+            return uri.getScheme() + ":<redacted>";
+        }
     }
 
     private String schemaLocation(CodegenModel model) {

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -1175,10 +1175,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                 }
             });
             List<Map<String, Object>> sortedSubtypes = concreteSubtypeNames.stream()
-                    .map(name -> new LinkedHashMap<String, Object>(Map.of(
-                            "alias", aliasesBySubtype.get(name),
-                            "aliasLiteral", JavaStringLiterals.toJavaStringLiteral(aliasesBySubtype.get(name)),
-                            "name", name)))
+                    .map(name -> polymorphicSubtype(name, aliasesBySubtype.get(name)))
                     .sorted((left, right) -> left.get("alias").toString().compareTo(right.get("alias").toString()))
                     .collect(Collectors.toCollection(ArrayList::new));
             for (int i = 0; i < sortedSubtypes.size(); i++) {
@@ -1191,6 +1188,9 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                                              JavaStringLiterals.toJavaStringLiteral(discriminatorKey));
             parentModel.vendorExtensions.put("x-polymorphic-subtypes", sortedSubtypes);
             parentModel.vendorExtensions.put("x-abstract-polymorphic-base", Boolean.TRUE);
+            if (aliasesBySubtype.values().stream().anyMatch(DiscriminatorSupport::requiresCustomConverter)) {
+                parentModel.vendorExtensions.put("x-use-polymorphic-converter", Boolean.TRUE);
+            }
 
             CodegenProperty discriminatorProperty = DiscriminatorSupport.property(parentModel, discriminatorKey);
             removeRenderedDiscriminatorProperty(parentModel, discriminatorKey);
@@ -1222,6 +1222,17 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                 }
             }
         });
+    }
+
+    private Map<String, Object> polymorphicSubtype(String name, String alias) {
+        String fieldBase = toVarName(name);
+        Map<String, Object> result = new LinkedHashMap<>();
+        result.put("alias", alias);
+        result.put("aliasLiteral", JavaStringLiterals.toJavaStringLiteral(alias));
+        result.put("deserializerField", fieldBase + "Deserializer");
+        result.put("name", name);
+        result.put("serializerField", fieldBase + "Serializer");
+        return result;
     }
 
     private void applyUnionDiscriminatorRepresentation(CodegenModel unionModel,

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -488,6 +488,20 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         boolean hasDeclaredProperties = hasDeclaredProperties(schema);
         model.vendorExtensions.put("x-has-declared-properties", hasDeclaredProperties);
         model.vendorExtensions.put("x-schema-nullable", Boolean.TRUE.equals(schema.getNullable()));
+        Object discriminatorValue = extensionValue(schema, "x-discriminator-value");
+        if (discriminatorValue == null && schema.getAllOf() != null) {
+            for (Object memberObject : schema.getAllOf()) {
+                if (memberObject instanceof Schema<?> member) {
+                    discriminatorValue = extensionValue(member, "x-discriminator-value");
+                    if (discriminatorValue != null) {
+                        break;
+                    }
+                }
+            }
+        }
+        if (discriminatorValue != null && !discriminatorValue.toString().isBlank()) {
+            model.vendorExtensions.put("x-declared-discriminator-value", discriminatorValue.toString());
+        }
         Object representation = extensionValue(schema, EXT_DISCRIMINATOR_REPRESENTATION);
         if (representation != null) {
             DiscriminatorRepresentation parsed = parseDiscriminatorRepresentation(representation,
@@ -960,10 +974,13 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             model.vendorExtensions.put("x-render-vars", model.vars);
         }
         for (CodegenModel model : models) {
+            if (model.oneOf.isEmpty() && model.anyOf.isEmpty() && !model.allOf.isEmpty()) {
+                normalizeAllOfModel(model, modelsByClassname);
+            }
+        }
+        for (CodegenModel model : models) {
             if ((!model.oneOf.isEmpty() || !model.anyOf.isEmpty()) && shouldRenderAsUnionInterface(model)) {
                 normalizeUnionModel(model, modelsByClassname, unionInterfacesByMember);
-            } else if (!model.allOf.isEmpty()) {
-                normalizeAllOfModel(model, modelsByClassname);
             }
         }
     }
@@ -1097,7 +1114,6 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
     private void applyAllOfDiscriminatorHierarchy(List<CodegenModel> models,
                                                   Map<String, CodegenModel> modelsByClassname) {
         Map<String, List<String>> subtypeNamesByParent = new LinkedHashMap<>();
-        Map<String, String> parentBySubtype = new LinkedHashMap<>();
 
         for (CodegenModel model : models) {
             String parentType = (String) model.vendorExtensions.get("x-extends-model");
@@ -1105,20 +1121,31 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                 continue;
             }
 
-            CodegenModel parentModel = modelsByClassname.get(parentType);
-            if (parentModel == null || parentModel.discriminator == null) {
+            if (!modelsByClassname.containsKey(parentType)) {
                 continue;
             }
             subtypeNamesByParent.computeIfAbsent(parentType, ignored -> new ArrayList<>()).add(model.classname);
-            parentBySubtype.put(model.classname, parentType);
         }
 
         Map<String, Map<String, String>> aliasesByParent = new LinkedHashMap<>();
-        subtypeNamesByParent.forEach((parentType, subtypeNames) -> {
+        List<String> parentTypes = new ArrayList<>(subtypeNamesByParent.keySet());
+        parentTypes.sort((left, right) -> Integer.compare(hierarchyDepth(left, subtypeNamesByParent),
+                                                          hierarchyDepth(right, subtypeNamesByParent)));
+        parentTypes.forEach(parentType -> {
             CodegenModel parentModel = modelsByClassname.get(parentType);
             if (parentModel != null && parentModel.discriminator != null) {
+                List<String> concreteSubtypeNames = concreteSubtypeNames(parentType, subtypeNamesByParent);
+                Map<String, String> descendantAliases = descendantAliases(parentType,
+                                                                           concreteSubtypeNames,
+                                                                           aliasesByParent,
+                                                                           subtypeNamesByParent,
+                                                                           modelsByClassname);
                 aliasesByParent.put(parentType,
-                                    validateAndResolveAliases(parentModel, subtypeNames, modelsByClassname));
+                                    validateAndResolveAliases(parentModel,
+                                                              concreteSubtypeNames,
+                                                              descendantAliases,
+                                                              subtypeNamesByParent,
+                                                              modelsByClassname));
             }
         });
 
@@ -1134,13 +1161,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             }
 
             List<String> concreteSubtypeNames = concreteSubtypeNames(parentType, subtypeNamesByParent);
-            Map<String, String> aliasesBySubtype = new LinkedHashMap<>();
-            for (String concreteSubtypeName : concreteSubtypeNames) {
-                String directParent = parentBySubtype.get(concreteSubtypeName);
-                aliasesBySubtype.put(concreteSubtypeName,
-                                     aliasesByParent.getOrDefault(directParent, Map.of())
-                                             .getOrDefault(concreteSubtypeName, concreteSubtypeName));
-            }
+            Map<String, String> aliasesBySubtype = aliasesByParent.getOrDefault(parentType, Map.of());
             Map<String, String> subtypeByAlias = new LinkedHashMap<>();
             aliasesBySubtype.forEach((subtype, alias) -> {
                 String previousSubtype = subtypeByAlias.putIfAbsent(alias, subtype);
@@ -1170,7 +1191,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
 
             CodegenProperty discriminatorProperty = discriminatorProperty(parentModel, discriminatorKey);
             removeRenderedDiscriminatorProperty(parentModel, discriminatorKey);
-            for (String subtypeName : subtypeNames) {
+            for (String subtypeName : descendantNames(parentType, subtypeNamesByParent)) {
                 removeRenderedDiscriminatorProperty(modelsByClassname.get(subtypeName), discriminatorKey);
             }
             DiscriminatorRepresentation representation = discriminatorRepresentation(parentModel,
@@ -1184,12 +1205,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                     parentModel.vendorExtensions.put("x-discriminator-enum-properties",
                                                      List.of(discriminatorProperty));
                 }
-                for (String subtypeName : subtypeNames) {
-                    if (subtypeNamesByParent.containsKey(subtypeName)) {
-                        // An intermediate polymorphic parent remains abstract; its concrete descendants
-                        // supply the discriminator accessor.
-                        continue;
-                    }
+                for (String subtypeName : concreteSubtypeNames) {
                     CodegenModel subtype = modelsByClassname.get(subtypeName);
                     String alias = aliasesBySubtype.get(subtypeName);
                     String valueExpression = discriminatorValueExpression(parentModel,
@@ -1210,6 +1226,79 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         LinkedHashSet<String> result = new LinkedHashSet<>();
         collectConcreteSubtypeNames(parentType, subtypeNamesByParent, new LinkedHashSet<>(), result);
         return new ArrayList<>(result);
+    }
+
+    private List<String> descendantNames(String parentType,
+                                         Map<String, List<String>> subtypeNamesByParent) {
+        LinkedHashSet<String> result = new LinkedHashSet<>();
+        collectDescendantNames(parentType, subtypeNamesByParent, new LinkedHashSet<>(), result);
+        return new ArrayList<>(result);
+    }
+
+    private int hierarchyDepth(String parentType, Map<String, List<String>> subtypeNamesByParent) {
+        return hierarchyDepth(parentType, subtypeNamesByParent, new LinkedHashSet<>());
+    }
+
+    private int hierarchyDepth(String parentType,
+                               Map<String, List<String>> subtypeNamesByParent,
+                               Set<String> visiting) {
+        if (!visiting.add(parentType)) {
+            throw new IllegalStateException("Cyclic allOf discriminator hierarchy involving model '"
+                                                    + parentType + "'");
+        }
+        int depth = 0;
+        for (String subtypeName : subtypeNamesByParent.getOrDefault(parentType, List.of())) {
+            depth = Math.max(depth, 1 + hierarchyDepth(subtypeName, subtypeNamesByParent, visiting));
+        }
+        visiting.remove(parentType);
+        return depth;
+    }
+
+    private Map<String, String> descendantAliases(String parentType,
+                                                  List<String> concreteSubtypeNames,
+                                                  Map<String, Map<String, String>> aliasesByParent,
+                                                  Map<String, List<String>> subtypeNamesByParent,
+                                                  Map<String, CodegenModel> modelsByClassname) {
+        CodegenModel parent = modelsByClassname.get(parentType);
+        String discriminatorKey = discriminatorKey(parent);
+        Map<String, String> result = new LinkedHashMap<>();
+        List<String> descendants = descendantNames(parentType, subtypeNamesByParent);
+        for (String concreteSubtypeName : concreteSubtypeNames) {
+            String selectedAlias = null;
+            int selectedDepth = -1;
+            for (String descendant : descendants) {
+                CodegenModel descendantModel = modelsByClassname.get(descendant);
+                Map<String, String> aliases = aliasesByParent.get(descendant);
+                if (aliases == null || !discriminatorKey.equals(discriminatorKey(descendantModel))
+                        || !aliases.containsKey(concreteSubtypeName)) {
+                    continue;
+                }
+                int depth = hierarchyDepth(descendant, subtypeNamesByParent);
+                if (depth > selectedDepth) {
+                    selectedAlias = aliases.get(concreteSubtypeName);
+                    selectedDepth = depth;
+                }
+            }
+            if (selectedAlias != null) {
+                result.put(concreteSubtypeName, selectedAlias);
+            }
+        }
+        return result;
+    }
+
+    private void collectDescendantNames(String parentType,
+                                        Map<String, List<String>> subtypeNamesByParent,
+                                        Set<String> visiting,
+                                        Set<String> result) {
+        if (!visiting.add(parentType)) {
+            throw new IllegalStateException("Cyclic allOf discriminator hierarchy involving model '"
+                                                    + parentType + "'");
+        }
+        for (String subtypeName : subtypeNamesByParent.getOrDefault(parentType, List.of())) {
+            result.add(subtypeName);
+            collectDescendantNames(subtypeName, subtypeNamesByParent, visiting, result);
+        }
+        visiting.remove(parentType);
     }
 
     private void collectConcreteSubtypeNames(String parentType,
@@ -1235,9 +1324,15 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                                                         Map<String, CodegenModel> modelsByClassname,
                                                         String discriminatorKey,
                                                         List<Map<String, Object>> unionMembers) {
-        boolean declared = members.stream()
+        List<DiscriminatorProperty> discriminatorProperties = members.stream()
                 .map(modelsByClassname::get)
-                .anyMatch(model -> discriminatorProperty(model, discriminatorKey) != null);
+                .map(model -> inheritedDiscriminatorProperty(model, discriminatorKey, modelsByClassname))
+                .filter(java.util.Objects::nonNull)
+                .toList();
+        DiscriminatorProperty discriminatorProperty = commonDiscriminatorProperty(unionModel,
+                                                                                    discriminatorKey,
+                                                                                    discriminatorProperties);
+        boolean declared = discriminatorProperty != null;
         for (String member : members) {
             removeRenderedDiscriminatorProperty(modelsByClassname.get(member), discriminatorKey);
         }
@@ -1246,22 +1341,90 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             return;
         }
 
-        Map<String, Object> abstractAccessor = discriminatorAccessor(discriminatorKey,
-                                                                      null,
-                                                                      null);
+        Map<String, Object> abstractAccessor = unionDiscriminatorAccessor(discriminatorKey,
+                                                                          discriminatorProperty,
+                                                                          null);
         addDiscriminatorAccessor(unionModel, "x-abstract-discriminator-accessors", abstractAccessor);
         for (Map<String, Object> unionMember : unionMembers) {
             CodegenModel member = modelsByClassname.get(unionMember.get("name").toString());
+            String valueExpression = discriminatorProperty == null
+                    ? unionMember.get("aliasLiteral").toString()
+                    : discriminatorValueExpression(discriminatorProperty.owner(),
+                                                   discriminatorKey,
+                                                   unionMember.get("alias").toString());
             addDiscriminatorAccessor(member,
                                      "x-concrete-discriminator-accessors",
-                                     discriminatorAccessor(discriminatorKey,
-                                                           null,
-                                                           unionMember.get("aliasLiteral").toString()));
+                                     unionDiscriminatorAccessor(discriminatorKey,
+                                                                 discriminatorProperty,
+                                                                 valueExpression));
         }
+    }
+
+    private DiscriminatorProperty commonDiscriminatorProperty(CodegenModel unionModel,
+                                                               String discriminatorKey,
+                                                               List<DiscriminatorProperty> properties) {
+        if (properties.isEmpty()) {
+            return null;
+        }
+        DiscriminatorProperty first = properties.getFirst();
+        String expectedType = qualifiedDiscriminatorType(first);
+        for (DiscriminatorProperty candidate : properties) {
+            if (!expectedType.equals(qualifiedDiscriminatorType(candidate))) {
+                throw discriminatorMappingFailure(unionModel,
+                                                   "members expose incompatible Java types for discriminator property '"
+                                                           + discriminatorKey + "': '" + expectedType + "' and '"
+                                                           + qualifiedDiscriminatorType(candidate) + "'");
+            }
+        }
+        return first;
+    }
+
+    private DiscriminatorProperty inheritedDiscriminatorProperty(CodegenModel model,
+                                                                  String discriminatorKey,
+                                                                  Map<String, CodegenModel> modelsByClassname) {
+        Set<String> visited = new LinkedHashSet<>();
+        CodegenModel current = model;
+        while (current != null && visited.add(current.classname)) {
+            CodegenProperty local = discriminatorProperty(renderVars(current), discriminatorKey);
+            if (local != null) {
+                return new DiscriminatorProperty(current, local);
+            }
+            Object parent = current.vendorExtensions.get("x-extends-model");
+            current = parent instanceof String parentName ? modelsByClassname.get(parentName) : null;
+        }
+        CodegenProperty inherited = discriminatorProperty(model, discriminatorKey);
+        return inherited == null ? null : new DiscriminatorProperty(model, inherited);
+    }
+
+    private Map<String, Object> unionDiscriminatorAccessor(String discriminatorKey,
+                                                           DiscriminatorProperty discriminatorProperty,
+                                                           String valueExpression) {
+        if (discriminatorProperty == null) {
+            return discriminatorAccessor(discriminatorKey, null, valueExpression);
+        }
+        Map<String, Object> result = discriminatorAccessor(discriminatorKey,
+                                                            discriminatorProperty.property(),
+                                                            valueExpression);
+        result.put("type", qualifiedDiscriminatorType(discriminatorProperty));
+        return result;
+    }
+
+    private String qualifiedDiscriminatorType(DiscriminatorProperty discriminatorProperty) {
+        CodegenProperty property = discriminatorProperty.property();
+        String type = property.datatypeWithEnum == null ? property.dataType : property.datatypeWithEnum;
+        return property.isEnum ? discriminatorProperty.owner().classname + "." + type : type;
     }
 
     private Map<String, String> validateAndResolveAliases(CodegenModel owner,
                                                           List<String> subtypeNames,
+                                                          Map<String, CodegenModel> modelsByClassname) {
+        return validateAndResolveAliases(owner, subtypeNames, Map.of(), Map.of(), modelsByClassname);
+    }
+
+    private Map<String, String> validateAndResolveAliases(CodegenModel owner,
+                                                          List<String> concreteSubtypeNames,
+                                                          Map<String, String> descendantAliases,
+                                                          Map<String, List<String>> subtypeNamesByParent,
                                                           Map<String, CodegenModel> modelsByClassname) {
         Map<String, List<String>> explicitAliasesBySubtype = new LinkedHashMap<>();
         Map<String, String> mapping = rawDiscriminatorMappingsBySchema.get(owner.schemaName);
@@ -1276,18 +1439,23 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                 if (owner.classname.equals(target)) {
                     throw unsupportedSelfMapping(owner, alias, targetRef);
                 }
-                if (target == null || !subtypeNames.contains(target) || !modelsByClassname.containsKey(target)) {
+                List<String> resolvedTargets = mappingTargets(target,
+                                                              concreteSubtypeNames,
+                                                              subtypeNamesByParent,
+                                                              modelsByClassname);
+                if (resolvedTargets.size() != 1) {
                     throw discriminatorMappingFailure(owner,
                                                       "alias '" + alias + "' targets '"
                                                               + sanitizeDiagnosticReference(targetRef)
                                                               + "', which does not resolve to exactly one concrete subtype");
                 }
-                explicitAliasesBySubtype.computeIfAbsent(target, ignored -> new ArrayList<>()).add(alias);
+                explicitAliasesBySubtype.computeIfAbsent(resolvedTargets.getFirst(), ignored -> new ArrayList<>())
+                        .add(alias);
             }
         }
 
         Map<String, String> result = new LinkedHashMap<>();
-        for (String subtypeName : subtypeNames) {
+        for (String subtypeName : concreteSubtypeNames) {
             List<String> aliases = explicitAliasesBySubtype.getOrDefault(subtypeName, List.of());
             if (aliases.size() > 1) {
                 throw discriminatorMappingFailure(owner,
@@ -1299,12 +1467,31 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                 continue;
             }
             CodegenModel subtype = modelsByClassname.get(subtypeName);
-            String implicitAlias = subtype.schemaName == null || subtype.schemaName.isBlank()
-                    ? subtypeName
-                    : subtype.schemaName;
+            Object declaredValue = subtype.vendorExtensions.get("x-declared-discriminator-value");
+            String implicitAlias = declaredValue == null || declaredValue.toString().isBlank()
+                    ? descendantAliases.getOrDefault(subtypeName,
+                            subtype.schemaName == null || subtype.schemaName.isBlank() ? subtypeName : subtype.schemaName)
+                    : declaredValue.toString();
             result.put(subtypeName, implicitAlias);
         }
         return result;
+    }
+
+    private List<String> mappingTargets(String target,
+                                        List<String> concreteSubtypeNames,
+                                        Map<String, List<String>> subtypeNamesByParent,
+                                        Map<String, CodegenModel> modelsByClassname) {
+        if (target == null || !modelsByClassname.containsKey(target)) {
+            return List.of();
+        }
+        if (concreteSubtypeNames.contains(target)) {
+            return List.of(target);
+        }
+        if (!subtypeNamesByParent.containsKey(target)) {
+            return List.of();
+        }
+        List<String> descendants = concreteSubtypeNames(target, subtypeNamesByParent);
+        return concreteSubtypeNames.containsAll(descendants) ? descendants : List.of();
     }
 
     private IllegalStateException unsupportedSelfMapping(CodegenModel owner, String alias, String targetRef) {
@@ -1410,7 +1597,9 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                                                       CodegenProperty property,
                                                       String valueExpression) {
         Map<String, Object> result = new LinkedHashMap<>();
-        result.put("name", property == null ? toVarName(discriminatorKey) : property.name);
+        String name = property == null ? toVarName(discriminatorKey) : property.name;
+        result.put("name", name);
+        result.put("fieldName", name);
         result.put("nameLiteral", JavaStringLiterals.toJavaStringLiteral(discriminatorKey));
         result.put("type", property == null ? "String" : property.datatypeWithEnum);
         if (valueExpression != null) {
@@ -1434,7 +1623,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                 return;
             }
             throw new IllegalStateException("Contradictory discriminator accessor '" + accessor.get("name")
-                    + "' on model '" + model.classname + "'");
+                    + "' on model '" + model.classname + "': " + existing + " versus " + accessor);
         }
         accessors.add(accessor);
     }
@@ -1668,6 +1857,10 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         List<CodegenProperty> properties = parentModel.allVars != null && !parentModel.allVars.isEmpty()
                 ? parentModel.allVars
                 : parentModel.vars;
+        return discriminatorProperty(properties, discriminatorKey);
+    }
+
+    private CodegenProperty discriminatorProperty(List<CodegenProperty> properties, String discriminatorKey) {
         if (properties == null) {
             return null;
         }
@@ -1681,6 +1874,9 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             }
         }
         return null;
+    }
+
+    private record DiscriminatorProperty(CodegenModel owner, CodegenProperty property) {
     }
 
     /**

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -124,7 +124,6 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
     private boolean avoidOptionalListParams = false;
     private DiscriminatorRepresentation discriminatorRepresentation;
     private List<SecurityRequirement> globalSecurityRequirements = List.of();
-    private Map<String, String> rawAllOfDiscriminatorValuesBySchema = Map.of();
     private final JsonStringEnumSupport jsonStringEnums;
     private Map<String, Map<String, String>> rawDiscriminatorMappingsBySchema = Map.of();
 
@@ -1193,7 +1192,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             parentModel.vendorExtensions.put("x-polymorphic-subtypes", sortedSubtypes);
             parentModel.vendorExtensions.put("x-abstract-polymorphic-base", Boolean.TRUE);
 
-            CodegenProperty discriminatorProperty = discriminatorProperty(parentModel, discriminatorKey);
+            CodegenProperty discriminatorProperty = DiscriminatorSupport.property(parentModel, discriminatorKey);
             removeRenderedDiscriminatorProperty(parentModel, discriminatorKey);
             for (String subtypeName : hierarchy.descendantNames(parentType)) {
                 removeRenderedDiscriminatorProperty(modelsByClassname.get(subtypeName), discriminatorKey);
@@ -1204,7 +1203,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                 Map<String, Object> abstractAccessor = discriminatorAccessor(discriminatorKey,
                                                                               discriminatorProperty,
                                                                               null);
-                addDiscriminatorAccessor(parentModel, "x-abstract-discriminator-accessors", abstractAccessor);
+                DiscriminatorSupport.addAccessor(parentModel, "x-abstract-discriminator-accessors", abstractAccessor);
                 if (discriminatorProperty != null && discriminatorProperty.isEnum) {
                     parentModel.vendorExtensions.put("x-discriminator-enum-properties",
                                                      List.of(discriminatorProperty));
@@ -1215,7 +1214,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                     String valueExpression = discriminatorValueExpression(parentModel,
                                                                           discriminatorKey,
                                                                           alias);
-                    addDiscriminatorAccessor(subtype,
+                    DiscriminatorSupport.addAccessor(subtype,
                                              "x-concrete-discriminator-accessors",
                                              discriminatorAccessor(discriminatorKey,
                                                                    discriminatorProperty,
@@ -1235,8 +1234,8 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                 .map(model -> DiscriminatorSupport.inheritedProperty(model,
                                                                       discriminatorKey,
                                                                       modelsByClassname,
-                                                                      this::renderVars,
-                                                                      this::discriminatorProperty))
+                                                                      DiscriminatorSupport::renderVars,
+                                                                      DiscriminatorSupport::property))
                 .filter(java.util.Objects::nonNull)
                 .toList();
         DiscriminatorSupport.Property discriminatorProperty = DiscriminatorSupport.commonProperty(
@@ -1255,7 +1254,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         Map<String, Object> abstractAccessor = unionDiscriminatorAccessor(discriminatorKey,
                                                                           discriminatorProperty,
                                                                           null);
-        addDiscriminatorAccessor(unionModel, "x-abstract-discriminator-accessors", abstractAccessor);
+        DiscriminatorSupport.addAccessor(unionModel, "x-abstract-discriminator-accessors", abstractAccessor);
         for (Map<String, Object> unionMember : unionMembers) {
             CodegenModel member = modelsByClassname.get(unionMember.get("name").toString());
             String valueExpression = discriminatorProperty == null
@@ -1263,7 +1262,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                     : discriminatorValueExpression(discriminatorProperty.owner(),
                                                    discriminatorKey,
                                                    unionMember.get("alias").toString());
-            addDiscriminatorAccessor(member,
+            DiscriminatorSupport.addAccessor(member,
                                      "x-concrete-discriminator-accessors",
                                      unionDiscriminatorAccessor(discriminatorKey,
                                                                  discriminatorProperty,
@@ -1338,7 +1337,9 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             if (declaredValue == null) {
                 Object shorthand = subtype.vendorExtensions.get("x-inline-discriminator-shorthand");
                 if (DiscriminatorSupport.isDeclaredEnumValue(
-                        discriminatorProperty(owner, discriminatorKey(owner)), shorthand, this::discriminatorEnumValues)) {
+                        DiscriminatorSupport.property(owner, discriminatorKey(owner)),
+                        shorthand,
+                        DiscriminatorSupport::enumValues)) {
                     declaredValue = shorthand;
                 }
             }
@@ -1415,14 +1416,10 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         if (model == null) {
             return;
         }
-        List<CodegenProperty> filtered = renderVars(model).stream()
-                .filter(property -> !isDiscriminatorProperty(property, discriminatorKey))
+        List<CodegenProperty> filtered = DiscriminatorSupport.renderVars(model).stream()
+                .filter(property -> !DiscriminatorSupport.isProperty(property, discriminatorKey))
                 .toList();
         model.vendorExtensions.put("x-render-vars", filtered);
-    }
-
-    private boolean isDiscriminatorProperty(CodegenProperty property, String discriminatorKey) {
-        return property != null && (discriminatorKey.equals(property.baseName) || discriminatorKey.equals(property.name));
     }
 
     private Map<String, Object> discriminatorAccessor(String discriminatorKey,
@@ -1440,25 +1437,6 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         return result;
     }
 
-    @SuppressWarnings("unchecked")
-    private void addDiscriminatorAccessor(CodegenModel model, String extensionName, Map<String, Object> accessor) {
-        if (model == null) {
-            return;
-        }
-        List<Map<String, Object>> accessors = (List<Map<String, Object>>) model.vendorExtensions
-                .computeIfAbsent(extensionName, ignored -> new ArrayList<>());
-        for (Map<String, Object> existing : accessors) {
-            if (!existing.get("name").equals(accessor.get("name"))) {
-                continue;
-            }
-            if (existing.equals(accessor)) {
-                return;
-            }
-            throw new IllegalStateException("Contradictory discriminator accessor '" + accessor.get("name")
-                    + "' on model '" + model.classname + "': " + existing + " versus " + accessor);
-        }
-        accessors.add(accessor);
-    }
 
     private Set<String> localAllOfPropertyNames(List<CodegenProperty> allOfSchemas,
                                                 CodegenProperty parentMember,
@@ -1626,35 +1604,10 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         return false;
     }
 
-    @SuppressWarnings("unchecked")
-    private List<String> discriminatorEnumValues(CodegenProperty property) {
-        if (property == null) {
-            return List.of();
-        }
-
-        if (property._enum != null && !property._enum.isEmpty()) {
-            return property._enum;
-        }
-
-        if (property.allowableValues == null) {
-            return List.of();
-        }
-
-        Object values = property.allowableValues.get("values");
-        if (values instanceof List<?> enumValues) {
-            return enumValues.stream()
-                    .filter(String.class::isInstance)
-                    .map(String.class::cast)
-                    .toList();
-        }
-
-        return List.of();
-    }
-
     private String discriminatorValueExpression(CodegenModel parentModel,
                                                 String discriminatorKey,
                                                 String discriminatorValue) {
-        CodegenProperty property = discriminatorProperty(parentModel, discriminatorKey);
+        CodegenProperty property = DiscriminatorSupport.property(parentModel, discriminatorKey);
         if (property == null) {
             return JavaStringLiterals.toJavaStringLiteral(discriminatorValue);
         }
@@ -1676,33 +1629,10 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             return null;
         }
 
-        for (String enumValue : discriminatorEnumValues(property)) {
+        for (String enumValue : DiscriminatorSupport.enumValues(property)) {
             String enumConstant = toEnumVarName(enumValue, "String");
             if (enumValue.equals(discriminatorValue)) {
                 return enumConstant;
-            }
-        }
-        return null;
-    }
-
-    private CodegenProperty discriminatorProperty(CodegenModel parentModel, String discriminatorKey) {
-        List<CodegenProperty> properties = parentModel.allVars != null && !parentModel.allVars.isEmpty()
-                ? parentModel.allVars
-                : parentModel.vars;
-        return discriminatorProperty(properties, discriminatorKey);
-    }
-
-    private CodegenProperty discriminatorProperty(List<CodegenProperty> properties, String discriminatorKey) {
-        if (properties == null) {
-            return null;
-        }
-
-        for (CodegenProperty property : properties) {
-            if (property == null) {
-                continue;
-            }
-            if (discriminatorKey.equals(property.baseName) || discriminatorKey.equals(property.name)) {
-                return property;
             }
         }
         return null;

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -502,6 +502,10 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         if (discriminatorValue != null && !discriminatorValue.toString().isBlank()) {
             model.vendorExtensions.put("x-declared-discriminator-value", discriminatorValue.toString());
         }
+        String legacyDiscriminatorValue = DiscriminatorSupport.inlineShorthand(schema);
+        if (legacyDiscriminatorValue != null) {
+            model.vendorExtensions.put("x-inline-discriminator-shorthand", legacyDiscriminatorValue);
+        }
         Object representation = extensionValue(schema, EXT_DISCRIMINATOR_REPRESENTATION);
         if (representation != null) {
             DiscriminatorRepresentation parsed = parseDiscriminatorRepresentation(representation,
@@ -1317,7 +1321,6 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
                         .add(alias);
             }
         }
-
         Map<String, String> result = new LinkedHashMap<>();
         for (String subtypeName : concreteSubtypeNames) {
             List<String> aliases = explicitAliasesBySubtype.getOrDefault(subtypeName, List.of());
@@ -1332,6 +1335,13 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
             }
             CodegenModel subtype = modelsByClassname.get(subtypeName);
             Object declaredValue = subtype.vendorExtensions.get("x-declared-discriminator-value");
+            if (declaredValue == null) {
+                Object shorthand = subtype.vendorExtensions.get("x-inline-discriminator-shorthand");
+                if (DiscriminatorSupport.isDeclaredEnumValue(
+                        discriminatorProperty(owner, discriminatorKey(owner)), shorthand, this::discriminatorEnumValues)) {
+                    declaredValue = shorthand;
+                }
+            }
             String implicitAlias = declaredValue == null || declaredValue.toString().isBlank()
                     ? descendantAliases.getOrDefault(subtypeName,
                             subtype.schemaName == null || subtype.schemaName.isBlank() ? subtypeName : subtype.schemaName)

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/UnionBranchConstraints.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/UnionBranchConstraints.java
@@ -26,6 +26,9 @@ import java.util.stream.Collectors;
 import org.openapitools.codegen.CodegenModel;
 import org.openapitools.codegen.CodegenProperty;
 
+/**
+ * Renders the structural JSON constraints used to distinguish union branches.
+ */
 final class UnionBranchConstraints {
 
     private UnionBranchConstraints() {

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
@@ -44,6 +44,21 @@ import io.helidon.json.binding.JsonDeserializer;
 import io.helidon.json.binding.JsonSerializer;
 import io.helidon.service.registry.Service;
 {{/vendorExtensions.x-use-union-converter}}{{/model}}
+{{#model}}{{#vendorExtensions.x-use-polymorphic-converter}}import java.io.ByteArrayOutputStream;
+import java.util.Set;
+import io.helidon.common.GenericType;
+import io.helidon.json.JsonGenerator;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonParser;
+import io.helidon.json.JsonValue;
+import io.helidon.json.JsonValueType;
+import io.helidon.json.binding.JsonBindingFactory;
+import io.helidon.json.binding.JsonBindingConfigurator;
+import io.helidon.json.binding.JsonConverter;
+import io.helidon.json.binding.JsonDeserializer;
+import io.helidon.json.binding.JsonSerializer;
+import io.helidon.service.registry.Service;
+{{/vendorExtensions.x-use-polymorphic-converter}}{{/model}}
 {{#imports}}
 import {{import}};
 {{/imports}}
@@ -387,10 +402,12 @@ final class {{classname}}JsonBindingFactory implements JsonBindingFactory<{{clas
         return Set.of({{classname}}.class);
     }
 }
-{{/vendorExtensions.x-use-union-converter}}{{/vendorExtensions.x-is-union-interface}}{{^vendorExtensions.x-is-union-interface}}@Json.Entity
+{{/vendorExtensions.x-use-union-converter}}{{/vendorExtensions.x-is-union-interface}}{{^vendorExtensions.x-is-union-interface}}{{#vendorExtensions.x-use-polymorphic-converter}}@Json.Converter({{classname}}.{{classname}}JsonConverter.class)
+{{/vendorExtensions.x-use-polymorphic-converter}}{{^vendorExtensions.x-use-polymorphic-converter}}@Json.Entity
 {{#vendorExtensions.x-has-polymorphic-subtypes}}@Json.Polymorphic(key = {{{vendorExtensions.x-polymorphic-key-literal}}})
 {{#vendorExtensions.x-polymorphic-subtypes}}@Json.Subtype(alias = {{{aliasLiteral}}}, value = {{name}}.class)
 {{/vendorExtensions.x-polymorphic-subtypes}}{{/vendorExtensions.x-has-polymorphic-subtypes}}
+{{/vendorExtensions.x-use-polymorphic-converter}}
 {{#isDeprecated}}@Deprecated
 {{/isDeprecated}}{{#vendorExtensions.x-has-validations}}@Validation.Validated
 {{/vendorExtensions.x-has-validations}}{{^vendorExtensions.x-abstract-polymorphic-base}}@Json.BuilderInfo({{classname}}.Builder.class)
@@ -654,6 +671,9 @@ final class {{classname}}JsonBindingFactory implements JsonBindingFactory<{{clas
     }
 
 {{/vendorExtensions.x-extends-model}}
+{{#vendorExtensions.x-use-polymorphic-converter}}{{>polymorphicClassConverter}}
+
+{{/vendorExtensions.x-use-polymorphic-converter}}
 {{#vendorExtensions.x-inline-string-enums}}
 {{>nestedStringEnum}}
 
@@ -673,6 +693,8 @@ final class {{classname}}JsonBindingFactory implements JsonBindingFactory<{{clas
 
 {{/vendorExtensions.x-enum-wire-constraints-validated}}{{/isEnum}}{{/vendorExtensions.x-render-vars}}
 }
+{{#vendorExtensions.x-use-polymorphic-converter}}{{>polymorphicClassConverterFactory}}
+{{/vendorExtensions.x-use-polymorphic-converter}}
 {{#vendorExtensions.x-inline-string-enums}}
 
 {{>stringEnumConverter}}

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
@@ -59,6 +59,15 @@ import {{import}};
 {{#isDeprecated}}@Deprecated
 {{/isDeprecated}}public interface {{classname}} {
 
+{{#vendorExtensions.x-abstract-discriminator-accessors}}    /**
+     * Canonical OpenAPI discriminator value for the runtime subtype.
+     *
+     * @return exact declared discriminator alias
+     */
+    @Json.Ignore
+    {{{type}}} {{name}}();
+
+{{/vendorExtensions.x-abstract-discriminator-accessors}}
     final class {{classname}}JsonConverter implements JsonConverter<{{classname}}> {
 {{#vendorExtensions.x-union-members}}
         private JsonDeserializer<{{name}}> {{deserializerField}};
@@ -96,7 +105,11 @@ import {{import}};
 {{#vendorExtensions.x-has-union-discriminator}}
             String discriminatorValue = jsonObject.stringValue({{{vendorExtensions.x-union-discriminator-key-literal}}}).orElse(null);
             if (discriminatorValue != null) {
-                {{classname}} discriminatorMatch = deserializeByAlias(discriminatorValue, jsonObject);
+                JsonObject modelObject = JsonObject.builder()
+                        .from(jsonObject)
+                        .unset({{{vendorExtensions.x-union-discriminator-key-literal}}})
+                        .build();
+                {{classname}} discriminatorMatch = deserializeByAlias(discriminatorValue, modelObject);
                 if (discriminatorMatch != null) {
                     return discriminatorMatch;
                 }
@@ -370,22 +383,7 @@ final class {{classname}}JsonBindingFactory implements JsonBindingFactory<{{clas
         return Set.of({{classname}}.class);
     }
 }
-{{/vendorExtensions.x-use-union-converter}}{{#vendorExtensions.x-use-polymorphic-union}}@Json.Entity
-@Json.Polymorphic(key = {{{vendorExtensions.x-polymorphic-key-literal}}})
-{{#vendorExtensions.x-polymorphic-subtypes}}@Json.Subtype(alias = {{{aliasLiteral}}}, value = {{name}}.class)
-{{/vendorExtensions.x-polymorphic-subtypes}}{{#isDeprecated}}@Deprecated
-{{/isDeprecated}}public interface {{classname}} {
-
-{{#vendorExtensions.x-abstract-discriminator-accessors}}    /**
-     * Canonical OpenAPI discriminator value for the runtime subtype.
-     *
-     * @return exact declared discriminator alias
-     */
-    @Json.Ignore
-    {{{type}}} {{name}}();
-
-{{/vendorExtensions.x-abstract-discriminator-accessors}}}
-{{/vendorExtensions.x-use-polymorphic-union}}{{/vendorExtensions.x-is-union-interface}}{{^vendorExtensions.x-is-union-interface}}@Json.Entity
+{{/vendorExtensions.x-use-union-converter}}{{/vendorExtensions.x-is-union-interface}}{{^vendorExtensions.x-is-union-interface}}@Json.Entity
 {{#vendorExtensions.x-has-polymorphic-subtypes}}@Json.Polymorphic(key = {{{vendorExtensions.x-polymorphic-key-literal}}})
 {{#vendorExtensions.x-polymorphic-subtypes}}@Json.Subtype(alias = {{{aliasLiteral}}}, value = {{name}}.class)
 {{/vendorExtensions.x-polymorphic-subtypes}}{{/vendorExtensions.x-has-polymorphic-subtypes}}
@@ -535,6 +533,7 @@ final class {{classname}}JsonBindingFactory implements JsonBindingFactory<{{clas
     }
 
 {{/vendorExtensions.x-extends-model}}{{#vendorExtensions.x-extends-model}}
+{{^vendorExtensions.x-abstract-polymorphic-base}}
     /**
      * Create a builder for {@link {{classname}}}.
      *
@@ -581,6 +580,7 @@ final class {{classname}}JsonBindingFactory implements JsonBindingFactory<{{clas
         }
     }
 
+{{/vendorExtensions.x-abstract-polymorphic-base}}
     /**
      * Base builder for {@link {{classname}}}.
      *

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
@@ -316,7 +316,7 @@ import {{import}};
 
 {{#vendorExtensions.x-union-members}}
         private {{classname}} deserialize{{name}}(JsonObject jsonObject) {
-            return {{deserializerField}}.deserialize(JsonParser.create(jsonObject));
+            return {{deserializerField}}.deserialize(JsonParser.create(jsonObject.toString()));
         }
 
         private JsonObject serialize{{name}}({{name}} instance, boolean writeNulls) {
@@ -398,7 +398,7 @@ final class {{classname}}JsonBindingFactory implements JsonBindingFactory<{{clas
 
 {{#vendorExtensions.x-concrete-discriminator-accessors}}    /** Canonical discriminator used by direct Helidon JSON binding. */
     @Json.Property({{{nameLiteral}}})
-    private {{{type}}} {{name}} = {{{valueExpression}}};
+    private {{{type}}} {{fieldName}} = {{{valueExpression}}};
 
 {{/vendorExtensions.x-concrete-discriminator-accessors}}
 {{#vendorExtensions.x-render-vars}}

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
@@ -25,7 +25,7 @@ import io.helidon.json.binding.JsonConverter;
 import io.helidon.service.registry.Service;
 {{#vendorExtensions.x-has-http-enum-mappers}}import io.helidon.common.mapper.Mapper;
 {{/vendorExtensions.x-has-http-enum-mappers}}{{/vendorExtensions.x-has-string-enums}}{{/model}}
-{{#model}}{{#vendorExtensions.x-is-union-interface}}import java.io.ByteArrayOutputStream;
+{{#model}}{{#vendorExtensions.x-use-union-converter}}import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -43,7 +43,7 @@ import io.helidon.json.binding.JsonConverter;
 import io.helidon.json.binding.JsonDeserializer;
 import io.helidon.json.binding.JsonSerializer;
 import io.helidon.service.registry.Service;
-{{/vendorExtensions.x-is-union-interface}}{{/model}}
+{{/vendorExtensions.x-use-union-converter}}{{/model}}
 {{#imports}}
 import {{import}};
 {{/imports}}
@@ -55,7 +55,7 @@ import {{import}};
 {{#vendorExtensions.x-top-level-string-enum}}{{>stringEnum}}
 
 {{>stringEnumConverter}}
-{{/vendorExtensions.x-top-level-string-enum}}{{^vendorExtensions.x-top-level-string-enum}}{{#vendorExtensions.x-is-union-interface}}@Json.Converter({{classname}}.{{classname}}JsonConverter.class)
+{{/vendorExtensions.x-top-level-string-enum}}{{^vendorExtensions.x-top-level-string-enum}}{{#vendorExtensions.x-is-union-interface}}{{#vendorExtensions.x-use-union-converter}}@Json.Converter({{classname}}.{{classname}}JsonConverter.class)
 {{#isDeprecated}}@Deprecated
 {{/isDeprecated}}public interface {{classname}} {
 
@@ -370,14 +370,29 @@ final class {{classname}}JsonBindingFactory implements JsonBindingFactory<{{clas
         return Set.of({{classname}}.class);
     }
 }
-{{/vendorExtensions.x-is-union-interface}}{{^vendorExtensions.x-is-union-interface}}@Json.Entity
+{{/vendorExtensions.x-use-union-converter}}{{#vendorExtensions.x-use-polymorphic-union}}@Json.Entity
+@Json.Polymorphic(key = {{{vendorExtensions.x-polymorphic-key-literal}}})
+{{#vendorExtensions.x-polymorphic-subtypes}}@Json.Subtype(alias = {{{aliasLiteral}}}, value = {{name}}.class)
+{{/vendorExtensions.x-polymorphic-subtypes}}{{#isDeprecated}}@Deprecated
+{{/isDeprecated}}public interface {{classname}} {
+
+{{#vendorExtensions.x-abstract-discriminator-accessors}}    /**
+     * Canonical OpenAPI discriminator value for the runtime subtype.
+     *
+     * @return exact declared discriminator alias
+     */
+    @Json.Ignore
+    {{{type}}} {{name}}();
+
+{{/vendorExtensions.x-abstract-discriminator-accessors}}}
+{{/vendorExtensions.x-use-polymorphic-union}}{{/vendorExtensions.x-is-union-interface}}{{^vendorExtensions.x-is-union-interface}}@Json.Entity
 {{#vendorExtensions.x-has-polymorphic-subtypes}}@Json.Polymorphic(key = {{{vendorExtensions.x-polymorphic-key-literal}}})
 {{#vendorExtensions.x-polymorphic-subtypes}}@Json.Subtype(alias = {{{aliasLiteral}}}, value = {{name}}.class)
 {{/vendorExtensions.x-polymorphic-subtypes}}{{/vendorExtensions.x-has-polymorphic-subtypes}}
 {{#isDeprecated}}@Deprecated
 {{/isDeprecated}}{{#vendorExtensions.x-has-validations}}@Validation.Validated
-{{/vendorExtensions.x-has-validations}}@Json.BuilderInfo({{classname}}.Builder.class)
-public class {{classname}}{{#vendorExtensions.x-extends-model}} extends {{vendorExtensions.x-extends-model}}{{/vendorExtensions.x-extends-model}}{{#vendorExtensions.x-has-implements-models}} implements {{#vendorExtensions.x-implements-models}}{{name}}{{^last}}, {{/last}}{{/vendorExtensions.x-implements-models}}{{/vendorExtensions.x-has-implements-models}} {
+{{/vendorExtensions.x-has-validations}}{{^vendorExtensions.x-abstract-polymorphic-base}}@Json.BuilderInfo({{classname}}.Builder.class)
+{{/vendorExtensions.x-abstract-polymorphic-base}}public {{#vendorExtensions.x-abstract-polymorphic-base}}abstract {{/vendorExtensions.x-abstract-polymorphic-base}}class {{classname}}{{#vendorExtensions.x-extends-model}} extends {{vendorExtensions.x-extends-model}}{{/vendorExtensions.x-extends-model}}{{#vendorExtensions.x-has-implements-models}} implements {{#vendorExtensions.x-implements-models}}{{name}}{{^last}}, {{/last}}{{/vendorExtensions.x-implements-models}}{{/vendorExtensions.x-has-implements-models}} {
 
 {{#vendorExtensions.x-render-vars}}
     {{#description}}/** {{description}} */
@@ -386,10 +401,29 @@ public class {{classname}}{{#vendorExtensions.x-extends-model}} extends {{vendor
 
 {{/vendorExtensions.x-render-vars}}
     /** No-arg constructor. */
-    public {{classname}}() {
-{{#vendorExtensions.x-has-allof-discriminator-setter}}        {{vendorExtensions.x-allof-discriminator-setter}}({{{vendorExtensions.x-allof-discriminator-value-expression}}});
-{{/vendorExtensions.x-has-allof-discriminator-setter}}
+    {{#vendorExtensions.x-abstract-polymorphic-base}}protected{{/vendorExtensions.x-abstract-polymorphic-base}}{{^vendorExtensions.x-abstract-polymorphic-base}}public{{/vendorExtensions.x-abstract-polymorphic-base}} {{classname}}() {
     }
+
+{{#vendorExtensions.x-abstract-discriminator-accessors}}    /**
+     * Canonical OpenAPI discriminator value for the runtime subtype.
+     *
+     * @return exact declared discriminator alias
+     */
+    @Json.Ignore
+    public abstract {{{type}}} {{name}}();
+
+{{/vendorExtensions.x-abstract-discriminator-accessors}}{{#vendorExtensions.x-concrete-discriminator-accessors}}    /**
+     * Canonical OpenAPI discriminator value for this subtype.
+     *
+     * @return exact declared discriminator alias
+     */
+    @Override
+    @Json.Ignore
+    public {{{type}}} {{name}}() {
+        return {{{valueExpression}}};
+    }
+
+{{/vendorExtensions.x-concrete-discriminator-accessors}}
 
 {{#vendorExtensions.x-render-vars}}
 {{#vendorExtensions.x-validation-annotations}}    {{{annotation}}}
@@ -403,6 +437,7 @@ public class {{classname}}{{#vendorExtensions.x-extends-model}} extends {{vendor
 
 {{/vendorExtensions.x-render-vars}}
 {{^vendorExtensions.x-extends-model}}
+{{^vendorExtensions.x-abstract-polymorphic-base}}
     /**
      * Create a builder for {@link {{classname}}}.
      *
@@ -413,6 +448,8 @@ public class {{classname}}{{#vendorExtensions.x-extends-model}} extends {{vendor
         return new Builder();
     }
 
+{{/vendorExtensions.x-abstract-polymorphic-base}}
+{{^vendorExtensions.x-abstract-polymorphic-base}}
     /**
      * Builder for {@link {{classname}}}.
      */
@@ -448,6 +485,7 @@ public class {{classname}}{{#vendorExtensions.x-extends-model}} extends {{vendor
         }
     }
 
+{{/vendorExtensions.x-abstract-polymorphic-base}}
     /**
      * Base builder for {@link {{classname}}}.
      *
@@ -581,6 +619,13 @@ public class {{classname}}{{#vendorExtensions.x-extends-model}} extends {{vendor
 {{>nestedStringEnum}}
 
 {{/vendorExtensions.x-inline-string-enums}}
+{{#vendorExtensions.x-discriminator-enum-properties}}{{#isEnum}}
+    public enum {{datatypeWithEnum}} {
+        {{#allowableValues}}{{#enumVars}}{{name}}{{^-last}},
+        {{/-last}}{{/enumVars}};{{/allowableValues}}
+    }
+
+{{/isEnum}}{{/vendorExtensions.x-discriminator-enum-properties}}
 {{#vendorExtensions.x-render-vars}}{{#isEnum}}{{^vendorExtensions.x-enum-wire-constraints-validated}}
     public enum {{vendorExtensions.x-enum-name}} {
         {{#allowableValues}}{{#enumVars}}{{name}}{{^-last}},

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/model.mustache
@@ -64,10 +64,10 @@ import {{import}};
      *
      * @return exact declared discriminator alias
      */
-    @Json.Ignore
     {{{type}}} {{name}}();
 
 {{/vendorExtensions.x-abstract-discriminator-accessors}}
+    /** Helidon JSON converter for the complete {{classname}} union. */
     final class {{classname}}JsonConverter implements JsonConverter<{{classname}}> {
 {{#vendorExtensions.x-union-members}}
         private JsonDeserializer<{{name}}> {{deserializerField}};
@@ -116,8 +116,11 @@ import {{import}};
                 throw new IllegalArgumentException("Unsupported discriminator value '" + discriminatorValue
                         + "' for {{classname}}");
             }
-{{/vendorExtensions.x-has-union-discriminator}}
+            throw new IllegalArgumentException("Missing discriminator property "
+                    + {{{vendorExtensions.x-union-discriminator-key-literal}}} + " for {{classname}}");
+{{/vendorExtensions.x-has-union-discriminator}}{{^vendorExtensions.x-has-union-discriminator}}
             return deserializeStructurally(jsonObject);
+{{/vendorExtensions.x-has-union-discriminator}}
         }
 
         @Override
@@ -325,6 +328,7 @@ import {{import}};
 {{#vendorExtensions.x-has-union-discriminator}}
             return JsonObject.builder()
                     .from(jsonObject)
+                    .unset({{{vendorExtensions.x-union-discriminator-key-literal}}})
                     .set({{{vendorExtensions.x-union-discriminator-key-literal}}}, {{{aliasLiteral}}})
                     .build();
 {{/vendorExtensions.x-has-union-discriminator}}{{^vendorExtensions.x-has-union-discriminator}}
@@ -392,6 +396,11 @@ final class {{classname}}JsonBindingFactory implements JsonBindingFactory<{{clas
 {{/vendorExtensions.x-has-validations}}{{^vendorExtensions.x-abstract-polymorphic-base}}@Json.BuilderInfo({{classname}}.Builder.class)
 {{/vendorExtensions.x-abstract-polymorphic-base}}public {{#vendorExtensions.x-abstract-polymorphic-base}}abstract {{/vendorExtensions.x-abstract-polymorphic-base}}class {{classname}}{{#vendorExtensions.x-extends-model}} extends {{vendorExtensions.x-extends-model}}{{/vendorExtensions.x-extends-model}}{{#vendorExtensions.x-has-implements-models}} implements {{#vendorExtensions.x-implements-models}}{{name}}{{^last}}, {{/last}}{{/vendorExtensions.x-implements-models}}{{/vendorExtensions.x-has-implements-models}} {
 
+{{#vendorExtensions.x-concrete-discriminator-accessors}}    /** Canonical discriminator used by direct Helidon JSON binding. */
+    @Json.Property({{{nameLiteral}}})
+    private {{{type}}} {{name}} = {{{valueExpression}}};
+
+{{/vendorExtensions.x-concrete-discriminator-accessors}}
 {{#vendorExtensions.x-render-vars}}
     {{#description}}/** {{description}} */
     {{/description}}{{#vendorExtensions.x-json-required}}@Json.Required
@@ -414,9 +423,9 @@ final class {{classname}}JsonBindingFactory implements JsonBindingFactory<{{clas
      * Canonical OpenAPI discriminator value for this subtype.
      *
      * @return exact declared discriminator alias
-     */
+    */
     @Override
-    @Json.Ignore
+    @Json.Property({{{nameLiteral}}})
     public {{{type}}} {{name}}() {
         return {{{valueExpression}}};
     }
@@ -472,6 +481,21 @@ final class {{classname}}JsonBindingFactory implements JsonBindingFactory<{{clas
         }
 
 {{/vendorExtensions.x-render-vars}}
+{{#vendorExtensions.x-concrete-discriminator-accessors}}        /**
+         * Accept the canonical discriminator during JSON binding.
+         *
+         * @param {{name}} discriminator value
+         * @return this builder
+         */
+        public Builder {{name}}({{{type}}} {{name}}) {
+            if (!{{{valueExpression}}}.equals({{name}})) {
+                throw new IllegalArgumentException("Unsupported discriminator value '" + {{name}}
+                        + "' for {{classname}}");
+            }
+            return this;
+        }
+
+{{/vendorExtensions.x-concrete-discriminator-accessors}}
         /**
          * Build the instance.
          *
@@ -569,6 +593,21 @@ final class {{classname}}JsonBindingFactory implements JsonBindingFactory<{{clas
         }
 
 {{/vendorExtensions.x-render-vars}}
+{{#vendorExtensions.x-concrete-discriminator-accessors}}        /**
+         * Accept the canonical discriminator during JSON binding.
+         *
+         * @param {{name}} discriminator value
+         * @return this builder
+         */
+        public Builder {{name}}({{{type}}} {{name}}) {
+            if (!{{{valueExpression}}}.equals({{name}})) {
+                throw new IllegalArgumentException("Unsupported discriminator value '" + {{name}}
+                        + "' for {{classname}}");
+            }
+            return this;
+        }
+
+{{/vendorExtensions.x-concrete-discriminator-accessors}}
         /**
          * Build the instance.
          *

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/polymorphicClassConverter.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/polymorphicClassConverter.mustache
@@ -1,0 +1,105 @@
+{{!
+Copyright (c) 2026 Oracle and/or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+
+    /** Helidon JSON converter for the complete {{classname}} hierarchy. */
+    public static final class {{classname}}JsonConverter implements JsonConverter<{{classname}}> {
+{{#vendorExtensions.x-polymorphic-subtypes}}
+        private JsonDeserializer<{{name}}> {{deserializerField}};
+        private JsonSerializer<{{name}}> {{serializerField}};
+{{/vendorExtensions.x-polymorphic-subtypes}}
+
+        @Override
+        public GenericType<{{classname}}> type() {
+            return new GenericType<>() {
+            };
+        }
+
+        @Override
+        public void configure(JsonBindingConfigurator jsonBindingConfigurator) {
+{{#vendorExtensions.x-polymorphic-subtypes}}
+            this.{{deserializerField}} = jsonBindingConfigurator.deserializer({{name}}.class);
+            this.{{serializerField}} = jsonBindingConfigurator.serializer({{name}}.class);
+{{/vendorExtensions.x-polymorphic-subtypes}}
+        }
+
+        @Override
+        public {{classname}} deserialize(JsonParser parser) {
+            JsonValue jsonValue = parser.readJsonValue();
+            if (jsonValue.type() == JsonValueType.NULL) {
+                return null;
+            }
+            if (jsonValue.type() != JsonValueType.OBJECT) {
+                throw new IllegalArgumentException("Expected JSON object for {{classname}}, but found "
+                                                           + jsonValue.type());
+            }
+            JsonObject jsonObject = jsonValue.asObject();
+            String alias = jsonObject.stringValue({{{vendorExtensions.x-polymorphic-key-literal}}}).orElse(null);
+            if (alias == null) {
+                throw new IllegalArgumentException("Missing discriminator property "
+                                                           + {{{vendorExtensions.x-polymorphic-key-literal}}}
+                                                           + " for {{classname}}");
+            }
+            JsonObject modelObject = JsonObject.builder()
+                    .from(jsonObject)
+                    .unset({{{vendorExtensions.x-polymorphic-key-literal}}})
+                    .build();
+            return switch (alias) {
+{{#vendorExtensions.x-polymorphic-subtypes}}
+                case {{{aliasLiteral}}} -> {{deserializerField}}.deserialize(
+                        JsonParser.create(modelObject.toString()));
+{{/vendorExtensions.x-polymorphic-subtypes}}
+                default -> throw new IllegalArgumentException("Unsupported discriminator value '" + alias
+                                                                      + "' for {{classname}}");
+            };
+        }
+
+        @Override
+        public void serialize(JsonGenerator generator, {{classname}} instance, boolean writeNulls) {
+            if (instance == null) {
+                generator.writeNull();
+                return;
+            }
+            generator.write(serializeSubtype(instance, writeNulls));
+        }
+
+        private JsonObject serializeSubtype({{classname}} instance, boolean writeNulls) {
+{{#vendorExtensions.x-polymorphic-subtypes}}
+            if (instance instanceof {{name}} value) {
+                return withDiscriminator(serialize(value, {{serializerField}}, writeNulls), {{{aliasLiteral}}});
+            }
+{{/vendorExtensions.x-polymorphic-subtypes}}
+            throw new IllegalArgumentException("Unsupported subtype '" + instance.getClass().getName()
+                                                       + "' for {{classname}}");
+        }
+
+        private <T extends {{classname}}> JsonObject serialize(T instance,
+                                                               JsonSerializer<T> serializer,
+                                                               boolean writeNulls) {
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            try (JsonGenerator delegate = JsonGenerator.create(outputStream)) {
+                serializer.serialize(delegate, instance, writeNulls);
+            }
+            return JsonParser.create(outputStream.toByteArray()).readJsonObject();
+        }
+
+        private JsonObject withDiscriminator(JsonObject jsonObject, String alias) {
+            return JsonObject.builder()
+                    .from(jsonObject)
+                    .unset({{{vendorExtensions.x-polymorphic-key-literal}}})
+                    .set({{{vendorExtensions.x-polymorphic-key-literal}}}, alias)
+                    .build();
+        }
+    }

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/polymorphicClassConverterFactory.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/polymorphicClassConverterFactory.mustache
@@ -1,0 +1,45 @@
+
+{{!
+Copyright (c) 2026 Oracle and/or its affiliates.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+}}
+
+@Service.Singleton
+final class {{classname}}JsonBindingFactory implements JsonBindingFactory<{{classname}}> {
+
+    @Override
+    public JsonDeserializer<{{classname}}> createDeserializer(Class<? extends {{classname}}> type) {
+        return new {{classname}}.{{classname}}JsonConverter();
+    }
+
+    @Override
+    public JsonDeserializer<{{classname}}> createDeserializer(GenericType<? extends {{classname}}> type) {
+        return new {{classname}}.{{classname}}JsonConverter();
+    }
+
+    @Override
+    public JsonSerializer<{{classname}}> createSerializer(Class<? extends {{classname}}> type) {
+        return new {{classname}}.{{classname}}JsonConverter();
+    }
+
+    @Override
+    public JsonSerializer<{{classname}}> createSerializer(GenericType<? extends {{classname}}> type) {
+        return new {{classname}}.{{classname}}JsonConverter();
+    }
+
+    @Override
+    public Set<Class<?>> supportedTypes() {
+        return Set.of({{classname}}.class);
+    }
+}

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/polymorphicClassConverterFactory.mustache
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/resources/helidon-declarative/polymorphicClassConverterFactory.mustache
@@ -1,4 +1,3 @@
-
 {{!
 Copyright (c) 2026 Oracle and/or its affiliates.
 

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/AuthoritativeDiscriminatorGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/AuthoritativeDiscriminatorGenerationIT.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.openapi.generator;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.openapitools.codegen.DefaultGenerator;
+import org.openapitools.codegen.config.CodegenConfigurator;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AuthoritativeDiscriminatorGenerationIT {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void schemaDrivenDefaultsUseDeclaredReadOnlyPropertyAndMetadataOnly() throws Exception {
+        Path output = generate("default", null);
+        String base = model(output, "DeclaredBase");
+        String cat = model(output, "DeclaredCat");
+        String metadataChoice = model(output, "MetadataChoice");
+
+        assertThat(base, containsString("public abstract class DeclaredBase"));
+        assertThat(base, containsString("@Json.Subtype(alias = \"weird.alias\", value = DeclaredCat.class)"));
+        assertThat(base, containsString("@Json.Subtype(alias = \"MixedCase-2\", value = DeclaredDog.class)"));
+        assertThat(base, containsString("@Json.Subtype(alias = \"DeclaredBird\", value = DeclaredBird.class)"));
+        assertThat(base, containsString("public abstract String kind();"));
+        assertThat(base, not(containsString("private String kind;")));
+        assertThat(base, not(containsString("void kind(")));
+        assertThat(base, not(containsString("static BuilderBase<?, ? extends DeclaredBase> builder()")));
+        assertThat(cat, containsString("return \"weird.alias\";"));
+        assertThat(cat, not(containsString("void kind(")));
+
+        assertThat(metadataChoice, containsString("@Json.Polymorphic(key = \"category\")"));
+        assertThat(metadataChoice,
+                   containsString("@Json.Subtype(alias = \"alpha.v1\", value = MetadataAlpha.class)"));
+        assertThat(metadataChoice,
+                   containsString("@Json.Subtype(alias = \"MetadataBeta\", value = MetadataBeta.class)"));
+        assertThat(metadataChoice, not(containsString("String category();")));
+        assertThat(metadataChoice, not(containsString("JsonConverter")));
+    }
+
+    @Test
+    void globalModesAndSchemaOverridesUseDocumentedPrecedence() throws Exception {
+        Path metadata = generate("metadata", "metadata");
+        assertThat(model(metadata, "DeclaredBase"), not(containsString("String kind();")));
+        assertThat(model(metadata, "ForcedReadOnly"), containsString("String type();"));
+
+        Path readOnly = generate("read-only", "readOnlyProperty");
+        assertThat(model(readOnly, "MetadataChoice"), containsString("String category();"));
+        assertThat(model(readOnly, "ForcedMetadata"), not(containsString("String type();")));
+        assertThat(model(readOnly, "ForcedMetadataCat"), not(containsString("private String type;")));
+    }
+
+    @Test
+    void ambiguousUnresolvedAndSelfMappingsFailBeforeRendering() throws Exception {
+        RuntimeException ambiguous = generateFailure("ambiguous", """
+                Cat:
+                  type: object
+                  properties:
+                    cat:
+                      type: string
+                Dog:
+                  type: object
+                  properties:
+                    dog:
+                      type: string
+                Choice:
+                  oneOf:
+                    - $ref: '#/components/schemas/Cat'
+                    - $ref: '#/components/schemas/Dog'
+                  discriminator:
+                    propertyName: kind
+                    mapping:
+                      first: '#/components/schemas/Cat'
+                      second: '#/components/schemas/Cat'
+                """);
+        assertThat(rootMessage(ambiguous), containsString("multiple explicit aliases [first, second]"));
+
+        RuntimeException unresolved = generateFailure("unresolved", """
+                Cat:
+                  type: object
+                  properties:
+                    cat:
+                      type: string
+                Choice:
+                  oneOf:
+                    - $ref: '#/components/schemas/Cat'
+                  discriminator:
+                    propertyName: kind
+                    mapping:
+                      missing: '#/components/schemas/DoesNotExist'
+                """);
+        assertThat(rootMessage(unresolved), containsString("does not resolve to exactly one concrete subtype"));
+
+        RuntimeException self = generateFailure("self", """
+                Base:
+                  type: object
+                  discriminator:
+                    propertyName: kind
+                    mapping:
+                      base: '#/components/schemas/Base'
+                      cat: '#/components/schemas/Cat'
+                Cat:
+                  allOf:
+                    - $ref: '#/components/schemas/Base'
+                    - type: object
+                      properties:
+                        value:
+                          type: string
+                """);
+        String message = rootMessage(self);
+        assertThat(message, containsString("Unsupported discriminator self-mapping"));
+        assertThat(message, containsString("#/components/schemas/Base"));
+        assertThat(message, containsString("discriminator property 'kind'"));
+        assertThat(message, containsString("alias 'base'"));
+        assertThat(message, containsString("target '#/components/schemas/Base'"));
+        assertThat(message, containsString("input specification '"));
+        assertThat(message, containsString("Define a concrete subtype"));
+        assertFalse(Files.exists(tempDir.resolve("self-generated/src/main/java")));
+    }
+
+    @Test
+    void regenerationIsByteStable() throws Exception {
+        Path first = generate("stable-first", null);
+        Path second = generate("stable-second", null);
+        Path firstRoot = first.resolve("src/main/java");
+        Path secondRoot = second.resolve("src/main/java");
+        List<Path> firstFiles;
+        List<Path> secondFiles;
+        try (var stream = Files.walk(firstRoot)) {
+            firstFiles = stream.filter(Files::isRegularFile).sorted().toList();
+        }
+        try (var stream = Files.walk(secondRoot)) {
+            secondFiles = stream.filter(Files::isRegularFile).sorted().toList();
+        }
+        assertEquals(firstFiles.stream().map(firstRoot::relativize).toList(),
+                     secondFiles.stream().map(secondRoot::relativize).toList());
+        for (Path file : firstFiles) {
+            Path relative = firstRoot.relativize(file);
+            assertArrayEquals(Files.readAllBytes(file), Files.readAllBytes(secondRoot.resolve(relative)),
+                              relative.toString());
+        }
+    }
+
+    private Path generate(String name, String representation) throws Exception {
+        URL resource = getClass().getClassLoader().getResource("authoritative-discriminators.yaml");
+        Path spec = Paths.get(resource.toURI()).toAbsolutePath();
+        return generate(name, spec, representation);
+    }
+
+    private Path generate(String name, Path spec, String representation) {
+        Path output = tempDir.resolve(name + "-generated");
+        CodegenConfigurator configurator = new CodegenConfigurator()
+                .setGeneratorName("helidon-declarative")
+                .setInputSpec(spec.toString())
+                .setOutputDir(output.toString())
+                .addAdditionalProperty("helidonVersion", "4.4.1")
+                .addAdditionalProperty("apiPackage", "io.helidon.example.api")
+                .addAdditionalProperty("modelPackage", "io.helidon.example.model")
+                .addAdditionalProperty("invokerPackage", "io.helidon.example");
+        if (representation != null) {
+            configurator.addAdditionalProperty("discriminatorRepresentation", representation);
+        }
+        new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
+        return output;
+    }
+
+    private RuntimeException generateFailure(String name, String schemas) throws IOException {
+        Path spec = tempDir.resolve(name + ".yaml");
+        Files.writeString(spec, """
+                openapi: 3.0.3
+                info:
+                  title: Invalid discriminator
+                  version: 1.0.0
+                paths: {}
+                components:
+                  schemas:
+                """ + schemas.indent(6));
+        return assertThrows(RuntimeException.class, () -> generate(name, spec, null));
+    }
+
+    private String model(Path output, String name) throws IOException {
+        return Files.readString(output.resolve("src/main/java/io/helidon/example/model/" + name + ".java"));
+    }
+
+    private String rootMessage(Throwable throwable) {
+        Throwable current = throwable;
+        while (current.getCause() != null) {
+            current = current.getCause();
+        }
+        return current.getMessage();
+    }
+}

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/AuthoritativeDiscriminatorGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/AuthoritativeDiscriminatorGenerationIT.java
@@ -145,6 +145,41 @@ class AuthoritativeDiscriminatorGenerationIT {
         assertThat(message, containsString("input specification '"));
         assertThat(message, containsString("Define a concrete subtype"));
         assertFalse(Files.exists(tempDir.resolve("self-generated/src/main/java")));
+
+        RuntimeException duplicateDescendantAlias = generateFailure("duplicate-descendant-alias", """
+                Base:
+                  type: object
+                  discriminator:
+                    propertyName: kind
+                  properties:
+                    kind:
+                      type: string
+                MidA:
+                  discriminator:
+                    propertyName: kind
+                    mapping:
+                      leaf: '#/components/schemas/LeafA'
+                  allOf:
+                    - $ref: '#/components/schemas/Base'
+                    - type: object
+                MidB:
+                  discriminator:
+                    propertyName: kind
+                    mapping:
+                      leaf: '#/components/schemas/LeafB'
+                  allOf:
+                    - $ref: '#/components/schemas/Base'
+                    - type: object
+                LeafA:
+                  allOf:
+                    - $ref: '#/components/schemas/MidA'
+                    - type: object
+                LeafB:
+                  allOf:
+                    - $ref: '#/components/schemas/MidB'
+                    - type: object
+                """);
+        assertThat(rootMessage(duplicateDescendantAlias), containsString("share canonical alias 'leaf'"));
     }
 
     @Test

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/AuthoritativeDiscriminatorGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/AuthoritativeDiscriminatorGenerationIT.java
@@ -57,15 +57,14 @@ class AuthoritativeDiscriminatorGenerationIT {
         assertThat(base, not(containsString("void kind(")));
         assertThat(base, not(containsString("static BuilderBase<?, ? extends DeclaredBase> builder()")));
         assertThat(cat, containsString("return \"weird.alias\";"));
+        assertThat(cat, not(containsString("private String kind;")));
         assertThat(cat, not(containsString("void kind(")));
 
-        assertThat(metadataChoice, containsString("@Json.Polymorphic(key = \"category\")"));
-        assertThat(metadataChoice,
-                   containsString("@Json.Subtype(alias = \"alpha.v1\", value = MetadataAlpha.class)"));
-        assertThat(metadataChoice,
-                   containsString("@Json.Subtype(alias = \"MetadataBeta\", value = MetadataBeta.class)"));
+        assertThat(metadataChoice, containsString("@Json.Converter(MetadataChoice.MetadataChoiceJsonConverter.class)"));
+        assertThat(metadataChoice, containsString("case \"alpha.v1\" -> deserializeMetadataAlpha(jsonObject)"));
+        assertThat(metadataChoice, containsString("case \"MetadataBeta\" -> deserializeMetadataBeta(jsonObject)"));
         assertThat(metadataChoice, not(containsString("String category();")));
-        assertThat(metadataChoice, not(containsString("JsonConverter")));
+        assertThat(metadataChoice, not(containsString("@Json.Polymorphic")));
     }
 
     @Test
@@ -169,6 +168,18 @@ class AuthoritativeDiscriminatorGenerationIT {
             assertArrayEquals(Files.readAllBytes(file), Files.readAllBytes(secondRoot.resolve(relative)),
                               relative.toString());
         }
+    }
+
+    @Test
+    void diagnosticReferencesDoNotExposeUriCredentialsOrQueries() {
+        assertEquals("https://example.invalid/api.yaml#/components/schemas/Cat",
+                     HelidonDeclarativeCodegen.sanitizeDiagnosticReference(
+                             "https://user:password@example.invalid/api.yaml?access_token=value"
+                                     + "#/components/schemas/Cat"));
+        assertEquals("#/components/schemas/Cat",
+                     HelidonDeclarativeCodegen.sanitizeDiagnosticReference("#/components/schemas/Cat"));
+        assertEquals("file:/tmp/spec.yaml",
+                     HelidonDeclarativeCodegen.sanitizeDiagnosticReference("file:/tmp/spec.yaml?token=hidden"));
     }
 
     private Path generate(String name, String representation) throws Exception {

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/AuthoritativeDiscriminatorGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/AuthoritativeDiscriminatorGenerationIT.java
@@ -49,9 +49,11 @@ class AuthoritativeDiscriminatorGenerationIT {
         String metadataChoice = model(output, "MetadataChoice");
 
         assertThat(base, containsString("public abstract class DeclaredBase"));
-        assertThat(base, containsString("@Json.Subtype(alias = \"weird.alias\", value = DeclaredCat.class)"));
-        assertThat(base, containsString("@Json.Subtype(alias = \"MixedCase-2\", value = DeclaredDog.class)"));
-        assertThat(base, containsString("@Json.Subtype(alias = \"DeclaredBird\", value = DeclaredBird.class)"));
+        assertThat(base, containsString("@Json.Converter(DeclaredBase.DeclaredBaseJsonConverter.class)"));
+        assertThat(base, containsString("case \"weird.alias\" -> declaredCatDeserializer.deserialize("));
+        assertThat(base, containsString("case \"MixedCase-2\" -> declaredDogDeserializer.deserialize("));
+        assertThat(base, containsString("case \"DeclaredBird\" -> declaredBirdDeserializer.deserialize("));
+        assertThat(base, not(containsString("@Json.Subtype")));
         assertThat(base, containsString("public abstract String kind();"));
         assertThat(base, not(containsString("private String kind;")));
         assertThat(base, not(containsString("void kind(")));

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/AuthoritativeDiscriminatorGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/AuthoritativeDiscriminatorGenerationIT.java
@@ -217,6 +217,26 @@ class AuthoritativeDiscriminatorGenerationIT {
                      HelidonDeclarativeCodegen.sanitizeDiagnosticReference("file:/tmp/spec.yaml?token=hidden"));
     }
 
+    @Test
+    void supportsExtensionValuesInheritedEnumTypesAndTransitiveHierarchies() throws Exception {
+        URL resource = getClass().getClassLoader().getResource("authoritative-discriminator-adversarial.yaml");
+        Path output = generate("adversarial", Paths.get(resource.toURI()).toAbsolutePath(), null);
+
+        assertThat(model(output, "ExtensionCat"), containsString("return ExtensionBase.KindEnum.WIRE_CAT;"));
+
+        String distinctLeaf = model(output, "DistinctLeaf");
+        assertThat(distinctLeaf, containsString("public BaseKindEnum baseKind()"));
+        assertThat(distinctLeaf, containsString("public LeafKindEnum leafKind()"));
+
+        assertThat(model(output, "EnumPet"), containsString("KindHolder.KindEnum kind();"));
+        assertThat(model(output, "UnionCat"), containsString("public KindHolder.KindEnum kind()"));
+        assertThat(model(output, "UnionDog"), containsString("public KindHolder.KindEnum kind()"));
+
+        assertThat(model(output, "TransitiveBase"),
+                   containsString("@Json.Subtype(alias = \"leaf\", value = TransitiveLeaf.class)"));
+        assertThat(model(output, "TransitiveLeaf"), containsString("return \"leaf\";"));
+    }
+
     private Path generate(String name, String representation) throws Exception {
         URL resource = getClass().getClassLoader().getResource("authoritative-discriminators.yaml");
         Path spec = Paths.get(resource.toURI()).toAbsolutePath();

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/ComposedSchemasGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/ComposedSchemasGenerationIT.java
@@ -92,6 +92,10 @@ class ComposedSchemasGenerationIT {
         String leaf = read(modelFile("LayeredLeaf.java"));
         assertThat(leaf, containsString("public class LayeredLeaf extends LayeredIntermediate"));
         assertThat(leaf, containsString("super(new LayeredLeaf())"));
+
+        String base = read(modelFile("LayeredBase.java"));
+        assertThat(base, containsString("@Json.Subtype(alias = \"leaf\", value = LayeredLeaf.class)"));
+        assertThat(base, not(containsString("value = LayeredIntermediate.class")));
     }
 
     @Test
@@ -110,6 +114,7 @@ class ComposedSchemasGenerationIT {
         assertThat(cat, containsString("implements"));
         assertThat(cat, containsString("Pet"));
         assertThat(cat, containsString("return \"cat$special\";"));
+        assertThat(cat, not(containsString("@Json.Ignore\n    public String kind()")));
         assertThat(cat, not(containsString("private String kind;")));
         assertThat(cat, not(containsString("void kind(")));
 
@@ -244,6 +249,7 @@ class ComposedSchemasGenerationIT {
                 import static org.hamcrest.CoreMatchers.instanceOf;
                 import static org.hamcrest.CoreMatchers.is;
                 import static org.hamcrest.MatcherAssert.assertThat;
+                import static org.junit.jupiter.api.Assertions.assertThrows;
 
                 class ComposedJsonBindingTest {
 
@@ -255,12 +261,86 @@ class ComposedSchemasGenerationIT {
                         cat.whiskers(7);
 
                         String json = jsonBinding.serialize((Pet) cat, Pet.class);
+                        assertThat(occurrences(json, "\\\"kind\\\""), is(1));
                         assertThat(json, containsString("\\\"kind\\\":\\\"cat$special\\\""));
                         assertThat(json, containsString("\\\"whiskers\\\":7"));
 
                         Pet pet = jsonBinding.deserialize("{\\\"kind\\\":\\\"cat$special\\\",\\\"whiskers\\\":7}", Pet.class);
                         assertThat(pet, instanceOf(Cat.class));
                         assertThat(((Cat) pet).whiskers(), is(7));
+                    }
+
+                    @Test
+                    void directMemberBindingPreservesDiscriminator() {
+                        Cat cat = new Cat();
+                        cat.whiskers(7);
+
+                        String json = jsonBinding.serialize(cat, Cat.class);
+                        assertThat(occurrences(json, "\\\"kind\\\""), is(1));
+                        assertThat(json, containsString("\\\"kind\\\":\\\"cat$special\\\""));
+
+                        Cat restored = jsonBinding.deserialize(
+                                "{\\\"kind\\\":\\\"cat$special\\\",\\\"whiskers\\\":7}", Cat.class);
+                        assertThat(restored.kind(), is("cat$special"));
+                        assertThat(restored.whiskers(), is(7));
+
+                        assertThrows(RuntimeException.class,
+                                     () -> jsonBinding.deserialize(
+                                             "{\\\"kind\\\":\\\"dog\\\",\\\"whiskers\\\":7}", Cat.class));
+                    }
+
+                    @Test
+                    void everyOneOfMemberRoundTripsWithItsCanonicalAlias() {
+                        Dog dog = new Dog();
+                        dog.bark(true);
+
+                        String json = jsonBinding.serialize((Pet) dog, Pet.class);
+                        assertThat(occurrences(json, "\\\"kind\\\""), is(1));
+                        assertThat(json, containsString("\\\"kind\\\":\\\"dog\\\""));
+
+                        Pet restored = jsonBinding.deserialize(json, Pet.class);
+                        assertThat(restored, instanceOf(Dog.class));
+                        assertThat(((Dog) restored).bark(), is(true));
+                    }
+
+                    @Test
+                    void metadataDiscriminatorIsRequired() {
+                        assertThrows(RuntimeException.class,
+                                     () -> jsonBinding.deserialize("{\\\"alpha\\\":\\\"value\\\"}",
+                                                                  MetadataChoice.class));
+                    }
+
+                    @Test
+                    void everyMetadataMemberRoundTripsWithItsCanonicalAlias() {
+                        MetadataAlpha alpha = new MetadataAlpha();
+                        alpha.alpha("a");
+                        String alphaJson = jsonBinding.serialize((MetadataChoice) alpha, MetadataChoice.class);
+                        assertThat(alphaJson, containsString("\\\"category\\\":\\\"alpha.v1\\\""));
+                        assertThat(jsonBinding.deserialize(alphaJson, MetadataChoice.class),
+                                   instanceOf(MetadataAlpha.class));
+
+                        MetadataBeta beta = new MetadataBeta();
+                        beta.beta("b");
+                        String betaJson = jsonBinding.serialize((MetadataChoice) beta, MetadataChoice.class);
+                        assertThat(betaJson, containsString("\\\"category\\\":\\\"MetadataBeta\\\""));
+                        assertThat(jsonBinding.deserialize(betaJson, MetadataChoice.class),
+                                   instanceOf(MetadataBeta.class));
+                    }
+
+                    @Test
+                    void layeredAllOfRoundTripsThroughRootBase() {
+                        LayeredLeaf leaf = new LayeredLeaf();
+                        leaf.middle("middle");
+                        leaf.leaf("leaf-value");
+
+                        String json = jsonBinding.serialize((LayeredBase) leaf, LayeredBase.class);
+                        assertThat(occurrences(json, "\\\"kind\\\""), is(1));
+                        assertThat(json, containsString("\\\"kind\\\":\\\"leaf\\\""));
+
+                        LayeredBase restored = jsonBinding.deserialize(json, LayeredBase.class);
+                        assertThat(restored, instanceOf(LayeredLeaf.class));
+                        assertThat(((LayeredLeaf) restored).middle(), is("middle"));
+                        assertThat(((LayeredLeaf) restored).leaf(), is("leaf-value"));
                     }
 
                     @Test
@@ -311,6 +391,10 @@ class ComposedSchemasGenerationIT {
                         PatternChoice numericCode = jsonBinding.deserialize("{\\\"code\\\":\\\"123\\\"}",
                                                                             PatternChoice.class);
                         assertThat(numericCode, instanceOf(NumericCode.class));
+                    }
+
+                    private int occurrences(String value, String token) {
+                        return (value.length() - value.replace(token, "").length()) / token.length();
                     }
                 }
                 """);

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/ComposedSchemasGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/ComposedSchemasGenerationIT.java
@@ -82,14 +82,26 @@ class ComposedSchemasGenerationIT {
     }
 
     @Test
+    void abstractIntermediateAllOfModelDoesNotInstantiateItself() throws IOException {
+        String content = read(modelFile("LayeredIntermediate.java"));
+        assertThat(content, containsString("public abstract class LayeredIntermediate extends LayeredBase"));
+        assertThat(content, containsString("class BuilderBase<B extends BuilderBase<B, T>"));
+        assertThat(content, not(containsString("new LayeredIntermediate()")));
+        assertThat(content, not(containsString("class Builder extends BuilderBase<Builder, LayeredIntermediate>")));
+
+        String leaf = read(modelFile("LayeredLeaf.java"));
+        assertThat(leaf, containsString("public class LayeredLeaf extends LayeredIntermediate"));
+        assertThat(leaf, containsString("super(new LayeredLeaf())"));
+    }
+
+    @Test
     void oneOfSchemaGeneratesInterface() throws IOException {
         String content = read(modelFile("Pet.java"));
         assertThat(content, containsString("public interface Pet"));
-        assertThat(content, containsString("@Json.Entity"));
-        assertThat(content, containsString("@Json.Polymorphic(key = \"kind\")"));
-        assertThat(content, containsString("@Json.Subtype(alias = \"cat$special\", value = Cat.class)"));
+        assertThat(content, containsString("@Json.Converter(Pet.PetJsonConverter.class)"));
+        assertThat(content, containsString("case \"cat$special\" -> deserializeCat(jsonObject)"));
         assertThat(content, containsString("String kind();"));
-        assertThat(content, not(containsString("PetJsonConverter")));
+        assertThat(content, not(containsString("@Json.Polymorphic")));
     }
 
     @Test
@@ -148,8 +160,7 @@ class ComposedSchemasGenerationIT {
     @Test
     void unmappedDiscriminatorDefaultsToSchemaName() throws IOException {
         String content = read(modelFile("Problem.java"));
-        assertThat(content, containsString("@Json.Subtype(alias = \"Error\", value = ApiError.class)"));
-        assertThat(content, not(containsString("alias = \"ApiError\"")));
+        assertThat(content, containsString("case \"Error\" -> deserializeApiError(jsonObject)"));
     }
 
     @Test

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/ComposedSchemasGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/ComposedSchemasGenerationIT.java
@@ -85,22 +85,26 @@ class ComposedSchemasGenerationIT {
     void oneOfSchemaGeneratesInterface() throws IOException {
         String content = read(modelFile("Pet.java"));
         assertThat(content, containsString("public interface Pet"));
-        assertThat(content, not(containsString("@Json.Entity")));
-        assertThat(content, containsString("@Json.Converter(Pet.PetJsonConverter.class)"));
-        assertThat(content, containsString("final class PetJsonConverter implements JsonConverter<Pet>"));
-        assertThat(content, containsString("final class PetJsonBindingFactory implements JsonBindingFactory<Pet>"));
-        assertThat(content, containsString("String discriminatorValue = jsonObject.stringValue(\"kind\").orElse(null);"));
-        assertThat(content, containsString("case \"cat&special\" -> deserializeCat(jsonObject);"));
-        assertThat(content, containsString(".set(\"kind\", \"cat&special\")"));
-        assertThat(content, not(containsString("cat&amp;special")));
+        assertThat(content, containsString("@Json.Entity"));
+        assertThat(content, containsString("@Json.Polymorphic(key = \"kind\")"));
+        assertThat(content, containsString("@Json.Subtype(alias = \"cat$special\", value = Cat.class)"));
+        assertThat(content, containsString("String kind();"));
+        assertThat(content, not(containsString("PetJsonConverter")));
     }
 
     @Test
     void oneOfMembersImplementGeneratedInterface() throws IOException {
-        assertThat(read(modelFile("Cat.java")), containsString("implements"));
-        assertThat(read(modelFile("Cat.java")), containsString("Pet"));
-        assertThat(read(modelFile("Dog.java")), containsString("implements"));
-        assertThat(read(modelFile("Dog.java")), containsString("Pet"));
+        String cat = read(modelFile("Cat.java"));
+        assertThat(cat, containsString("implements"));
+        assertThat(cat, containsString("Pet"));
+        assertThat(cat, containsString("return \"cat$special\";"));
+        assertThat(cat, not(containsString("private String kind;")));
+        assertThat(cat, not(containsString("void kind(")));
+
+        String dog = read(modelFile("Dog.java"));
+        assertThat(dog, containsString("implements"));
+        assertThat(dog, containsString("Pet"));
+        assertThat(dog, containsString("return \"dog\";"));
     }
 
     @Test
@@ -144,9 +148,8 @@ class ComposedSchemasGenerationIT {
     @Test
     void unmappedDiscriminatorDefaultsToSchemaName() throws IOException {
         String content = read(modelFile("Problem.java"));
-        assertThat(content, containsString("case \"Error\" -> deserializeApiError(jsonObject);"));
-        assertThat(content, containsString(".set(\"kind\", \"Error\")"));
-        assertThat(content, not(containsString(".set(\"kind\", \"ApiError\")")));
+        assertThat(content, containsString("@Json.Subtype(alias = \"Error\", value = ApiError.class)"));
+        assertThat(content, not(containsString("alias = \"ApiError\"")));
     }
 
     @Test
@@ -241,10 +244,10 @@ class ComposedSchemasGenerationIT {
                         cat.whiskers(7);
 
                         String json = jsonBinding.serialize((Pet) cat, Pet.class);
-                        assertThat(json, containsString("\\\"kind\\\":\\\"cat&special\\\""));
+                        assertThat(json, containsString("\\\"kind\\\":\\\"cat$special\\\""));
                         assertThat(json, containsString("\\\"whiskers\\\":7"));
 
-                        Pet pet = jsonBinding.deserialize("{\\\"kind\\\":\\\"cat&special\\\",\\\"whiskers\\\":7}", Pet.class);
+                        Pet pet = jsonBinding.deserialize("{\\\"kind\\\":\\\"cat$special\\\",\\\"whiskers\\\":7}", Pet.class);
                         assertThat(pet, instanceOf(Cat.class));
                         assertThat(((Cat) pet).whiskers(), is(7));
                     }

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/DiscriminatorAllOfGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/DiscriminatorAllOfGenerationIT.java
@@ -62,6 +62,11 @@ class DiscriminatorAllOfGenerationIT {
         String content = read(modelFile("CreateConditionShapeDetails.java"));
         assertThat(content, containsString("@Json.Polymorphic(key = \"conditionShape\")"));
         assertThat(content, containsString("@Json.Subtype(alias = \"CHANGE_FREEZE\", value = CreateChangeFreezeConditionShape.class)"));
+        assertThat(content, containsString("public abstract class CreateConditionShapeDetails"));
+        assertThat(content, containsString("public abstract String conditionShape();"));
+        assertThat(content, not(containsString("private String conditionShape;")));
+        assertThat(content, not(containsString("static BuilderBase<?, ? extends CreateConditionShapeDetails> builder()")));
+        assertThat(content, not(containsString("class Builder extends BuilderBase<Builder, CreateConditionShapeDetails>")));
     }
 
     @Test
@@ -74,10 +79,12 @@ class DiscriminatorAllOfGenerationIT {
     }
 
     @Test
-    void discriminatorAllOfSubtypeInitializesInheritedDiscriminator() throws IOException {
+    void discriminatorAllOfSubtypeDerivesCanonicalDiscriminator() throws IOException {
         String content = read(modelFile("CreateChangeFreezeConditionShape.java"));
-        assertThat(content, containsString("public CreateChangeFreezeConditionShape()"));
-        assertThat(content, containsString("conditionShape(\"CHANGE_FREEZE\");"));
+        assertThat(content, containsString("public String conditionShape()"));
+        assertThat(content, containsString("return \"CHANGE_FREEZE\";"));
+        assertThat(content, not(containsString("void conditionShape(")));
+        assertThat(content, not(containsString("Builder conditionShape(")));
     }
 
     private static File modelFile(String fileName) {

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/DiscriminatorAllOfGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/DiscriminatorAllOfGenerationIT.java
@@ -84,7 +84,8 @@ class DiscriminatorAllOfGenerationIT {
         assertThat(content, containsString("public String conditionShape()"));
         assertThat(content, containsString("return \"CHANGE_FREEZE\";"));
         assertThat(content, not(containsString("void conditionShape(")));
-        assertThat(content, not(containsString("Builder conditionShape(")));
+        assertThat(content, containsString("public Builder conditionShape(String conditionShape)"));
+        assertThat(content, containsString("Unsupported discriminator value '"));
     }
 
     private static File modelFile(String fileName) {

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/DiscriminatorEnumAllOfGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/DiscriminatorEnumAllOfGenerationIT.java
@@ -30,7 +30,6 @@ import org.openapitools.codegen.config.CodegenConfigurator;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DiscriminatorEnumAllOfGenerationIT {
 
@@ -66,12 +65,16 @@ class DiscriminatorEnumAllOfGenerationIT {
     }
 
     @Test
-    void legacySubtypeAliasInferenceIsNotApplied() {
-        IllegalStateException exception = assertThrows(IllegalStateException.class,
-                                                        () -> generate("discriminator-enum-repro.yaml"));
-        assertThat(exception.getMessage(), containsString("Unable to resolve discriminator value"));
-        assertThat(exception.getMessage(), containsString("RegionHealthCheckCategoryDetails"));
-        assertThat(exception.getMessage(), containsString("property 'category'"));
+    void explicitSubtypeExtensionProducesDerivedEnumAccessor() throws Exception {
+        Path output = generate("discriminator-enum-repro.yaml");
+        String parent = read(output, "MqlCheckDetails");
+        String subtype = read(output, "RegionHealthCheckCategoryDetails");
+
+        assertThat(parent,
+                   containsString("@Json.Subtype(alias = \"REGION_HEALTH_CHECK\", "
+                                          + "value = RegionHealthCheckCategoryDetails.class)"));
+        assertThat(subtype,
+                   containsString("return MqlCheckDetails.CategoryEnum.REGION_HEALTH_CHECK;"));
     }
 
     private Path generate(String resourceName) throws Exception {

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/DiscriminatorEnumAllOfGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/DiscriminatorEnumAllOfGenerationIT.java
@@ -77,6 +77,22 @@ class DiscriminatorEnumAllOfGenerationIT {
                    containsString("return MqlCheckDetails.CategoryEnum.REGION_HEALTH_CHECK;"));
     }
 
+    @Test
+    void convertedSwagger2InlineDiscriminatorValuesRemainAuthoritative() throws Exception {
+        Path output = generate("discriminator-swagger2-name-drift.yaml");
+        String parent = read(output, "ConditionShapeDetails");
+
+        assertThat(parent,
+                   containsString("@Json.Subtype(alias = \"CHANGE_FREEZE\", value = ChangeFreezeConditionShape.class)"));
+        assertThat(parent,
+                   containsString("@Json.Subtype(alias = \"CM_PREREQUISITES_VIOLATION\", "
+                                          + "value = CmPreRequisiteViolationConditionShape.class)"));
+        assertThat(read(output, "ChangeFreezeConditionShape"),
+                   containsString("return ConditionShapeDetails.ConditionShapeEnum.CHANGE_FREEZE;"));
+        assertThat(read(output, "CmPreRequisiteViolationConditionShape"),
+                   containsString("return ConditionShapeDetails.ConditionShapeEnum.CM_PREREQUISITES_VIOLATION;"));
+    }
+
     private Path generate(String resourceName) throws Exception {
         URL resource = getClass().getClassLoader().getResource(resourceName);
         Path spec = Paths.get(resource.toURI()).toAbsolutePath();

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/DiscriminatorEnumAllOfGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/DiscriminatorEnumAllOfGenerationIT.java
@@ -16,7 +16,6 @@
 
 package io.helidon.openapi.generator;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -31,6 +30,7 @@ import org.openapitools.codegen.config.CodegenConfigurator;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class DiscriminatorEnumAllOfGenerationIT {
 
@@ -38,296 +38,59 @@ class DiscriminatorEnumAllOfGenerationIT {
     Path tempDir;
 
     @Test
-    void explicitEnumDiscriminatorSubtypeSeedsEnumConstant() throws Exception {
-        Path outputDir = generate("discriminator-enum-repro.yaml");
-        String content = read(modelFile(outputDir, "RegionHealthCheckCategoryDetails.java"));
-        assertThat(content, containsString("public RegionHealthCheckCategoryDetails()"));
-        assertThat(content, containsString("category(MqlCheckDetails.CategoryEnum.REGION_HEALTH_CHECK);"));
-        assertThat(content, not(containsString("category(\"REGION_HEALTH_CHECK\")")));
+    void exactMappedEnumAliasesProduceDerivedEnumAccessors() throws Exception {
+        Path output = generate("discriminator-enum-mapping-repro.yaml");
+        String parent = read(output, "ConditionShapeDetails");
+        String changeFreeze = read(output, "ChangeFreezeConditionShape");
+        String timeWindow = read(output, "TimeWindowConstraintsConditionShape");
+
+        assertThat(parent, containsString("public abstract ConditionShapeEnum conditionShape();"));
+        assertThat(parent,
+                   containsString("@Json.Subtype(alias = \"CHANGE_FREEZE\", value = ChangeFreezeConditionShape.class)"));
+        assertThat(parent, not(containsString("private ConditionShapeEnum conditionShape;")));
+        assertThat(changeFreeze,
+                   containsString("return ConditionShapeDetails.ConditionShapeEnum.CHANGE_FREEZE;"));
+        assertThat(timeWindow,
+                   containsString("return ConditionShapeDetails.ConditionShapeEnum.TIME_WINDOW_CONSTRAINTS;"));
+        assertThat(changeFreeze, not(containsString("void conditionShape(")));
     }
 
     @Test
-    void baseDiscriminatorRemainsEnumTyped() throws Exception {
-        Path outputDir = generate("discriminator-enum-repro.yaml");
-        String content = read(modelFile(outputDir, "MqlCheckDetails.java"));
-        assertThat(content, containsString("private CategoryEnum category;"));
-        assertThat(content, containsString("public void category(CategoryEnum category)"));
-        assertThat(content, containsString("public enum CategoryEnum"));
+    void exactMappedEnumAliasesWorkInSimpleHierarchy() throws Exception {
+        Path output = generate("discriminator-enum-mapping-repro-2.yaml");
+        assertThat(read(output, "UserConfig"), containsString("public abstract TypeEnum type();"));
+        assertThat(read(output, "UserConfigStringValue"),
+                   containsString("return UserConfig.TypeEnum.STRING;"));
+        assertThat(read(output, "UserConfigInstantValue"),
+                   containsString("return UserConfig.TypeEnum.INSTANT;"));
     }
 
     @Test
-    void mappedEnumDiscriminatorSubtypeUsesActualDiscriminatorValue() throws Exception {
-        Path outputDir = generate("discriminator-enum-mapping-repro.yaml");
-
-        String parent = read(modelFile(outputDir, "ConditionShapeDetails.java"));
-        assertThat(parent, containsString("@Json.Subtype(alias = \"CHANGE_FREEZE\", value = ChangeFreezeConditionShape.class)"));
-        assertThat(parent, containsString("@Json.Subtype(alias = \"TIME_WINDOW_CONSTRAINTS\", value = TimeWindowConstraintsConditionShape.class)"));
-
-        String changeFreeze = read(modelFile(outputDir, "ChangeFreezeConditionShape.java"));
-        assertThat(changeFreeze, containsString("conditionShape(ConditionShapeDetails.ConditionShapeEnum.CHANGE_FREEZE);"));
-        assertThat(changeFreeze, not(containsString("CHANGE_FREEZE_CONDITION_SHAPE")));
-
-        String timeWindow = read(modelFile(outputDir, "TimeWindowConstraintsConditionShape.java"));
-        assertThat(timeWindow, containsString("conditionShape(ConditionShapeDetails.ConditionShapeEnum.TIME_WINDOW_CONSTRAINTS);"));
-        assertThat(timeWindow, not(containsString("TIME_WINDOW_CONSTRAINTS_CONDITION_SHAPE")));
-    }
-
-    @Test
-    void mappedEnumDiscriminatorSubtypeUsesActualDiscriminatorValueInSimpleHierarchy() throws Exception {
-        Path outputDir = generate("discriminator-enum-mapping-repro-2.yaml");
-
-        String parent = read(modelFile(outputDir, "UserConfig.java"));
-        assertThat(parent, containsString("@Json.Subtype(alias = \"INSTANT\", value = UserConfigInstantValue.class)"));
-        assertThat(parent, containsString("@Json.Subtype(alias = \"STRING\", value = UserConfigStringValue.class)"));
-
-        String stringValue = read(modelFile(outputDir, "UserConfigStringValue.java"));
-        assertThat(stringValue, containsString("type(UserConfig.TypeEnum.STRING);"));
-        assertThat(stringValue, not(containsString("USER_CONFIG_STRING_VALUE")));
-
-        String instantValue = read(modelFile(outputDir, "UserConfigInstantValue.java"));
-        assertThat(instantValue, containsString("type(UserConfig.TypeEnum.INSTANT);"));
-        assertThat(instantValue, not(containsString("USER_CONFIG_INSTANT_VALUE")));
-    }
-
-    @Test
-    void explicitDiscriminatorValueWinsOverSubtypeSchemaName() throws Exception {
-        Path outputDir = generate("discriminator-enum-explicit-value-repro.yaml");
-
-        String parent = read(modelFile(outputDir, "ApprovalInvalidationTypeDetails.java"));
-        assertThat(parent, containsString("AUTHOR_DEFINED_TIME_EXPIRY"));
-
-        String explicitSubtype = read(modelFile(outputDir, "ConditionAuthorDefinedExpiringApprovalInvalidationTypeDetails.java"));
-        assertThat(explicitSubtype, containsString("approvalInvalidationType("
-                + "ApprovalInvalidationTypeDetails.ApprovalInvalidationTypeEnum.AUTHOR_DEFINED_TIME_EXPIRY);"));
-        assertThat(explicitSubtype,
-                not(containsString("CONDITION_AUTHOR_DEFINED_EXPIRING_APPROVAL_INVALIDATION_TYPE_DETAILS")));
-    }
-
-    @Test
-    void explicitDiscriminatorValuePreservesPhonebookNormalization() throws Exception {
-        Path outputDir = generate("discriminator-enum-phonebook-repro.yaml");
-
-        String parent = read(modelFile(outputDir, "ApplicableScope.java"));
-        assertThat(parent, containsString("SERVICE_PHONEBOOK_SCOPE"));
-
-        String subtype = read(modelFile(outputDir, "ServicePhoneBookScope.java"));
-        assertThat(subtype, containsString("scopeType(ApplicableScope.ScopeTypeEnum.SERVICE_PHONEBOOK_SCOPE);"));
-        assertThat(subtype, not(containsString("SERVICE_PHONE_BOOK_SCOPE")));
-    }
-
-    @Test
-    void explicitDiscriminatorValuePreservesPrerequisitesCanonicalization() throws Exception {
-        Path outputDir = generate("discriminator-enum-prerequisites-repro.yaml");
-
-        String parent = read(modelFile(outputDir, "ConditionShapeDetails.java"));
-        assertThat(parent, containsString("CM_PREREQUISITES_VIOLATION"));
-
-        String subtype = read(modelFile(outputDir, "CmPreRequisiteViolationConditionShape.java"));
-        assertThat(subtype, containsString("conditionShape("
-                + "ConditionShapeDetails.ConditionShapeEnum.CM_PREREQUISITES_VIOLATION);"));
-        assertThat(subtype, not(containsString("CM_PRE_REQUISITE_VIOLATION_CONDITION_SHAPE")));
-    }
-
-    @Test
-    void oneOfParentConstructorUsesExplicitDiscriminatorValue() throws Exception {
-        Path outputDir = generate("discriminator-oneof-explicit-value.yaml");
-
-        String parent = read(modelFile(outputDir, "ApprovalInvalidationTypeDetails.java"));
-        assertThat(parent, containsString("AUTHOR_DEFINED_TIME_EXPIRY"));
-
-        String subtype = read(modelFile(outputDir, "AuthorDefinedExpiryDetails.java"));
-        assertThat(subtype, containsString("approvalInvalidationType("
-                + "ApprovalInvalidationTypeDetails.ApprovalInvalidationTypeEnum.AUTHOR_DEFINED_TIME_EXPIRY);"));
-        assertThat(subtype, not(containsString("AUTHOR_DEFINED_EXPIRY_DETAILS")));
-    }
-
-    @Test
-    void oneOfParentConstructorPreservesCompoundWordNormalization() throws Exception {
-        Path outputDir = generate("discriminator-oneof-compound-word.yaml");
-
-        String parent = read(modelFile(outputDir, "ApplicableScope.java"));
-        assertThat(parent, containsString("SERVICE_PHONEBOOK_SCOPE"));
-
-        String subtype = read(modelFile(outputDir, "ServicePhoneBookScope.java"));
-        assertThat(subtype, containsString("scopeType(ApplicableScope.ScopeTypeEnum.SERVICE_PHONEBOOK_SCOPE);"));
-        assertThat(subtype, not(containsString("SERVICE_PHONE_BOOK_SCOPE")));
-    }
-
-    @Test
-    void oneOfParentConstructorIgnoresLegacyClassNameDrift() throws Exception {
-        Path outputDir = generate("discriminator-oneof-name-drift.yaml");
-
-        String parent = read(modelFile(outputDir, "ConditionShapeDetails.java"));
-        assertThat(parent, containsString("CM_PREREQUISITES_VIOLATION"));
-
-        String subtype = read(modelFile(outputDir, "CmPreRequisiteViolationConditionShape.java"));
-        assertThat(subtype, containsString("conditionShape("
-                + "ConditionShapeDetails.ConditionShapeEnum.CM_PREREQUISITES_VIOLATION);"));
-        assertThat(subtype, not(containsString("CM_PRE_REQUISITE_VIOLATION_CONDITION_SHAPE")));
-    }
-
-    @Test
-    void anyOfParentDeclaredViaAllOfUsesCanonicalExplicitDiscriminatorValue() throws Exception {
-        Path outputDir = generate("discriminator-anyof-allof-base-explicit-value.yaml");
-
-        String parent = read(modelFile(outputDir, "ApprovalInvalidationTypeDetails.java"));
-        assertThat(parent, containsString("public class ApprovalInvalidationTypeDetails"));
-        assertThat(parent, containsString("AUTHOR_DEFINED_TIME_EXPIRY"));
-        assertThat(parent, containsString("@Json.Subtype(alias = \"AUTHOR_DEFINED_TIME_EXPIRY\", value = AuthorDefinedExpiryDetails.class)"));
-
-        String subtype = read(modelFile(outputDir, "AuthorDefinedExpiryDetails.java"));
-        assertThat(subtype, containsString("public class AuthorDefinedExpiryDetails extends ApprovalInvalidationTypeDetails"));
-        assertThat(subtype, containsString("approvalInvalidationType("
-                + "ApprovalInvalidationTypeDetails.ApprovalInvalidationTypeEnum.AUTHOR_DEFINED_TIME_EXPIRY);"));
-        assertThat(subtype, not(containsString("AUTHOR_DEFINED_EXPIRY_DETAILS")));
-    }
-
-    @Test
-    void anyOfParentDeclaredViaAllOfPreservesCompoundWordEnumValue() throws Exception {
-        Path outputDir = generate("discriminator-anyof-allof-base-phonebook.yaml");
-
-        String parent = read(modelFile(outputDir, "ApplicableScope.java"));
-        assertThat(parent, containsString("public class ApplicableScope"));
-        assertThat(parent, containsString("SERVICE_PHONEBOOK_SCOPE"));
-        assertThat(parent, containsString("@Json.Subtype(alias = \"SERVICE_PHONEBOOK_SCOPE\", value = ServicePhoneBookScope.class)"));
-
-        String subtype = read(modelFile(outputDir, "ServicePhoneBookScope.java"));
-        assertThat(subtype, containsString("public class ServicePhoneBookScope extends ApplicableScope"));
-        assertThat(subtype, containsString("scopeType(ApplicableScope.ScopeTypeEnum.SERVICE_PHONEBOOK_SCOPE);"));
-        assertThat(subtype, not(containsString("SERVICE_PHONE_BOOK_SCOPE")));
-    }
-
-    @Test
-    void shorthandDiscriminatorValueSupportsNameDrift() throws Exception {
-        Path outputDir = generate("discriminator-shorthand-name-drift.yaml", false);
-
-        String parent = read(modelFile(outputDir, "ConditionShapeDetails.java"));
-        assertThat(parent, containsString("CM_PREREQUISITES_VIOLATION"));
-        assertThat(parent, containsString("@Json.Subtype(alias = \"CM_PREREQUISITES_VIOLATION\", value = CmPreRequisiteViolationConditionShape.class)"));
-
-        String subtype = read(modelFile(outputDir, "CmPreRequisiteViolationConditionShape.java"));
-        assertThat(subtype, containsString("conditionShape("
-                + "ConditionShapeDetails.ConditionShapeEnum.CM_PREREQUISITES_VIOLATION);"));
-        assertThat(subtype, not(containsString("CM_PRE_REQUISITE_VIOLATION_CONDITION_SHAPE")));
-    }
-
-    @Test
-    void shorthandDiscriminatorValueSupportsCompoundWordNormalization() throws Exception {
-        Path outputDir = generate("discriminator-shorthand-compound-word.yaml", false);
-
-        String parent = read(modelFile(outputDir, "ApplicableScope.java"));
-        assertThat(parent, containsString("SERVICE_PHONEBOOK_SCOPE"));
-        assertThat(parent, containsString("@Json.Subtype(alias = \"SERVICE_PHONEBOOK_SCOPE\", value = ServicePhoneBookScope.class)"));
-
-        String subtype = read(modelFile(outputDir, "ServicePhoneBookScope.java"));
-        assertThat(subtype, containsString("scopeType(ApplicableScope.ScopeTypeEnum.SERVICE_PHONEBOOK_SCOPE);"));
-        assertThat(subtype, not(containsString("SERVICE_PHONE_BOOK_SCOPE")));
-    }
-
-    @Test
-    void shorthandDiscriminatorValueSupportsExplicitValueDifferentFromClassName() throws Exception {
-        Path outputDir = generate("discriminator-shorthand-explicit-value.yaml", false);
-
-        String parent = read(modelFile(outputDir, "ApprovalInvalidationTypeDetails.java"));
-        assertThat(parent, containsString("AUTHOR_DEFINED_TIME_EXPIRY"));
-        assertThat(parent, containsString("@Json.Subtype(alias = \"AUTHOR_DEFINED_TIME_EXPIRY\", value = AuthorDefinedExpiryDetails.class)"));
-
-        String subtype = read(modelFile(outputDir, "AuthorDefinedExpiryDetails.java"));
-        assertThat(subtype, containsString("approvalInvalidationType("
-                + "ApprovalInvalidationTypeDetails.ApprovalInvalidationTypeEnum.AUTHOR_DEFINED_TIME_EXPIRY);"));
-        assertThat(subtype, not(containsString("AUTHOR_DEFINED_EXPIRY_DETAILS")));
-    }
-
-    @Test
-    void swagger2ShorthandDiscriminatorValueSupportsNameDrift() throws Exception {
-        Path outputDir = generate("discriminator-swagger2-name-drift.yaml", false);
-
-        String parent = read(modelFile(outputDir, "ConditionShapeDetails.java"));
-        assertThat(parent, containsString("CM_PREREQUISITES_VIOLATION"));
-        assertThat(parent, containsString("@Json.Subtype(alias = \"CM_PREREQUISITES_VIOLATION\", value = CmPreRequisiteViolationConditionShape.class)"));
-
-        String subtype = read(modelFile(outputDir, "CmPreRequisiteViolationConditionShape.java"));
-        assertThat(subtype, containsString("conditionShape("
-                + "ConditionShapeDetails.ConditionShapeEnum.CM_PREREQUISITES_VIOLATION);"));
-        assertThat(subtype, not(containsString("CM_PRE_REQUISITE_VIOLATION_CONDITION_SHAPE")));
-    }
-
-    @Test
-    void swagger2ShorthandDiscriminatorValueSupportsUrlInputSpec() throws Exception {
-        URL resource = DiscriminatorEnumAllOfGenerationIT.class
-                .getClassLoader()
-                .getResource("discriminator-swagger2-name-drift.yaml");
-        Path outputDir = generate(resource.toExternalForm(), "discriminator-swagger2-name-drift-url", false);
-
-        String parent = read(modelFile(outputDir, "ConditionShapeDetails.java"));
-        assertThat(parent, containsString("@Json.Subtype(alias = \"CM_PREREQUISITES_VIOLATION\", value = CmPreRequisiteViolationConditionShape.class)"));
-
-        String subtype = read(modelFile(outputDir, "CmPreRequisiteViolationConditionShape.java"));
-        assertThat(subtype, containsString("conditionShape("
-                + "ConditionShapeDetails.ConditionShapeEnum.CM_PREREQUISITES_VIOLATION);"));
-        assertThat(subtype, not(containsString("CM_PRE_REQUISITE_VIOLATION_CONDITION_SHAPE")));
-    }
-
-    @Test
-    void swagger2ShorthandDiscriminatorValueSupportsCompoundWordNormalization() throws Exception {
-        Path outputDir = generate("discriminator-swagger2-phonebook.yaml", false);
-
-        String parent = read(modelFile(outputDir, "ApplicableScope.java"));
-        assertThat(parent, containsString("SERVICE_PHONEBOOK_SCOPE"));
-        assertThat(parent, containsString("@Json.Subtype(alias = \"SERVICE_PHONEBOOK_SCOPE\", value = ServicePhoneBookScope.class)"));
-
-        String subtype = read(modelFile(outputDir, "ServicePhoneBookScope.java"));
-        assertThat(subtype, containsString("scopeType(ApplicableScope.ScopeTypeEnum.SERVICE_PHONEBOOK_SCOPE);"));
-        assertThat(subtype, not(containsString("SERVICE_PHONE_BOOK_SCOPE")));
-    }
-
-    @Test
-    void swagger2ShorthandDiscriminatorValueSupportsExplicitValueDifferentFromClassName() throws Exception {
-        Path outputDir = generate("discriminator-swagger2-expiry.yaml", false);
-
-        String parent = read(modelFile(outputDir, "ApprovalInvalidationTypeDetails.java"));
-        assertThat(parent, containsString("AUTHOR_DEFINED_TIME_EXPIRY"));
-        assertThat(parent, containsString("@Json.Subtype(alias = \"AUTHOR_DEFINED_TIME_EXPIRY\", value = ConditionAuthorDefinedExpiringApprovalInvalidationTypeDetails.class)"));
-
-        String subtype = read(modelFile(outputDir, "ConditionAuthorDefinedExpiringApprovalInvalidationTypeDetails.java"));
-        assertThat(subtype, containsString("approvalInvalidationType("
-                + "ApprovalInvalidationTypeDetails.ApprovalInvalidationTypeEnum.AUTHOR_DEFINED_TIME_EXPIRY);"));
-        assertThat(subtype, not(containsString("CONDITION_AUTHOR_DEFINED_EXPIRING_APPROVAL_INVALIDATION_TYPE_DETAILS")));
+    void legacySubtypeAliasInferenceIsNotApplied() {
+        IllegalStateException exception = assertThrows(IllegalStateException.class,
+                                                        () -> generate("discriminator-enum-repro.yaml"));
+        assertThat(exception.getMessage(), containsString("Unable to resolve discriminator value"));
+        assertThat(exception.getMessage(), containsString("RegionHealthCheckCategoryDetails"));
+        assertThat(exception.getMessage(), containsString("property 'category'"));
     }
 
     private Path generate(String resourceName) throws Exception {
-        return generate(resourceName, true);
-    }
-
-    private Path generate(String resourceName, boolean validateSpec) throws Exception {
-        URL resource = DiscriminatorEnumAllOfGenerationIT.class
-                .getClassLoader()
-                .getResource(resourceName);
-        String specPath = Paths.get(resource.toURI()).toAbsolutePath().toString();
-        return generate(specPath, resourceName.replace(".yaml", ""), validateSpec);
-    }
-
-    private Path generate(String inputSpec, String outputName, boolean validateSpec) {
-        Path outputDir = tempDir.resolve(outputName);
+        URL resource = getClass().getClassLoader().getResource(resourceName);
+        Path spec = Paths.get(resource.toURI()).toAbsolutePath();
+        Path output = tempDir.resolve(resourceName.replace(".yaml", ""));
         CodegenConfigurator configurator = new CodegenConfigurator()
                 .setGeneratorName("helidon-declarative")
-                .setInputSpec(inputSpec)
-                .setOutputDir(outputDir.toString())
-                .setValidateSpec(validateSpec)
+                .setInputSpec(spec.toString())
+                .setOutputDir(output.toString())
                 .addAdditionalProperty("helidonVersion", "4.4.1")
                 .addAdditionalProperty("apiPackage", "io.helidon.example.api")
                 .addAdditionalProperty("modelPackage", "io.helidon.example.model")
                 .addAdditionalProperty("invokerPackage", "io.helidon.example");
-
         new DefaultGenerator().opts(configurator.toClientOptInput()).generate();
-        return outputDir;
+        return output;
     }
 
-    private static File modelFile(Path outputDir, String fileName) {
-        return outputDir.resolve("src/main/java/io/helidon/example/model/" + fileName).toFile();
-    }
-
-    private static String read(File file) throws IOException {
-        return Files.readString(file.toPath());
+    private String read(Path output, String model) throws IOException {
+        return Files.readString(output.resolve("src/main/java/io/helidon/example/model/" + model + ".java"));
     }
 }

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/authoritative-discriminator-adversarial.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/authoritative-discriminator-adversarial.yaml
@@ -13,46 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
----
 openapi: 3.0.3
 info:
-  title: discriminator-enum-reproducer
+  title: Adversarial discriminator cases
   version: 1.0.0
 paths: {}
 components:
   schemas:
-    ConditionShapeDetails:
-      type: object
-      required:
-        - conditionShape
-      discriminator:
-        propertyName: conditionShape
-        mapping:
-          CHANGE_FREEZE: '#/components/schemas/ChangeFreezeConditionShape'
-          TIME_WINDOW_CONSTRAINTS: '#/components/schemas/TimeWindowConstraintsConditionShape'
-      properties:
-        conditionShape:
-          type: string
-          enum:
-            - CHANGE_FREEZE
-            - TIME_WINDOW_CONSTRAINTS
-
-    ChangeFreezeConditionShape:
-      allOf:
-        - $ref: '#/components/schemas/ConditionShapeDetails'
-        - type: object
-          properties:
-            changeFreezeDetails:
-              type: string
-
-    TimeWindowConstraintsConditionShape:
-      allOf:
-        - $ref: '#/components/schemas/ConditionShapeDetails'
-        - type: object
-          properties:
-            timeWindowDetails:
-              type: string
-
     ExtensionBase:
       type: object
       properties:

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/authoritative-discriminators.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/authoritative-discriminators.yaml
@@ -39,6 +39,8 @@ components:
         - $ref: '#/components/schemas/DeclaredBase'
         - type: object
           properties:
+            kind:
+              type: string
             whiskers:
               type: integer
               format: int32

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/authoritative-discriminators.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/authoritative-discriminators.yaml
@@ -1,0 +1,117 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+---
+openapi: 3.0.3
+info:
+  title: Authoritative discriminators
+  version: 1.0.0
+paths: {}
+components:
+  schemas:
+    DeclaredBase:
+      type: object
+      discriminator:
+        propertyName: kind
+        mapping:
+          weird.alias: '#/components/schemas/DeclaredCat'
+          MixedCase-2: '#/components/schemas/DeclaredDog'
+      required: [kind]
+      properties:
+        kind:
+          type: string
+        common:
+          type: string
+    DeclaredCat:
+      allOf:
+        - $ref: '#/components/schemas/DeclaredBase'
+        - type: object
+          properties:
+            whiskers:
+              type: integer
+              format: int32
+    DeclaredDog:
+      allOf:
+        - $ref: '#/components/schemas/DeclaredBase'
+        - type: object
+          properties:
+            bark:
+              type: boolean
+    DeclaredBird:
+      allOf:
+        - $ref: '#/components/schemas/DeclaredBase'
+        - type: object
+          properties:
+            wingspan:
+              type: integer
+              format: int32
+    MetadataAlpha:
+      type: object
+      properties:
+        alpha:
+          type: string
+    MetadataBeta:
+      type: object
+      properties:
+        beta:
+          type: string
+    MetadataChoice:
+      oneOf:
+        - $ref: '#/components/schemas/MetadataAlpha'
+        - $ref: '#/components/schemas/MetadataBeta'
+      discriminator:
+        propertyName: category
+        mapping:
+          alpha.v1: '#/components/schemas/MetadataAlpha'
+    ForcedMetadataCat:
+      type: object
+      properties:
+        type:
+          type: string
+        value:
+          type: string
+    ForcedMetadataDog:
+      type: object
+      properties:
+        type:
+          type: string
+        count:
+          type: integer
+          format: int32
+    ForcedMetadata:
+      x-helidon-discriminator-representation: metadata
+      oneOf:
+        - $ref: '#/components/schemas/ForcedMetadataCat'
+        - $ref: '#/components/schemas/ForcedMetadataDog'
+      discriminator:
+        propertyName: type
+    ForcedReadOnlyAlpha:
+      type: object
+      properties:
+        value:
+          type: string
+    ForcedReadOnlyBeta:
+      type: object
+      properties:
+        count:
+          type: integer
+          format: int32
+    ForcedReadOnly:
+      x-helidon-discriminator-representation: readOnlyProperty
+      oneOf:
+        - $ref: '#/components/schemas/ForcedReadOnlyAlpha'
+        - $ref: '#/components/schemas/ForcedReadOnlyBeta'
+      discriminator:
+        propertyName: type

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/composed-schemas.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/composed-schemas.yaml
@@ -135,6 +135,33 @@ components:
             name:
               type: string
               description: Extended name
+    LayeredBase:
+      type: object
+      discriminator:
+        propertyName: kind
+        mapping:
+          intermediate: '#/components/schemas/LayeredIntermediate'
+      properties:
+        kind:
+          type: string
+    LayeredIntermediate:
+      discriminator:
+        propertyName: kind
+        mapping:
+          leaf: '#/components/schemas/LayeredLeaf'
+      allOf:
+        - $ref: '#/components/schemas/LayeredBase'
+        - type: object
+          properties:
+            middle:
+              type: string
+    LayeredLeaf:
+      allOf:
+        - $ref: '#/components/schemas/LayeredIntermediate'
+        - type: object
+          properties:
+            leaf:
+              type: string
     Cat:
       type: object
       required:

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/composed-schemas.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/composed-schemas.yaml
@@ -173,6 +173,24 @@ components:
         whiskers:
           type: integer
           format: int32
+    MetadataAlpha:
+      type: object
+      properties:
+        alpha:
+          type: string
+    MetadataBeta:
+      type: object
+      properties:
+        beta:
+          type: string
+    MetadataChoice:
+      oneOf:
+        - $ref: '#/components/schemas/MetadataAlpha'
+        - $ref: '#/components/schemas/MetadataBeta'
+      discriminator:
+        propertyName: category
+        mapping:
+          alpha.v1: '#/components/schemas/MetadataAlpha'
     Dog:
       type: object
       required:

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/composed-schemas.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/composed-schemas.yaml
@@ -140,7 +140,7 @@ components:
       discriminator:
         propertyName: kind
         mapping:
-          intermediate: '#/components/schemas/LayeredIntermediate'
+          leaf: '#/components/schemas/LayeredIntermediate'
       properties:
         kind:
           type: string

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/composed-schemas.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/composed-schemas.yaml
@@ -163,7 +163,7 @@ components:
       discriminator:
         propertyName: kind
         mapping:
-          cat&special: '#/components/schemas/Cat'
+          cat$special: '#/components/schemas/Cat'
           dog: '#/components/schemas/Dog'
     NullablePet:
       nullable: true
@@ -173,7 +173,7 @@ components:
       discriminator:
         propertyName: kind
         mapping:
-          cat&special: '#/components/schemas/Cat'
+          cat$special: '#/components/schemas/Cat'
           dog: '#/components/schemas/Dog'
     EmailContact:
       type: object

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/discriminator-allof.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/discriminator-allof.yaml
@@ -39,6 +39,8 @@ components:
       type: object
       discriminator:
         propertyName: conditionShape
+        mapping:
+          CHANGE_FREEZE: '#/components/schemas/CreateChangeFreezeConditionShape'
       properties:
         conditionShape:
           type: string

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/discriminator-enum-mapping-repro-2.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/discriminator-enum-mapping-repro-2.yaml
@@ -28,8 +28,8 @@ components:
       discriminator:
         propertyName: type
         mapping:
-          UserConfigStringValue: '#/components/schemas/UserConfigStringValue'
-          UserConfigInstantValue: '#/components/schemas/UserConfigInstantValue'
+          STRING: '#/components/schemas/UserConfigStringValue'
+          INSTANT: '#/components/schemas/UserConfigInstantValue'
       properties:
         type:
           type: string

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/discriminator-enum-mapping-repro.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/discriminator-enum-mapping-repro.yaml
@@ -28,8 +28,8 @@ components:
       discriminator:
         propertyName: conditionShape
         mapping:
-          ChangeFreezeConditionShape: '#/components/schemas/ChangeFreezeConditionShape'
-          TimeWindowConstraintsConditionShape: '#/components/schemas/TimeWindowConstraintsConditionShape'
+          CHANGE_FREEZE: '#/components/schemas/ChangeFreezeConditionShape'
+          TIME_WINDOW_CONSTRAINTS: '#/components/schemas/TimeWindowConstraintsConditionShape'
       properties:
         conditionShape:
           type: string


### PR DESCRIPTION
## Summary

- serialize one authoritative discriminator using declared OpenAPI mapping values for direct-member and base/union binding;
- use Helidon streaming polymorphic metadata for allOf while retaining an order-independent buffered converter for discriminated oneOf/anyOf;
- reject missing and unknown declared discriminators before structural matching;
- remove mutable subtype-local discriminator state and derive read-only accessors without changing equality/hash-code state;
- route concrete descendants through abstract intermediate discriminator hierarchies;
- add discriminatorRepresentation and x-helidon-discriminator-representation with documented precedence;
- fail ambiguous alias/self mappings deterministically and sanitize credential-bearing URI diagnostics;
- document the intentional discriminator-first constraint for streaming allOf input.

## Verification

- 202 generator tests
- complete 15-module generated-project invoker suite
- generated-runtime direct-member/base round trips, discriminator-last buffered binding, missing/unknown rejection, and three-level hierarchy round trips
- byte-stable regeneration, Javadoc, checkstyle, and copyright checks
- Linux and Windows OpenAPI Generator CI

Fixes #108