### PR TITLE
Upgrade OpenAPI Generator to Helidon 4.5.3

### DIFF
--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/cascading-validation-mapped-containers/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/cascading-validation-mapped-containers/pom.xml
@@ -30,7 +30,7 @@
     <name>OpenAPI Generator IT Cascading Validation Mapped Containers</name>
 
     <properties>
-        <helidon.version>4.5.2</helidon.version>
+        <helidon.version>4.5.3</helidon.version>
         <inputSpec>${project.basedir}/../../specs/cascading-validation-mapped-containers.yaml</inputSpec>
         <skipGeneratedTests>false</skipGeneratedTests>
     </properties>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/cascading-validation/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/cascading-validation/pom.xml
@@ -30,7 +30,7 @@
     <name>OpenAPI Generator IT Cascading Validation</name>
 
     <properties>
-        <helidon.version>4.5.2</helidon.version>
+        <helidon.version>4.5.3</helidon.version>
         <inputSpec>${project.basedir}/../../specs/cascading-validation.yaml</inputSpec>
         <skipGeneratedTests>false</skipGeneratedTests>
     </properties>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/json-string-enums/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/json-string-enums/pom.xml
@@ -30,7 +30,7 @@
     <name>OpenAPI Generator IT JSON String Enums</name>
 
     <properties>
-        <helidon.version>4.5.2</helidon.version>
+        <helidon.version>4.5.3</helidon.version>
         <inputSpec>${project.basedir}/../../specs/json-string-enums.yaml</inputSpec>
         <skipGeneratedTests>false</skipGeneratedTests>
     </properties>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <!-- Compatibility baseline; feature-specific modules override this when they require Helidon 4.5. -->
-        <helidon.version>4.4.1</helidon.version>
+        <helidon.version>4.5.3</helidon.version>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mainClass>io.helidon.example.Main</mainClass>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/swagger2-contracts/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/swagger2-contracts/pom.xml
@@ -30,7 +30,7 @@
     <name>OpenAPI Generator IT Swagger 2 Contracts</name>
 
     <properties>
-        <helidon.version>4.5.2</helidon.version>
+        <helidon.version>4.5.3</helidon.version>
         <inputSpec>${project.basedir}/../../specs/swagger2-contracts.yaml</inputSpec>
         <skipGeneratedTests>false</skipGeneratedTests>
     </properties>

--- a/extensions/openapi-generator/pom.xml
+++ b/extensions/openapi-generator/pom.xml
@@ -42,8 +42,8 @@
     </modules>
 
     <properties>
-        <!-- Compatibility baseline for building the generator; generated projects default to 4.5.2. -->
-        <helidon.version>4.4.1</helidon.version>
+        <!-- Compatibility baseline for building the generator; generated projects default to 4.5.3. -->
+        <helidon.version>4.5.3</helidon.version>
         <version.java>21</version.java>
 
         <version.lib.openapi-generator>7.11.0</version.lib.openapi-generator>


### PR DESCRIPTION
## Summary
- upgrade the OpenAPI Generator compatibility baseline to Helidon 4.5.3
- update generated-project integration-test module defaults to Helidon 4.5.3

## Validation
- mvn -pl extensions/openapi-generator/modules/openapi-generator -am verify -Pcopyright,checkstyle,spotbugs

All 250 tests passed; copyright, Checkstyle, and SpotBugs checks passed.