### PR TITLE
Align OWASP Dependency-Check with core

### DIFF
--- a/etc/scripts/owasp-dependency-check.sh
+++ b/etc/scripts/owasp-dependency-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 #
-# Copyright (c) 2020, 2025 Oracle and/or its affiliates.
+# Copyright (c) 2020, 2026 Oracle and/or its affiliates.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -57,7 +57,7 @@ fi
 mvn ${MAVEN_ARGS} -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN org.owasp:dependency-check-maven:aggregate \
         -f "${WS_DIR}"/pom.xml \
         -Dtop.parent.basedir="${WS_DIR}" \
-        -Dnvd-api-key="${NVD_API_KEY}" \
+        -DnvdApiKey="${NVD_API_KEY}" \
         > "${RESULT_FILE}" || die "Error running the Maven command"
 
 grep -i "One or more dependencies were identified with known vulnerabilities" "${RESULT_FILE}" \

--- a/etc/scripts/owasp-dependency-check.sh
+++ b/etc/scripts/owasp-dependency-check.sh
@@ -57,7 +57,7 @@ fi
 mvn ${MAVEN_ARGS} -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN org.owasp:dependency-check-maven:aggregate \
         -f "${WS_DIR}"/pom.xml \
         -Dtop.parent.basedir="${WS_DIR}" \
-        -DnvdApiKey="${NVD_API_KEY}" \
+        -DnvdApiKeyEnvironmentVariable=NVD_API_KEY \
         > "${RESULT_FILE}" || die "Error running the Maven command"
 
 grep -i "One or more dependencies were identified with known vulnerabilities" "${RESULT_FILE}" \

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <version.plugin.spotbugs>4.7.3.5</version.plugin.spotbugs>
         <version.plugin.surefire>3.1.0</version.plugin.surefire>
         <version.plugin.findsecbugs>1.12.0</version.plugin.findsecbugs>
-        <version.plugin.dependency-check>10.0.3</version.plugin.dependency-check>
+        <version.plugin.dependency-check>13.0.0</version.plugin.dependency-check>
     </properties>
 
     <dependencyManagement>
@@ -304,7 +304,7 @@
                     <configuration>
                         <skip>${dependency-check.skip}</skip>
                         <skipTestScope>true</skipTestScope>
-                        <failBuildOnAnyVulnerability>false</failBuildOnAnyVulnerability>
+                        <failBuildOnCVSS>11</failBuildOnCVSS>
                         <assemblyAnalyzerEnabled>false</assemblyAnalyzerEnabled>
                         <excludes>
                             <exclude>org.testng:testng</exclude>


### PR DESCRIPTION
Resolves #119

Aligns the OWASP Dependency-Check Maven plugin with Helidon core at version `13.0.0`. The removed `failBuildOnAnyVulnerability` setting is replaced with the supported behavior-equivalent CVSS threshold, and the scan script passes the NVD key through the plugin's environment-variable indirection.

This is coordinated with helidon-io/helidon-microprofile#98; core already uses `13.0.0`.
