### PR TITLE
Allow nullable cascading validation boundaries

### DIFF
--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/CascadingValidationSupport.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/CascadingValidationSupport.java
@@ -69,7 +69,6 @@ final class CascadingValidationSupport {
                                                                  directlyConstrained);
         Map<String, List<CodegenProperty>> effectiveProperties = effectiveProperties(propertiesByModel, inheritance);
         validateShapes(models, effectiveProperties, modelNames, participating);
-        validateNestedNullability(models, effectiveProperties, modelNames, participating);
         validateAcyclicGraph(effectiveProperties, modelNames, participating);
         Map<String, Set<String>> unsupportedPolymorphicTypes = unsupportedPolymorphicTypes(
                 models, participating, modelSpecificValidation);
@@ -135,39 +134,6 @@ final class CascadingValidationSupport {
             }
         }
         return Set.copyOf(result);
-    }
-
-    private static void validateNestedNullability(List<CodegenModel> models,
-                                                  Map<String, List<CodegenProperty>> propertiesByModel,
-                                                  Set<String> modelNames,
-                                                  Set<String> participating) {
-        for (CodegenModel model : models) {
-            for (CodegenProperty property : propertiesByModel.getOrDefault(model.classname, List.of())) {
-                String javaType = propertyType(property);
-                validateNestedModelNullability(model, property, javaType, modelNames, participating);
-            }
-        }
-    }
-
-    private static void validateNestedModelNullability(CodegenModel model,
-                                                       CodegenProperty property,
-                                                       String javaType,
-                                                       Set<String> modelNames,
-                                                       Set<String> participating) {
-        CodegenProperty nested = property.items != null ? property.items : property.additionalProperties;
-        if (nested == null) {
-            return;
-        }
-        String nestedType = propertyType(nested);
-        if (nested.isNullable
-                && ValidationTypeSupport.isDirectParticipatingModel(nestedType, modelNames, participating)) {
-            throw new IllegalArgumentException("Unsupported nullable cascading validation boundary for schema '"
-                    + model.classname + "', property '" + property.baseName + "', mapped Java type '" + javaType
-                    + "': a nested model element or map value is nullable, but Helidon 4.5 invokes "
-                    + "@Validation.Valid validators eagerly without a null guard. Make nested model values "
-                    + "non-nullable or validate the boundary in application logic.");
-        }
-        validateNestedModelNullability(model, nested, javaType, modelNames, participating);
     }
 
     @SuppressWarnings("unchecked")
@@ -448,17 +414,12 @@ final class CascadingValidationSupport {
                          Analysis analysis,
                          String modelPackage) {
         String javaType = effectiveRequestEntityType(parameter);
-        boolean participatingBoundary = ValidationTypeSupport.referencedModels(javaType, analysis.modelNames).stream()
-                .anyMatch(analysis.participatingModels::contains);
         if (!javaType.equals(parameter.dataType)) {
             parameter.dataType = javaType;
             parameter.datatypeWithEnum = javaType;
             parameter.baseType = javaType;
             parameter.isPrimitiveType = false;
             parameter.isFreeFormObject = false;
-        }
-        if (participatingBoundary) {
-            validateRequestNullability(parameter, javaType);
         }
         Set<String> unsupportedPolymorphicTypes = ValidationTypeSupport.referencedModels(
                 javaType, analysis.unsupportedPolymorphicTypes.keySet());
@@ -511,33 +472,6 @@ final class CascadingValidationSupport {
                     + contentTypes + '.');
         }
         return contentTypes.stream().findFirst().orElse(parameter.dataType);
-    }
-
-    private static void validateRequestNullability(CodegenParameter parameter, String javaType) {
-        if (!parameter.requiredAndNotNullable()) {
-            throw new IllegalArgumentException("Unsupported nullable cascading validation request entity '"
-                    + parameter.baseName + "', mapped Java type '" + javaType + "'. Helidon 4.5 invokes "
-                    + "@Validation.Valid validators eagerly and does not guard null. Make the request body required "
-                    + "and non-nullable or validate it in application logic.");
-        }
-        validateNestedRequestNullability(parameter.items, parameter.baseName, javaType);
-        validateNestedRequestNullability(parameter.additionalProperties, parameter.baseName, javaType);
-    }
-
-    private static void validateNestedRequestNullability(CodegenProperty property,
-                                                          String parameterName,
-                                                          String javaType) {
-        if (property == null) {
-            return;
-        }
-        if (property.isModel && property.isNullable) {
-            throw new IllegalArgumentException("Unsupported nullable cascading validation request entity '"
-                    + parameterName + "', mapped Java type '" + javaType + "': a nested model element or map value "
-                    + "is nullable, but Helidon 4.5 invokes @Validation.Valid validators eagerly without a null "
-                    + "guard. Make nested model values non-nullable or validate the boundary in application logic.");
-        }
-        validateNestedRequestNullability(property.items, parameterName, javaType);
-        validateNestedRequestNullability(property.additionalProperties, parameterName, javaType);
     }
 
     static void applyInherited(CodegenModel model,

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/CascadingValidationGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/CascadingValidationGenerationIT.java
@@ -195,37 +195,43 @@ class CascadingValidationGenerationIT {
     }
 
     @Test
-    void rejectsNullableDirectRequestEntityBeforeRendering() {
+    void supportsNullableDirectRequestEntity() throws Exception {
         Path target = outputDir.resolve("nullable-request");
-        RuntimeException error = assertThrows(RuntimeException.class,
-                                              () -> generate(target,
-                                                             "nullable-request-cascading-validation.yaml",
-                                                             null));
-        assertThat(rootMessage(error), containsString("nullable cascading validation request entity"));
-        assertThat(rootMessage(error), containsString("ConstrainedChild"));
+        generate(target, "nullable-request-cascading-validation.yaml", null);
+        assertThat(read(apiFile(target, "DefaultApi.java")),
+                   containsString("@Validation.Valid @Http.Entity ConstrainedChild constrainedChild"));
     }
 
     @Test
-    void rejectsNullableRequestContainerElementBeforeRendering() {
+    void supportsOpenApiRequestEntityWhenRequiredIsOmitted() throws Exception {
+        Path target = outputDir.resolve("optional-request");
+        generate(target, "optional-request-cascading-validation.yaml", null);
+        assertThat(read(apiFile(target, "DefaultApi.java")),
+                   containsString("@Validation.Valid @Http.Entity ConstrainedChild constrainedChild"));
+    }
+
+    @Test
+    void supportsSwagger2RequestEntityWhenRequiredIsOmitted() throws Exception {
+        Path target = outputDir.resolve("swagger2-optional-request");
+        generate(target, "swagger2-optional-request-cascading-validation.yaml", null);
+        assertThat(read(apiFile(target, "DefaultApi.java")),
+                   containsString("@Validation.Valid @Http.Entity ConstrainedChild child"));
+    }
+
+    @Test
+    void supportsNullableRequestContainerElement() throws Exception {
         Path target = outputDir.resolve("nullable-request-element");
-        RuntimeException error = assertThrows(RuntimeException.class,
-                                              () -> generate(target,
-                                                             "nullable-request-element-cascading-validation.yaml",
-                                                             null));
-        assertThat(rootMessage(error), containsString("nested model element or map value is nullable"));
-        assertThat(rootMessage(error), containsString("List<ConstrainedChild>"));
+        generate(target, "nullable-request-element-cascading-validation.yaml", null);
+        assertThat(read(apiFile(target, "DefaultApi.java")),
+                   containsString("@Http.Entity List<@Validation.Valid ConstrainedChild> constrainedChild"));
     }
 
     @Test
-    void rejectsNullableModelContainerElementBeforeRendering() {
+    void supportsNullableModelContainerElement() throws Exception {
         Path target = outputDir.resolve("nullable-model-element");
-        IllegalArgumentException error = assertThrows(IllegalArgumentException.class,
-                                                       () -> generate(target,
-                                                                      "nullable-model-element-cascading-validation.yaml",
-                                                                      null));
-        assertThat(error.getMessage(), containsString("schema 'Parent', property 'children'"));
-        assertThat(error.getMessage(), containsString("nested model element or map value is nullable"));
-        assertThat(Files.exists(modelFile(target, "Parent.java")), org.hamcrest.CoreMatchers.is(false));
+        generate(target, "nullable-model-element-cascading-validation.yaml", null);
+        assertThat(read(modelFile(target, "Parent.java")),
+                   containsString("public List<@Validation.Valid ConstrainedChild> children()"));
     }
 
     @Test

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/optional-request-cascading-validation.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/optional-request-cascading-validation.yaml
@@ -15,20 +15,17 @@
 #
 openapi: 3.0.3
 info:
-  title: Nullable request cascading validation
+  title: Optional request cascading validation
   version: "1.0"
 paths:
   /child:
     post:
       operationId: createChild
       requestBody:
-        required: false
         content:
           application/json:
             schema:
-              nullable: true
-              allOf:
-                - $ref: '#/components/schemas/ConstrainedChild'
+              $ref: '#/components/schemas/ConstrainedChild'
       responses:
         "204":
           description: Valid

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/resources/swagger2-optional-request-cascading-validation.yaml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/resources/swagger2-optional-request-cascading-validation.yaml
@@ -13,30 +13,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-openapi: 3.0.3
+swagger: "2.0"
 info:
-  title: Nullable request cascading validation
+  title: Swagger 2 optional request cascading validation
   version: "1.0"
+basePath: /
 paths:
   /child:
     post:
       operationId: createChild
-      requestBody:
-        required: false
-        content:
-          application/json:
-            schema:
-              nullable: true
-              allOf:
-                - $ref: '#/components/schemas/ConstrainedChild'
+      parameters:
+        - name: child
+          in: body
+          schema:
+            $ref: '#/definitions/ConstrainedChild'
       responses:
         "204":
           description: Valid
-components:
-  schemas:
-    ConstrainedChild:
-      type: object
-      properties:
-        code:
-          type: string
-          minLength: 3
+definitions:
+  ConstrainedChild:
+    type: object
+    properties:
+      code:
+        type: string
+        minLength: 3


### PR DESCRIPTION
### Description

Fixes #118 by allowing declarative OpenAPI generation when cascading validation
crosses an optional or nullable boundary.

Previously, the generator rejected these valid API contracts and required
`required: true` as a workaround. That changed Swagger 2 and OpenAPI 3
semantics by making an optional request body mandatory.

With this change, cascading validation remains present for supplied model
values, while request-body requiredness continues to come from the OpenAPI
contract.

### What changed

- Removed nullability-only rejection paths for direct request bodies, nullable
  collection/map elements, and nullable model container elements.
- Kept existing diagnostics for unsupported containers, recursive validation
  graphs, and unsupported polymorphic dispatch.
- Added generation coverage for:
  - OpenAPI 3 request bodies with `required: false`
  - OpenAPI 3 request bodies with `required` omitted
  - Swagger 2 body parameters with `required` omitted
  - nullable direct and container model boundaries

### Validation

```text
mvn -pl extensions/openapi-generator/modules/openapi-generator -am \
  -Pcheckstyle,copyright,spotbugs verify