### PR TITLE
Preserve Eureka lastDirtyTimestamp for unchanged status

### DIFF
--- a/extensions/eureka/modules/eureka/src/main/java/io/helidon/extensions/eureka/EurekaRegistrationHttpFeature.java
+++ b/extensions/eureka/modules/eureka/src/main/java/io/helidon/extensions/eureka/EurekaRegistrationHttpFeature.java
@@ -651,7 +651,7 @@ final class EurekaRegistrationHttpFeature implements HttpFeature {
     private JsonObject json(JsonObject json, JsonString status) {
         // https://github.com/Netflix/eureka/blob/v2.0.4/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java#L55
         JsonObject instance = json.objectValue("instance", null);
-        if (instance.stringValue("status", null).equals(Objects.requireNonNull(status, "status"))) {
+        if (instance.stringValue("status", null).equals(Objects.requireNonNull(status, "status").value())) {
             return json;
         }
         var b = JsonObject.builder();

--- a/extensions/eureka/modules/eureka/src/main/java/io/helidon/extensions/eureka/EurekaRegistrationHttpFeature.java
+++ b/extensions/eureka/modules/eureka/src/main/java/io/helidon/extensions/eureka/EurekaRegistrationHttpFeature.java
@@ -651,7 +651,7 @@ final class EurekaRegistrationHttpFeature implements HttpFeature {
     private JsonObject json(JsonObject json, JsonString status) {
         // https://github.com/Netflix/eureka/blob/v2.0.4/eureka-client/src/main/java/com/netflix/appinfo/InstanceInfo.java#L55
         JsonObject instance = json.objectValue("instance", null);
-        if (instance.stringValue("status", null).equals(Objects.requireNonNull(status, "status").value())) {
+        if (Objects.requireNonNull(status, "status").value().equals(instance.stringValue("status", null))) {
             return json;
         }
         var b = JsonObject.builder();


### PR DESCRIPTION
Resolves helidon-io/helidon-extensions#123

Preserve the existing Eureka registration state when the requested status already matches the current status. The stored status is a `String`, so compare it with the value represented by the `JsonString` instead of comparing the two different types.

This bug was introduced by the independent Extensions migration to Helidon JSON; the corresponding 4.x implementation already compares like types.
