### PR TITLE
Add Helidon Chaos extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ See README for individual extensions.
 * [OpenAPI UI](extensions/openapi-ui/docs/README.md)
 * [gson](extensions/gson/docs/README.md)
 * [toml](extensions/toml/docs/README.md)
+* [Chaos](extensions/chaos/docs/README.md)
 
 ## Examples
 

--- a/extensions/chaos/THIRD_PARTY_LICENSES.txt
+++ b/extensions/chaos/THIRD_PARTY_LICENSES.txt
@@ -1,0 +1,1 @@
+This module introduces no third-party runtime dependencies.

--- a/extensions/chaos/bom/pom.xml
+++ b/extensions/chaos/bom/pom.xml
@@ -18,33 +18,33 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>io.helidon.extensions</groupId>
-        <artifactId>helidon-extensions-project</artifactId>
+        <artifactId>helidon-extensions-parent</artifactId>
         <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <relativePath>../../../parent/pom.xml</relativePath>
     </parent>
 
-    <artifactId>helidon-extensions-modules-project</artifactId>
-
+    <groupId>io.helidon.extensions.chaos</groupId>
+    <artifactId>helidon-extensions-chaos-bom</artifactId>
+    <version>27.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>Helidon Extensions Modules Project</name>
+    <name>Helidon Extensions Chaos BOM</name>
 
-    <modules>
-        <module>chaos</module>
-        <module>hashicorp-vault</module>
-        <module>neo4j</module>
-        <module>oci-v3</module>
-        <module>langchain4j</module>
-        <module>eureka</module>
-        <module>crac</module>
-        <module>openapi-ui</module>
-        <module>openapi-generator</module>
-        <module>gson</module>
-        <module>toml</module>
-    </modules>
+    <properties>
+        <chaos.extension.version>27.0.0-SNAPSHOT</chaos.extension.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.helidon.extensions.chaos</groupId>
+                <artifactId>helidon-extensions-chaos</artifactId>
+                <version>${chaos.extension.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 </project>

--- a/extensions/chaos/bom/pom.xml
+++ b/extensions/chaos/bom/pom.xml
@@ -29,13 +29,13 @@
 
     <groupId>io.helidon.extensions.chaos</groupId>
     <artifactId>helidon-extensions-chaos-bom</artifactId>
-    <version>27.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Helidon Extensions Chaos BOM</name>
 
     <properties>
-        <chaos.extension.version>27.0.0-SNAPSHOT</chaos.extension.version>
+        <chaos.extension.version>4.0.0-SNAPSHOT</chaos.extension.version>
     </properties>
 
     <dependencyManagement>

--- a/extensions/chaos/docs/README.md
+++ b/extensions/chaos/docs/README.md
@@ -75,6 +75,8 @@ server:
 ```
 
 Startup fails if anonymous mode resolves to a wildcard, non-loopback, unresolved, or unsupported binding.
+For a Unix-domain control socket, restrict the socket path and its parent directories to trusted principals because
+filesystem permissions are the control API's access boundary.
 
 ### Authenticated mode
 

--- a/extensions/chaos/docs/README.md
+++ b/extensions/chaos/docs/README.md
@@ -52,9 +52,9 @@ server:
 
 When disabled, the extension does not inspect sockets, create an engine, register routes, or add filters.
 
-### Loopback-only mode
+### Local-only mode
 
-Anonymous mode is available only when the control listener is bound to loopback.
+Anonymous mode is available only when the control listener is bound to loopback or to a Unix-domain socket.
 
 ```yaml
 server:
@@ -71,10 +71,10 @@ server:
       control-socket: chaos-control
       application-sockets: ["@default"]
       security:
-        allow-unauthenticated-loopback: true
+        allow-unauthenticated-local: true
 ```
 
-Startup fails if anonymous mode resolves to a wildcard or non-loopback binding.
+Startup fails if anonymous mode resolves to a wildcard, non-loopback, unresolved, or unsupported binding.
 
 ### Authenticated mode
 
@@ -105,7 +105,7 @@ server:
       application-sockets: ["@default"]
       security:
         required-role: chaos-operator
-        allow-unauthenticated-loopback: false
+        allow-unauthenticated-local: false
 ```
 
 HTTP Basic authentication is shown only as a self-contained test example. Use an appropriate Helidon authentication provider for your environment. Do not put plaintext credentials in configuration.

--- a/extensions/chaos/docs/README.md
+++ b/extensions/chaos/docs/README.md
@@ -1,0 +1,213 @@
+# Helidon Chaos extension
+
+The Helidon Chaos extension adds a bounded, process-local chaos run engine to Helidon WebServer. Operators create and stop runs through `/chaos/v1` on a dedicated control socket. Matching requests on explicitly selected application sockets can receive a synthetic HTTP error response.
+
+This first slice targets Helidon 27 and is disabled by default.
+
+## Maven coordinates
+
+Import the BOM:
+
+```xml
+<dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.extensions.chaos</groupId>
+            <artifactId>helidon-extensions-chaos-bom</artifactId>
+            <version>27.0.0-SNAPSHOT</version>
+            <type>pom</type>
+            <scope>import</scope>
+        </dependency>
+    </dependencies>
+</dependencyManagement>
+```
+
+Then add the extension when direct packaging is appropriate:
+
+```xml
+<dependency>
+    <groupId>io.helidon.extensions.chaos</groupId>
+    <artifactId>helidon-extensions-chaos</artifactId>
+</dependency>
+```
+
+Helidon discovers the extension through `ServerFeatureProvider`; application code does not register `/chaos/v1` or install a filter.
+
+## Configuration
+
+### Disabled default
+
+```yaml
+server:
+  features:
+    chaos:
+      enabled: false
+```
+
+When disabled, the extension does not inspect sockets, create an engine, register routes, or add filters.
+
+### Loopback-only mode
+
+Anonymous mode is available only when the control listener is bound to loopback.
+
+```yaml
+server:
+  host: 127.0.0.1
+  port: 8080
+  sockets:
+    chaos-control:
+      host: 127.0.0.1
+      port: 9080
+      max-payload-size: 65536
+  features:
+    chaos:
+      enabled: true
+      control-socket: chaos-control
+      application-sockets: ["@default"]
+      security:
+        allow-unauthenticated-loopback: true
+```
+
+Startup fails if anonymous mode resolves to a wildcard or non-loopback binding.
+
+### Authenticated mode
+
+The Chaos extension is authentication-provider-neutral. Configure the normal Helidon `SecurityFeature` with an appropriate authentication provider, and map authorized operators to `chaos-operator`.
+
+```yaml
+server:
+  host: 0.0.0.0
+  port: 8080
+  sockets:
+    chaos-control:
+      host: 0.0.0.0
+      port: 9080
+      max-payload-size: 65536
+  features:
+    security:
+      security:
+        providers:
+          - http-basic-auth:
+              realm: chaos-test
+              users:
+                - login: operator
+                  password: test-only-password
+                  roles: ["chaos-operator"]
+    chaos:
+      enabled: true
+      control-socket: chaos-control
+      application-sockets: ["@default"]
+      security:
+        required-role: chaos-operator
+        allow-unauthenticated-loopback: false
+```
+
+HTTP Basic authentication is shown only as a self-contained test example. Use an appropriate Helidon authentication provider for your environment. Do not put plaintext credentials in configuration.
+
+Enabled mode requires the control listener to have a finite `max-payload-size` no larger than `maximum-control-request-bytes`. Secured mode also fails during server construction unless Helidon Security is enabled and has an authentication provider. Missing sockets and control/application socket overlap fail before traffic is accepted.
+
+## Control API
+
+All resources are under the dedicated control listener:
+
+| Method | Resource | Result |
+|---|---|---|
+| `POST` | `/chaos/v1/runs` | Validate and start one local run; returns `201` and `Location` |
+| `GET` | `/chaos/v1/runs` | List retained runs, newest first |
+| `GET` | `/chaos/v1/runs/{runId}` | Read normalized plan, lifecycle, actor, timestamps, and counters |
+| `DELETE` | `/chaos/v1/runs/{runId}` | Stop a run; returns `200`, or `202` while in-flight work drains |
+
+Validation uses strict JSON. Request-shape errors return `400`; policy and limit violations return `422`; active-run or scope conflicts return `409`. Errors use `application/problem+json` without stack traces or internal configuration data.
+
+### Create a run
+
+```json
+{
+  "name": "orders-unavailable",
+  "maximumDuration": "PT30S",
+  "seed": 148894,
+  "stages": [
+    {
+      "name": "reject-orders",
+      "duration": "PT10S",
+      "disruptions": [
+        {
+          "name": "orders-503",
+          "scope": {
+            "type": "inbound-http",
+            "methods": ["GET"],
+            "path": {"match": "prefix", "value": "/orders"}
+          },
+          "activation": {"type": "always"},
+          "effect": {
+            "type": "synthetic-http-response",
+            "status": 503,
+            "headers": {"Retry-After": "1"},
+            "mediaType": "application/problem+json",
+            "body": "{\"title\":\"Synthetic service failure\",\"status\":503}"
+          },
+          "budget": {"maximumActivations": 20, "maximumConcurrent": 2}
+        }
+      ]
+    }
+  ]
+}
+```
+
+An exact path matches only that path. A prefix is segment-aware: `/orders` matches `/orders` and `/orders/42`, but not `/orders-old`. The filter does not invoke application code after it reserves a synthetic response. Non-matching or budget-skipped traffic continues normally.
+
+Activation can also select a deterministic fraction of matching requests:
+
+```json
+{"type": "probability", "probability": 0.25}
+```
+
+`probability` must be between `2^-53` (approximately `1.1102230246251565e-16`) and one, matching the sampler's explicit 53-bit resolution. Values below that resolution, or values below one that would round to one, are rejected rather than silently changing their meaning. The extension derives an independent pseudo-random stream from the run `seed` and unambiguously encoded stage/disruption identity. The same normalized plan, seed, and matched-request order therefore produce the same decisions. Probability misses increment `skippedActivation` and do not consume cumulative or concurrency budget. The implementation uses extension-owned deterministic mixing rather than a JDK random-generator implementation.
+
+```bash
+curl --fail-with-body \
+  --user operator:test-only-password \
+  --header 'Content-Type: application/json' \
+  --data @run.json \
+  http://127.0.0.1:9080/chaos/v1/runs
+
+curl --fail-with-body --user operator:test-only-password \
+  http://127.0.0.1:9080/chaos/v1/runs
+
+curl --fail-with-body --user operator:test-only-password \
+  http://127.0.0.1:9080/chaos/v1/runs/7bb7b42d-5056-4b88-a734-e309909d1721
+
+# DELETE /chaos/v1/runs/{runId}
+curl --fail-with-body --request DELETE --user operator:test-only-password \
+  http://127.0.0.1:9080/chaos/v1/runs/7bb7b42d-5056-4b88-a734-e309909d1721
+```
+
+## Server-enforced limits
+
+| Configuration key under `server.features.chaos.limits` | Default |
+|---|---:|
+| `maximum-active-runs` | `1` |
+| `maximum-run-duration` | `PT15M` |
+| `maximum-activations-per-disruption` | `10000` |
+| `maximum-concurrent-activations-per-disruption` | `64` |
+| `maximum-synthetic-body-bytes` | `65536` |
+| `maximum-control-request-bytes` | `65536` |
+| `maximum-concurrent-control-requests` | `16` |
+| `maximum-retained-runs` | `32` |
+| `terminal-run-retention` | `PT15M` |
+
+Request budgets may be lower than these ceilings but never higher. Concurrent and cumulative reservations are atomic,
+and stopping a run prevents new reservations while in-flight work drains.
+
+## Runtime model and first-slice boundary
+
+Runs are local to one Helidon server process, in memory, bounded, and not reconstructed after restart. A caller must create a run on each selected instance. Restart is an unconditional cleanup boundary.
+
+The current slice intentionally supports one stage, one inbound HTTP disruption, `always` or deterministic
+`probability` activation, exact or segment-aware prefix paths, and a synthetic 4xx/5xx HTTP response. Its public vocabulary includes `runs`, `stages`,
+`disruptions`, `scope`, `activation`, `effect`, and `budget` so later additions can introduce invocation cycles,
+repetitions, and other bounded local effects without adopting another project's API.
+
+Out of scope for this slice are timeout or connection-stall effects, bytecode injection, exception injection inside
+arbitrary methods, outbound client failures, CPU or memory pressure, network faults outside the process, distributed
+orchestration, persistent run recovery, and automatic enablement.

--- a/extensions/chaos/docs/README.md
+++ b/extensions/chaos/docs/README.md
@@ -2,7 +2,7 @@
 
 The Helidon Chaos extension adds a bounded, process-local chaos run engine to Helidon WebServer. Operators create and stop runs through `/chaos/v1` on a dedicated control socket. Matching requests on explicitly selected application sockets can receive a synthetic HTTP error response.
 
-This first slice targets Helidon 27 and is disabled by default.
+This first slice targets Helidon 4.5.3 and is disabled by default.
 
 ## Maven coordinates
 
@@ -14,7 +14,7 @@ Import the BOM:
         <dependency>
             <groupId>io.helidon.extensions.chaos</groupId>
             <artifactId>helidon-extensions-chaos-bom</artifactId>
-            <version>27.0.0-SNAPSHOT</version>
+            <version>4.0.0-SNAPSHOT</version>
             <type>pom</type>
             <scope>import</scope>
         </dependency>

--- a/extensions/chaos/docs/README.md
+++ b/extensions/chaos/docs/README.md
@@ -4,6 +4,12 @@ The Helidon Chaos extension adds a bounded, process-local chaos run engine to He
 
 This first slice targets Helidon 4.5.3 and is disabled by default.
 
+## Versioning
+
+The Chaos extension deliberately declares its own `4.0.0-SNAPSHOT` project and BOM version so that it can track the
+Helidon 4 compatibility line independently of the parent extensions repository version. This is a documented exception
+to Helidon development guideline 4.2.2.3, which normally requires modules to inherit their version.
+
 ## Maven coordinates
 
 Import the BOM:

--- a/extensions/chaos/modules/chaos/pom.xml
+++ b/extensions/chaos/modules/chaos/pom.xml
@@ -1,0 +1,176 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.extensions.chaos</groupId>
+        <artifactId>helidon-extensions-chaos-modules-project</artifactId>
+        <version>27.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-extensions-chaos</artifactId>
+    <name>Helidon Extensions Chaos</name>
+    <description>Bounded local chaos engineering for Helidon WebServer.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.builder</groupId>
+            <artifactId>helidon-builder-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common</groupId>
+            <artifactId>helidon-common-media-type</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.common.features</groupId>
+            <artifactId>helidon-common-features-api</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config.metadata</groupId>
+            <artifactId>helidon-config-metadata</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.http</groupId>
+            <artifactId>helidon-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.http.media</groupId>
+            <artifactId>helidon-http-media</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.json</groupId>
+            <artifactId>helidon-json</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.service</groupId>
+            <artifactId>helidon-service-registry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>io.helidon.http.media</groupId>
+            <artifactId>helidon-http-media-json</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.common.features</groupId>
+                            <artifactId>helidon-common-features-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.config.metadata</groupId>
+                            <artifactId>helidon-config-metadata-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.builder</groupId>
+                            <artifactId>helidon-builder-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.helidon.common.features</groupId>
+                        <artifactId>helidon-common-features-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.config.metadata</groupId>
+                        <artifactId>helidon-config-metadata-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.builder</groupId>
+                        <artifactId>helidon-builder-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/chaos/modules/chaos/pom.xml
+++ b/extensions/chaos/modules/chaos/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.extensions.chaos</groupId>
         <artifactId>helidon-extensions-chaos-modules-project</artifactId>
-        <version>27.0.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-extensions-chaos</artifactId>

--- a/extensions/chaos/modules/chaos/pom.xml
+++ b/extensions/chaos/modules/chaos/pom.xml
@@ -63,7 +63,7 @@
         </dependency>
         <dependency>
             <groupId>io.helidon.http.media</groupId>
-            <artifactId>helidon-http-media</artifactId>
+            <artifactId>helidon-http-media-json</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.json</groupId>
@@ -74,18 +74,16 @@
             <artifactId>helidon-service-registry</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.helidon.security</groupId>
+            <artifactId>helidon-security</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver</artifactId>
         </dependency>
         <dependency>
             <groupId>io.helidon.webserver</groupId>
             <artifactId>helidon-webserver-security</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>io.helidon.http.media</groupId>
-            <artifactId>helidon-http-media-json</artifactId>
-            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosActivation.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosActivation.java
@@ -18,7 +18,7 @@ package io.helidon.extensions.chaos;
 /**
  * Determines whether a matched invocation attempts to reserve disruption budget.
  */
-sealed interface ChaosActivation permits AlwaysActivation, ProbabilityActivation {
+sealed interface ChaosActivation permits ChaosActivation.AlwaysActivation, ChaosActivation.ProbabilityActivation {
 
     /**
      * Shared activation that accepts every matched invocation.
@@ -28,25 +28,25 @@ sealed interface ChaosActivation permits AlwaysActivation, ProbabilityActivation
     static ChaosActivation always() {
         return ALWAYS;
     }
-}
 
-/**
- * Activates every matched invocation.
- */
-final class AlwaysActivation implements ChaosActivation {
-}
+    /**
+     * Activates every matched invocation.
+     */
+    final class AlwaysActivation implements ChaosActivation {
+    }
 
-/**
- * Activates a deterministic fraction of matched invocations.
- *
- * @param probability value greater than zero and at most one
- */
-record ProbabilityActivation(double probability) implements ChaosActivation {
-    private static final double MINIMUM = 0x1.0p-53;
+    /**
+     * Activates a deterministic fraction of matched invocations.
+     *
+     * @param probability value greater than zero and at most one
+     */
+    record ProbabilityActivation(double probability) implements ChaosActivation {
+        private static final double MINIMUM = 0x1.0p-53;
 
-    ProbabilityActivation {
-        if (!Double.isFinite(probability) || probability < MINIMUM || probability > 1) {
-            throw new IllegalArgumentException("probability must be between 2^-53 and one");
+        public ProbabilityActivation {
+            if (!Double.isFinite(probability) || probability < MINIMUM || probability > 1) {
+                throw new IllegalArgumentException("probability must be between 2^-53 and one");
+            }
         }
     }
 }

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosActivation.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosActivation.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+/**
+ * Determines whether a matched invocation attempts to reserve disruption budget.
+ */
+sealed interface ChaosActivation permits ChaosActivation.Always, ChaosActivation.Probability {
+
+    /**
+     * Shared activation that accepts every matched invocation.
+     */
+    Always ALWAYS = new Always();
+
+    static Always always() {
+        return ALWAYS;
+    }
+
+    /**
+     * Activates every matched invocation.
+     */
+    record Always() implements ChaosActivation {
+    }
+
+    /**
+     * Activates a deterministic fraction of matched invocations.
+     *
+     * @param probability value greater than zero and at most one
+     */
+    record Probability(double probability) implements ChaosActivation {
+        private static final double MINIMUM = 0x1.0p-53;
+
+        public Probability {
+            if (!Double.isFinite(probability) || probability < MINIMUM || probability > 1) {
+                throw new IllegalArgumentException("probability must be between 2^-53 and one");
+            }
+        }
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosActivation.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosActivation.java
@@ -43,6 +43,7 @@ sealed interface ChaosActivation permits ChaosActivation.AlwaysActivation, Chaos
     record ProbabilityActivation(double probability) implements ChaosActivation {
         private static final double MINIMUM = 0x1.0p-53;
 
+        // must be public, as the record is implicitly public (on interface), even though it cannot be accessed
         public ProbabilityActivation {
             if (!Double.isFinite(probability) || probability < MINIMUM || probability > 1) {
                 throw new IllegalArgumentException("probability must be between 2^-53 and one");

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosActivation.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosActivation.java
@@ -18,35 +18,35 @@ package io.helidon.extensions.chaos;
 /**
  * Determines whether a matched invocation attempts to reserve disruption budget.
  */
-sealed interface ChaosActivation permits ChaosActivation.Always, ChaosActivation.Probability {
+sealed interface ChaosActivation permits AlwaysActivation, ProbabilityActivation {
 
     /**
      * Shared activation that accepts every matched invocation.
      */
-    Always ALWAYS = new Always();
+    ChaosActivation ALWAYS = new AlwaysActivation();
 
-    static Always always() {
+    static ChaosActivation always() {
         return ALWAYS;
     }
+}
 
-    /**
-     * Activates every matched invocation.
-     */
-    record Always() implements ChaosActivation {
-    }
+/**
+ * Activates every matched invocation.
+ */
+final class AlwaysActivation implements ChaosActivation {
+}
 
-    /**
-     * Activates a deterministic fraction of matched invocations.
-     *
-     * @param probability value greater than zero and at most one
-     */
-    record Probability(double probability) implements ChaosActivation {
-        private static final double MINIMUM = 0x1.0p-53;
+/**
+ * Activates a deterministic fraction of matched invocations.
+ *
+ * @param probability value greater than zero and at most one
+ */
+record ProbabilityActivation(double probability) implements ChaosActivation {
+    private static final double MINIMUM = 0x1.0p-53;
 
-        public Probability {
-            if (!Double.isFinite(probability) || probability < MINIMUM || probability > 1) {
-                throw new IllegalArgumentException("probability must be between 2^-53 and one");
-            }
+    ProbabilityActivation {
+        if (!Double.isFinite(probability) || probability < MINIMUM || probability > 1) {
+            throw new IllegalArgumentException("probability must be between 2^-53 and one");
         }
     }
 }

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosActivationDecider.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosActivationDecider.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Stable activation decisions that do not depend on JDK random-generator implementations.
+ */
+final class ChaosActivationDecider {
+    private static final long FNV_OFFSET_BASIS = 0xcbf29ce484222325L;
+    private static final long FNV_PRIME = 0x100000001b3L;
+    private static final long GOLDEN_GAMMA = 0x9e3779b97f4a7c15L;
+    private static final double DOUBLE_UNIT = 0x1.0p-53;
+
+    private ChaosActivationDecider() {
+    }
+
+    static long streamSeed(long runSeed, String... identities) {
+        long identityHash = FNV_OFFSET_BASIS;
+        identityHash = hashByte(identityHash, identities.length);
+        for (String component : identities) {
+            byte[] bytes = component.getBytes(StandardCharsets.UTF_8);
+            identityHash = hashByte(identityHash, bytes.length >>> 24);
+            identityHash = hashByte(identityHash, bytes.length >>> 16);
+            identityHash = hashByte(identityHash, bytes.length >>> 8);
+            identityHash = hashByte(identityHash, bytes.length);
+            for (byte value : bytes) {
+                identityHash = hashByte(identityHash, value);
+            }
+        }
+        return mix64(runSeed ^ identityHash);
+    }
+
+    static boolean activates(ChaosActivation activation, long streamSeed, long matchedInvocation) {
+        if (activation instanceof ChaosActivation.Probability probability) {
+            long sampleBits = mix64(streamSeed + (matchedInvocation - 1) * GOLDEN_GAMMA);
+            double sample = (sampleBits >>> 11) * DOUBLE_UNIT;
+            return sample < probability.probability();
+        }
+        return true;
+    }
+
+    static long mix64(long value) {
+        long mixed = value;
+        mixed = (mixed ^ (mixed >>> 30)) * 0xbf58476d1ce4e5b9L;
+        mixed = (mixed ^ (mixed >>> 27)) * 0x94d049bb133111ebL;
+        return mixed ^ (mixed >>> 31);
+    }
+
+    private static long hashByte(long hash, int value) {
+        return (hash ^ (value & 0xff)) * FNV_PRIME;
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosActivationDecider.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosActivationDecider.java
@@ -46,7 +46,7 @@ final class ChaosActivationDecider {
     }
 
     static boolean activates(ChaosActivation activation, long streamSeed, long matchedInvocation) {
-        if (activation instanceof ChaosActivation.Probability probability) {
+        if (activation instanceof ProbabilityActivation probability) {
             long sampleBits = mix64(streamSeed + (matchedInvocation - 1) * GOLDEN_GAMMA);
             double sample = (sampleBits >>> 11) * DOUBLE_UNIT;
             return sample < probability.probability();

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosActivationDecider.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosActivationDecider.java
@@ -17,6 +17,8 @@ package io.helidon.extensions.chaos;
 
 import java.nio.charset.StandardCharsets;
 
+import io.helidon.extensions.chaos.ChaosActivation.ProbabilityActivation;
+
 /**
  * Stable activation decisions that do not depend on JDK random-generator implementations.
  */

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosApplicationFilter.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosApplicationFilter.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.util.Optional;
+
+import io.helidon.http.HeaderNames;
+import io.helidon.webserver.http.Filter;
+import io.helidon.webserver.http.FilterChain;
+import io.helidon.webserver.http.RoutingRequest;
+import io.helidon.webserver.http.RoutingResponse;
+
+
+/**
+ * Applies accepted disruption reservations before application routing.
+ */
+final class ChaosApplicationFilter implements Filter {
+    private final ChaosRunEngine engine;
+
+    ChaosApplicationFilter(ChaosRunEngine engine) {
+        this.engine = engine;
+    }
+
+    @Override
+    public void filter(FilterChain chain, RoutingRequest request, RoutingResponse response) {
+        String method = request.prologue().method().text();
+        String path = request.path().absolute().path();
+        Optional<ChaosRunEngine.Reservation> candidate = engine.reserve(method, path);
+        if (candidate.isEmpty()) {
+            chain.proceed();
+            return;
+        }
+
+        try (ChaosRunEngine.Reservation reservation = candidate.orElseThrow()) {
+            ChaosSyntheticResponse effect = (ChaosSyntheticResponse) reservation.effect();
+            byte[] body = effect.body();
+            response.status(effect.status());
+            effect.headers().forEach(response::header);
+            effect.mediaType().ifPresent(mediaType -> response.header(HeaderNames.CONTENT_TYPE, mediaType.text()));
+            response.contentLength(body.length);
+            if (body.length == 0) {
+                response.send();
+            } else {
+                response.send(body);
+            }
+        }
+    }
+
+    @Override
+    public void afterStop() {
+        engine.close();
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosBudget.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosBudget.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+/**
+ * Cumulative and concurrent activation ceilings.
+ *
+ * @param maximumActivations maximum cumulative activations
+ * @param maximumConcurrent maximum concurrent activations
+ */
+record ChaosBudget(long maximumActivations, int maximumConcurrent) {
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosConfigBlueprint.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosConfigBlueprint.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.util.Optional;
+import java.util.Set;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+import io.helidon.webserver.spi.ServerFeatureProvider;
+
+/**
+ * Startup configuration for the Helidon Chaos server feature.
+ */
+@Prototype.Blueprint(decorator = ChaosConfigSupport.BuilderDecorator.class)
+@Prototype.Configured(value = "chaos", root = false)
+@Prototype.Provides(ServerFeatureProvider.class)
+interface ChaosConfigBlueprint extends Prototype.Factory<ChaosServerFeature> {
+
+    /**
+     * Whether the feature is enabled at server startup.
+     *
+     * @return whether the feature is enabled
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(false)
+    boolean enabled();
+
+    /**
+     * Name of the dedicated control socket.
+     *
+     * @return control socket name
+     */
+    @Option.Configured
+    Optional<String> controlSocket();
+
+    /**
+     * Names of sockets whose application traffic may be disrupted.
+     *
+     * @return application socket names
+     */
+    @Option.Configured
+    @Option.Singular
+    Set<String> applicationSockets();
+
+    /**
+     * Control-plane security configuration.
+     *
+     * @return security configuration
+     */
+    @Option.Configured
+    @Option.DefaultMethod("create")
+    ChaosSecurityConfig security();
+
+    /**
+     * Server-enforced ceilings for all runs.
+     *
+     * @return configured ceilings
+     */
+    @Option.Configured
+    @Option.DefaultMethod("create")
+    ChaosLimitsConfig limits();
+
+    /**
+     * Configured feature instance name.
+     *
+     * @return feature instance name
+     */
+    @Option.Default("chaos")
+    String name();
+
+    /**
+     * Feature installation weight.
+     *
+     * @return feature weight
+     */
+    @Option.Configured
+    @Option.DefaultDouble(700.0)
+    double weight();
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosConfigSupport.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosConfigSupport.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import io.helidon.builder.api.Prototype;
+
+/**
+ * Cross-property validation for {@link ChaosConfig}.
+ */
+final class ChaosConfigSupport {
+
+    private ChaosConfigSupport() {
+    }
+
+    static final class BuilderDecorator implements Prototype.BuilderDecorator<ChaosConfig.BuilderBase<?, ?>> {
+
+        @Override
+        public void decorate(ChaosConfig.BuilderBase<?, ?> builder) {
+            requireText(builder.name(), "Chaos feature name must not be blank");
+            builder.controlSocket().ifPresent(socket -> requireText(socket, "Control socket name must not be blank"));
+            builder.applicationSockets()
+                    .forEach(socket -> requireText(socket, "Application socket name must not be blank"));
+
+            if (!builder.enabled()) {
+                return;
+            }
+            String controlSocket = builder.controlSocket()
+                    .orElseThrow(() -> new IllegalArgumentException("Enabled Chaos requires control-socket"));
+            if (builder.applicationSockets().isEmpty()) {
+                throw new IllegalArgumentException("Enabled Chaos requires at least one application-socket");
+            }
+            if (builder.applicationSockets().contains(controlSocket)) {
+                throw new IllegalArgumentException("Control socket must not be an application socket");
+            }
+        }
+
+        private static void requireText(String value, String message) {
+            if (value.isBlank()) {
+                throw new IllegalArgumentException(message);
+            }
+        }
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosControlService.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosControlService.java
@@ -44,26 +44,26 @@ final class ChaosControlService implements HttpService {
 
     private final ChaosRunEngine engine;
     private final ChaosLimitsConfig limits;
-    private final boolean anonymousLoopback;
+    private final boolean anonymousLocal;
     private final Handler authorization;
     private final Semaphore capacity;
 
-    ChaosControlService(ChaosRunEngine engine, ChaosConfig config, boolean anonymousLoopback) {
+    ChaosControlService(ChaosRunEngine engine, ChaosConfig config, boolean anonymousLocal) {
         this(engine,
              config,
-             anonymousLoopback,
+             anonymousLocal,
              new Semaphore(config.limits().maximumConcurrentControlRequests(), true));
     }
 
     ChaosControlService(ChaosRunEngine engine,
                         ChaosConfig config,
-                        boolean anonymousLoopback,
+                        boolean anonymousLocal,
                         Semaphore capacity) {
         this.engine = Objects.requireNonNull(engine);
         this.limits = Objects.requireNonNull(config).limits();
-        this.anonymousLoopback = anonymousLoopback;
+        this.anonymousLocal = anonymousLocal;
         this.capacity = Objects.requireNonNull(capacity);
-        this.authorization = anonymousLoopback
+        this.authorization = anonymousLocal
                 ? (request, response) -> response.next()
                 : SecurityFeature.rolesAllowed(config.security().requiredRole()).audit();
     }
@@ -182,7 +182,7 @@ final class ChaosControlService implements HttpService {
     }
 
     private String actor(ServerRequest request) {
-        if (anonymousLoopback) {
+        if (anonymousLocal) {
             return "anonymous-local";
         }
         String actor = request.context()

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosControlService.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosControlService.java
@@ -81,6 +81,55 @@ final class ChaosControlService implements HttpService {
         engine.close();
     }
 
+    private static JsonObject requestBody(ServerRequest request) {
+        if (!request.content().hasEntity()) {
+            throw ChaosRequestException.badRequest("", "missing-body", "A JSON request body is required.");
+        }
+        try {
+            return request.content().as(JsonObject.class);
+        } catch (RuntimeException e) {
+            throw ChaosRequestException.badRequest("",
+                                                    "malformed-json",
+                                                    "The request body must contain one JSON object.",
+                                                    e);
+        }
+    }
+
+    private static UUID runId(ServerRequest request) {
+        String value = request.path().pathParameters().get("runId");
+        try {
+            UUID id = UUID.fromString(value);
+            if (!id.toString().equalsIgnoreCase(value)) {
+                throw new IllegalArgumentException("UUID is not in canonical form");
+            }
+            return id;
+        } catch (IllegalArgumentException e) {
+            throw ChaosRequestException.badRequest("/runId", "invalid-run-id", "runId must be a UUID.", e);
+        }
+    }
+
+    private static ChaosRunEngine.NotFoundException notFound(UUID id) {
+        return new ChaosRunEngine.NotFoundException(id);
+    }
+
+    private static String instance(ServerRequest request) {
+        return request.path().absolute().path();
+    }
+
+    private static void sendJson(ServerResponse response, Status status, Object body) {
+        response.status(status)
+                .header(HeaderNames.CONTENT_TYPE, MediaTypes.APPLICATION_JSON.text())
+                .send(body);
+    }
+
+    private static void sendProblem(ServerResponse response, ChaosProblemJson.Problem problem) {
+        byte[] body = problem.body().toString().getBytes(StandardCharsets.UTF_8);
+        response.status(problem.status())
+                .header(HeaderNames.CONTENT_TYPE, PROBLEM_JSON.text());
+        response.contentLength(body.length);
+        response.send(body);
+    }
+
     private void createRun(ServerRequest request, ServerResponse response) {
         bounded(request, response, () -> {
             if (!request.headers().testContentType(MediaTypes.APPLICATION_JSON)) {
@@ -125,7 +174,7 @@ final class ChaosControlService implements HttpService {
         }
         try {
             operation.execute();
-        } catch (Exception e) {
+        } catch (RuntimeException e) {
             sendProblem(response, ChaosProblemJson.from(e, instance));
         } finally {
             capacity.release();
@@ -147,54 +196,8 @@ final class ChaosControlService implements HttpService {
         return actor;
     }
 
-    private static JsonObject requestBody(ServerRequest request) {
-        if (!request.content().hasEntity()) {
-            throw ChaosRequestException.badRequest("", "missing-body", "A JSON request body is required.");
-        }
-        try {
-            return request.content().as(JsonObject.class);
-        } catch (RuntimeException e) {
-            throw ChaosRequestException.badRequest("", "malformed-json", "The request body must contain one JSON object.");
-        }
-    }
-
-    private static UUID runId(ServerRequest request) {
-        String value = request.path().pathParameters().get("runId");
-        try {
-            UUID id = UUID.fromString(value);
-            if (!id.toString().equalsIgnoreCase(value)) {
-                throw new IllegalArgumentException("UUID is not in canonical form");
-            }
-            return id;
-        } catch (IllegalArgumentException e) {
-            throw ChaosRequestException.badRequest("/runId", "invalid-run-id", "runId must be a UUID.");
-        }
-    }
-
-    private static ChaosRunEngine.NotFoundException notFound(UUID id) {
-        return new ChaosRunEngine.NotFoundException(id);
-    }
-
-    private static String instance(ServerRequest request) {
-        return request.path().absolute().path();
-    }
-
-    private static void sendJson(ServerResponse response, Status status, Object body) {
-        response.status(status)
-                .header(HeaderNames.CONTENT_TYPE, MediaTypes.APPLICATION_JSON.text())
-                .send(body);
-    }
-
-    private static void sendProblem(ServerResponse response, ChaosProblemJson.Problem problem) {
-        byte[] body = problem.body().toString().getBytes(StandardCharsets.UTF_8);
-        response.status(problem.status())
-                .header(HeaderNames.CONTENT_TYPE, PROBLEM_JSON.text());
-        response.contentLength(body.length);
-        response.send(body);
-    }
-
     @FunctionalInterface
     private interface Operation {
-        void execute() throws Exception;
+        void execute();
     }
 }

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosControlService.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosControlService.java
@@ -87,11 +87,11 @@ final class ChaosControlService implements HttpService {
         }
         try {
             return request.content().as(JsonObject.class);
-        } catch (RuntimeException e) {
+        } catch (RuntimeException exception) {
             throw ChaosRequestException.badRequest("",
                                                     "malformed-json",
                                                     "The request body must contain one JSON object.",
-                                                    e);
+                                                    exception);
         }
     }
 
@@ -103,8 +103,8 @@ final class ChaosControlService implements HttpService {
                 throw new IllegalArgumentException("UUID is not in canonical form");
             }
             return id;
-        } catch (IllegalArgumentException e) {
-            throw ChaosRequestException.badRequest("/runId", "invalid-run-id", "runId must be a UUID.", e);
+        } catch (IllegalArgumentException exception) {
+            throw ChaosRequestException.badRequest("/runId", "invalid-run-id", "runId must be a UUID.", exception);
         }
     }
 
@@ -174,8 +174,8 @@ final class ChaosControlService implements HttpService {
         }
         try {
             operation.execute();
-        } catch (RuntimeException e) {
-            sendProblem(response, ChaosProblemJson.from(e, instance));
+        } catch (RuntimeException exception) {
+            sendProblem(response, ChaosProblemJson.from(exception, instance));
         } finally {
             capacity.release();
         }

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosControlService.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosControlService.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.Semaphore;
+
+import io.helidon.common.media.type.MediaType;
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Status;
+import io.helidon.json.JsonObject;
+import io.helidon.security.SecurityContext;
+import io.helidon.webserver.http.Handler;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.HttpService;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.security.SecurityFeature;
+
+import static io.helidon.extensions.chaos.ChaosRunState.STOPPING;
+
+/**
+ * Role-protected control resources for bounded local chaos runs.
+ */
+final class ChaosControlService implements HttpService {
+    private static final String RUNS_PATH = "/chaos/v1/runs/";
+    private static final MediaType PROBLEM_JSON = MediaTypes.create("application", "problem+json");
+
+    private final ChaosRunEngine engine;
+    private final ChaosLimitsConfig limits;
+    private final boolean anonymousLoopback;
+    private final Handler authorization;
+    private final Semaphore capacity;
+
+    ChaosControlService(ChaosRunEngine engine, ChaosConfig config, boolean anonymousLoopback) {
+        this(engine,
+             config,
+             anonymousLoopback,
+             new Semaphore(config.limits().maximumConcurrentControlRequests(), true));
+    }
+
+    ChaosControlService(ChaosRunEngine engine,
+                        ChaosConfig config,
+                        boolean anonymousLoopback,
+                        Semaphore capacity) {
+        this.engine = Objects.requireNonNull(engine);
+        this.limits = Objects.requireNonNull(config).limits();
+        this.anonymousLoopback = anonymousLoopback;
+        this.capacity = Objects.requireNonNull(capacity);
+        this.authorization = anonymousLoopback
+                ? (request, response) -> response.next()
+                : SecurityFeature.rolesAllowed(config.security().requiredRole()).audit();
+    }
+
+    @Override
+    public void routing(HttpRules rules) {
+        rules.post("/runs", authorization, this::createRun)
+                .get("/runs", authorization, this::listRuns)
+                .get("/runs/{runId}", authorization, this::getRun)
+                .delete("/runs/{runId}", authorization, this::deleteRun);
+    }
+
+    @Override
+    public void afterStop() {
+        engine.close();
+    }
+
+    private void createRun(ServerRequest request, ServerResponse response) {
+        bounded(request, response, () -> {
+            if (!request.headers().testContentType(MediaTypes.APPLICATION_JSON)) {
+                sendProblem(response, ChaosProblemJson.unsupportedMediaType(instance(request)));
+                return;
+            }
+            JsonObject body = requestBody(request);
+            ChaosRunPlan plan = ChaosRunPlanJson.parse(body, limits);
+            ChaosRunView run = engine.create(plan, actor(request));
+            response.header(HeaderNames.LOCATION, RUNS_PATH + run.id());
+            sendJson(response, Status.CREATED_201, ChaosRunJson.toJson(run));
+        });
+    }
+
+    private void listRuns(ServerRequest request, ServerResponse response) {
+        bounded(request,
+                response,
+                () -> sendJson(response, Status.OK_200, ChaosRunJson.toJson(engine.list())));
+    }
+
+    private void getRun(ServerRequest request, ServerResponse response) {
+        bounded(request, response, () -> {
+            UUID id = runId(request);
+            ChaosRunView run = engine.get(id).orElseThrow(() -> notFound(id));
+            sendJson(response, Status.OK_200, ChaosRunJson.toJson(run));
+        });
+    }
+
+    private void deleteRun(ServerRequest request, ServerResponse response) {
+        bounded(request, response, () -> {
+            ChaosRunView run = engine.stop(runId(request));
+            Status status = run.state() == STOPPING ? Status.ACCEPTED_202 : Status.OK_200;
+            sendJson(response, status, ChaosRunJson.toJson(run));
+        });
+    }
+
+    private void bounded(ServerRequest request, ServerResponse response, Operation operation) {
+        String instance = instance(request);
+        if (!capacity.tryAcquire()) {
+            sendProblem(response, ChaosProblemJson.controlCapacity(instance));
+            return;
+        }
+        try {
+            operation.execute();
+        } catch (Exception e) {
+            sendProblem(response, ChaosProblemJson.from(e, instance));
+        } finally {
+            capacity.release();
+        }
+    }
+
+    private String actor(ServerRequest request) {
+        if (anonymousLoopback) {
+            return "anonymous-local";
+        }
+        String actor = request.context()
+                .get(SecurityContext.class)
+                .filter(SecurityContext::isAuthenticated)
+                .map(SecurityContext::userName)
+                .orElseThrow(() -> new IllegalStateException("Authenticated security context is unavailable"));
+        if (actor.isBlank()) {
+            throw new IllegalStateException("Authenticated principal name is blank");
+        }
+        return actor;
+    }
+
+    private static JsonObject requestBody(ServerRequest request) {
+        if (!request.content().hasEntity()) {
+            throw ChaosRequestException.badRequest("", "missing-body", "A JSON request body is required.");
+        }
+        try {
+            return request.content().as(JsonObject.class);
+        } catch (RuntimeException e) {
+            throw ChaosRequestException.badRequest("", "malformed-json", "The request body must contain one JSON object.");
+        }
+    }
+
+    private static UUID runId(ServerRequest request) {
+        String value = request.path().pathParameters().get("runId");
+        try {
+            UUID id = UUID.fromString(value);
+            if (!id.toString().equalsIgnoreCase(value)) {
+                throw new IllegalArgumentException("UUID is not in canonical form");
+            }
+            return id;
+        } catch (IllegalArgumentException e) {
+            throw ChaosRequestException.badRequest("/runId", "invalid-run-id", "runId must be a UUID.");
+        }
+    }
+
+    private static ChaosRunEngine.NotFoundException notFound(UUID id) {
+        return new ChaosRunEngine.NotFoundException(id);
+    }
+
+    private static String instance(ServerRequest request) {
+        return request.path().absolute().path();
+    }
+
+    private static void sendJson(ServerResponse response, Status status, Object body) {
+        response.status(status)
+                .header(HeaderNames.CONTENT_TYPE, MediaTypes.APPLICATION_JSON.text())
+                .send(body);
+    }
+
+    private static void sendProblem(ServerResponse response, ChaosProblemJson.Problem problem) {
+        byte[] body = problem.body().toString().getBytes(StandardCharsets.UTF_8);
+        response.status(problem.status())
+                .header(HeaderNames.CONTENT_TYPE, PROBLEM_JSON.text());
+        response.contentLength(body.length);
+        response.send(body);
+    }
+
+    @FunctionalInterface
+    private interface Operation {
+        void execute() throws Exception;
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosEffect.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosEffect.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+/**
+ * Normalized effect in a Chaos run plan.
+ */
+sealed interface ChaosEffect permits ChaosSyntheticResponse {
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosHttpScope.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosHttpScope.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Normalized inbound HTTP method and path scope.
+ *
+ * @param methods normalized HTTP methods
+ * @param pathMatch path matching mode
+ * @param path normalized absolute path
+ */
+record ChaosHttpScope(Set<String> methods, PathMatch pathMatch, String path) {
+
+    ChaosHttpScope {
+        methods = Collections.unmodifiableSet(new LinkedHashSet<>(methods));
+        Objects.requireNonNull(pathMatch);
+        Objects.requireNonNull(path);
+    }
+
+    boolean matches(String method, String requestPath) {
+        if (!methods.contains(method.toUpperCase(Locale.ROOT))) {
+            return false;
+        }
+        return switch (pathMatch) {
+        case EXACT -> requestPath.equals(path);
+        case PREFIX -> path.equals("/") || requestPath.equals(path) || requestPath.startsWith(path + "/");
+        };
+    }
+
+    /**
+     * Supported path matching modes.
+     */
+    enum PathMatch {
+        /** Exact normalized path. */
+        EXACT,
+        /** Normalized path-segment prefix. */
+        PREFIX
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosLimitsConfigBlueprint.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosLimitsConfigBlueprint.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.time.Duration;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+/**
+ * Server-enforced ceilings for Chaos runs.
+ */
+@Prototype.Blueprint(decorator = ChaosLimitsConfigSupport.BuilderDecorator.class)
+@Prototype.Configured
+interface ChaosLimitsConfigBlueprint {
+
+    /**
+     * Maximum concurrently active runs.
+     *
+     * @return maximum active runs
+     */
+    @Option.Configured
+    @Option.DefaultInt(1)
+    int maximumActiveRuns();
+
+    /**
+     * Maximum guard duration of one run.
+     *
+     * @return maximum run duration
+     */
+    @Option.Configured
+    @Option.Default("PT15M")
+    Duration maximumRunDuration();
+
+    /**
+     * Maximum cumulative activations of one disruption.
+     *
+     * @return maximum activations
+     */
+    @Option.Configured
+    @Option.DefaultLong(10_000)
+    long maximumActivationsPerDisruption();
+
+    /**
+     * Maximum concurrent activations of one disruption.
+     *
+     * @return maximum concurrent activations
+     */
+    @Option.Configured
+    @Option.DefaultInt(64)
+    int maximumConcurrentActivationsPerDisruption();
+
+    /**
+     * Maximum synthetic response body size in UTF-8 bytes.
+     *
+     * @return maximum body size
+     */
+    @Option.Configured
+    @Option.DefaultInt(65_536)
+    int maximumSyntheticBodyBytes();
+
+    /**
+     * Maximum control request size in bytes.
+     *
+     * @return maximum control request size
+     */
+    @Option.Configured
+    @Option.DefaultLong(65_536)
+    long maximumControlRequestBytes();
+
+    /**
+     * Maximum concurrent control requests.
+     *
+     * @return maximum concurrent control requests
+     */
+    @Option.Configured
+    @Option.DefaultInt(16)
+    int maximumConcurrentControlRequests();
+
+    /**
+     * Maximum retained run representations.
+     *
+     * @return maximum retained runs
+     */
+    @Option.Configured
+    @Option.DefaultInt(32)
+    int maximumRetainedRuns();
+
+    /**
+     * Duration for retaining a terminal run.
+     *
+     * @return terminal run retention
+     */
+    @Option.Configured
+    @Option.Default("PT15M")
+    Duration terminalRunRetention();
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosLimitsConfigSupport.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosLimitsConfigSupport.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.time.Duration;
+
+import io.helidon.builder.api.Prototype;
+
+/**
+ * Validation for {@link ChaosLimitsConfig}.
+ */
+final class ChaosLimitsConfigSupport {
+
+    private ChaosLimitsConfigSupport() {
+    }
+
+    static final class BuilderDecorator implements Prototype.BuilderDecorator<ChaosLimitsConfig.BuilderBase<?, ?>> {
+
+        @Override
+        public void decorate(ChaosLimitsConfig.BuilderBase<?, ?> builder) {
+            requirePositive(builder.maximumActiveRuns(), "maximum-active-runs");
+            requirePositive(builder.maximumRunDuration(), "maximum-run-duration");
+            requirePositive(builder.maximumActivationsPerDisruption(), "maximum-activations-per-disruption");
+            requirePositive(builder.maximumConcurrentActivationsPerDisruption(),
+                            "maximum-concurrent-activations-per-disruption");
+            requirePositive(builder.maximumSyntheticBodyBytes(), "maximum-synthetic-body-bytes");
+            requirePositive(builder.maximumControlRequestBytes(), "maximum-control-request-bytes");
+            requirePositive(builder.maximumConcurrentControlRequests(), "maximum-concurrent-control-requests");
+            requirePositive(builder.maximumRetainedRuns(), "maximum-retained-runs");
+            requirePositive(builder.terminalRunRetention(), "terminal-run-retention");
+            if (builder.maximumRetainedRuns() < builder.maximumActiveRuns()) {
+                throw new IllegalArgumentException("maximum-retained-runs must be at least maximum-active-runs");
+            }
+        }
+
+        private static void requirePositive(long value, String key) {
+            if (value <= 0) {
+                throw new IllegalArgumentException(key + " must be positive");
+            }
+        }
+
+        private static void requirePositive(Duration value, String key) {
+            if (value.isZero() || value.isNegative()) {
+                throw new IllegalArgumentException(key + " must be positive");
+            }
+        }
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosProblemJson.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosProblemJson.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.util.List;
+import java.util.Objects;
+
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+
+/**
+ * Safe RFC 9457 problem representations for the control API.
+ */
+final class ChaosProblemJson {
+    private static final String PROBLEM_PATH = "/chaos/v1/problems/";
+
+    private ChaosProblemJson() {
+    }
+
+    static Problem from(Throwable error, String instance) {
+        Objects.requireNonNull(error);
+        if (error instanceof ChaosRequestException request) {
+            return problem(request.status(),
+                           request.problemType(),
+                           request.title(),
+                           request.getMessage(),
+                           instance,
+                           request.violations());
+        }
+        if (error instanceof ChaosRunEngine.ConflictException) {
+            return problem(409,
+                           "run-conflict",
+                           "Chaos run conflict",
+                           "The run conflicts with the current local chaos engine state.",
+                           instance,
+                           List.of());
+        }
+        if (error instanceof ChaosRunEngine.NotFoundException) {
+            return problem(404,
+                           "run-not-found",
+                           "Chaos run not found",
+                           "The requested chaos run does not exist or is no longer retained.",
+                           instance,
+                           List.of());
+        }
+        return problem(500,
+                       "internal-error",
+                       "Internal chaos error",
+                       "The chaos request could not be completed.",
+                       instance,
+                       List.of());
+    }
+
+    static Problem unsupportedMediaType(String instance) {
+        return problem(415,
+                       "unsupported-media-type",
+                       "Unsupported media type",
+                       "Chaos run creation requires an application/json request body.",
+                       instance,
+                       List.of());
+    }
+
+    static Problem controlCapacity(String instance) {
+        return problem(429,
+                       "control-capacity",
+                       "Chaos control capacity exhausted",
+                       "The bounded chaos control request capacity is currently exhausted.",
+                       instance,
+                       List.of());
+    }
+
+    private static Problem problem(int status,
+                                   String type,
+                                   String title,
+                                   String detail,
+                                   String instance,
+                                   List<ChaosViolation> violations) {
+        JsonObject.Builder body = JsonObject.builder()
+                .set("type", PROBLEM_PATH + type)
+                .set("title", title)
+                .set("status", status)
+                .set("detail", detail)
+                .set("instance", instance);
+        if (!violations.isEmpty()) {
+            body.set("violations", JsonArray.create(violations.stream()
+                                                      .map(ChaosProblemJson::violation)
+                                                      .toList()));
+        }
+        return new Problem(status, body.build());
+    }
+
+    private static JsonObject violation(ChaosViolation violation) {
+        return JsonObject.builder()
+                .set("path", violation.path())
+                .set("code", violation.code())
+                .set("message", violation.message())
+                .build();
+    }
+
+    /**
+     * HTTP status and body for one problem response.
+     *
+     * @param status HTTP status
+     * @param body RFC 9457 body
+     */
+    record Problem(int status, JsonObject body) {
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRequestException.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRequestException.java
@@ -31,8 +31,9 @@ final class ChaosRequestException extends RuntimeException {
                                   String problemType,
                                   String title,
                                   String detail,
-                                  List<ChaosViolation> violations) {
-        super(detail);
+                                  List<ChaosViolation> violations,
+                                  Throwable cause) {
+        super(detail, cause);
         this.status = status;
         this.problemType = problemType;
         this.title = title;
@@ -40,19 +41,29 @@ final class ChaosRequestException extends RuntimeException {
     }
 
     static ChaosRequestException badRequest(String path, String code, String message) {
+        return badRequest(path, code, message, null);
+    }
+
+    static ChaosRequestException badRequest(String path, String code, String message, Throwable cause) {
         return new ChaosRequestException(400,
                                          "invalid-request",
                                          "Invalid chaos request",
                                          "The request body is not a valid chaos run request.",
-                                         List.of(new ChaosViolation(path, code, message)));
+                                         List.of(new ChaosViolation(path, code, message)),
+                                         cause);
     }
 
     static ChaosRequestException invalidPlan(String path, String code, String message) {
+        return invalidPlan(path, code, message, null);
+    }
+
+    static ChaosRequestException invalidPlan(String path, String code, String message, Throwable cause) {
         return new ChaosRequestException(422,
                                          "invalid-plan",
                                          "Invalid chaos run plan",
                                          "The run plan violates one or more constraints.",
-                                         List.of(new ChaosViolation(path, code, message)));
+                                         List.of(new ChaosViolation(path, code, message)),
+                                         cause);
     }
 
     int status() {

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRequestException.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRequestException.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.util.List;
+
+/**
+ * Safe request error that can be converted to an RFC 9457 response.
+ */
+final class ChaosRequestException extends RuntimeException {
+
+    private final int status;
+    private final String problemType;
+    private final String title;
+    private final List<ChaosViolation> violations;
+
+    private ChaosRequestException(int status,
+                                  String problemType,
+                                  String title,
+                                  String detail,
+                                  List<ChaosViolation> violations) {
+        super(detail);
+        this.status = status;
+        this.problemType = problemType;
+        this.title = title;
+        this.violations = List.copyOf(violations);
+    }
+
+    static ChaosRequestException badRequest(String path, String code, String message) {
+        return new ChaosRequestException(400,
+                                         "invalid-request",
+                                         "Invalid chaos request",
+                                         "The request body is not a valid chaos run request.",
+                                         List.of(new ChaosViolation(path, code, message)));
+    }
+
+    static ChaosRequestException invalidPlan(String path, String code, String message) {
+        return new ChaosRequestException(422,
+                                         "invalid-plan",
+                                         "Invalid chaos run plan",
+                                         "The run plan violates one or more constraints.",
+                                         List.of(new ChaosViolation(path, code, message)));
+    }
+
+    int status() {
+        return status;
+    }
+
+    String problemType() {
+        return problemType;
+    }
+
+    String title() {
+        return title;
+    }
+
+    List<ChaosViolation> violations() {
+        return violations;
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRun.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRun.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+final class ChaosRun {
+    private final UUID id;
+    private final long sequence;
+    private final ChaosRunPlan plan;
+    private final String actor;
+    private final Instant createdAt;
+    private final Instant expiresAt;
+    private final long activationStreamSeed;
+
+    private ChaosRunState state = ChaosRunState.RUNNING;
+    private ChaosRunState drainedState;
+    private Instant terminalAt;
+    private String terminalReason;
+    private long matched;
+    private long activated;
+    private long skippedActivation;
+    private long skippedConcurrent;
+    private long skippedBudget;
+    private long inFlight;
+    private long completed;
+    private ChaosScheduler.Cancellable completionTask;
+    private ChaosScheduler.Cancellable expirationTask;
+
+    ChaosRun(UUID id,
+             long sequence,
+             ChaosRunPlan plan,
+             String actor,
+             Instant createdAt) {
+        this.id = id;
+        this.sequence = sequence;
+        this.plan = plan;
+        this.actor = actor;
+        this.createdAt = createdAt;
+        this.expiresAt = createdAt.plus(plan.maximumDuration());
+        ChaosRunPlan.ChaosDisruption disruption = plan.stage().disruption();
+        this.activationStreamSeed = ChaosActivationDecider.streamSeed(plan.seed(),
+                                                                      plan.stage().name(),
+                                                                      disruption.name());
+    }
+
+    UUID id() {
+        return id;
+    }
+
+    long sequence() {
+        return sequence;
+    }
+
+    ChaosHttpScope scope() {
+        return plan.stage().disruption().scope();
+    }
+
+    boolean running() {
+        return state == ChaosRunState.RUNNING;
+    }
+
+    boolean terminal() {
+        return state != ChaosRunState.RUNNING && state != ChaosRunState.STOPPING;
+    }
+
+    boolean terminalAtOrBefore(Instant instant) {
+        return terminal() && terminalAt != null && !terminalAt.isAfter(instant);
+    }
+
+    void tasks(ChaosScheduler.Cancellable completionTask, ChaosScheduler.Cancellable expirationTask) {
+        this.completionTask = completionTask;
+        this.expirationTask = expirationTask;
+    }
+
+    Optional<Activation> reserve(String method, String requestPath) {
+        ChaosRunPlan.ChaosDisruption disruption = plan.stage().disruption();
+        if (!running() || !disruption.scope().matches(method, requestPath)) {
+            return Optional.empty();
+        }
+        matched++;
+        if (!ChaosActivationDecider.activates(disruption.activation(), activationStreamSeed, matched)) {
+            skippedActivation++;
+            return Optional.empty();
+        }
+        ChaosBudget budget = disruption.budget();
+        if (inFlight >= budget.maximumConcurrent()) {
+            skippedConcurrent++;
+            return Optional.empty();
+        }
+        if (activated >= budget.maximumActivations()) {
+            skippedBudget++;
+            return Optional.empty();
+        }
+        inFlight++;
+        activated++;
+        return Optional.of(new Activation(disruption.effect()));
+    }
+
+    void terminate(ChaosRunState terminalState, String reason, Instant now) {
+        cancelTasks();
+        terminalReason = reason;
+        if (inFlight == 0) {
+            state = terminalState;
+            terminalAt = now;
+        } else {
+            state = ChaosRunState.STOPPING;
+            drainedState = terminalState;
+        }
+    }
+
+    void release(Instant now) {
+        if (inFlight == 0) {
+            return;
+        }
+        inFlight--;
+        completed++;
+        if (state == ChaosRunState.STOPPING && inFlight == 0) {
+            state = drainedState;
+            terminalAt = now;
+        }
+    }
+
+    ChaosRunView view() {
+        return new ChaosRunView(id,
+                                plan.name(),
+                                state,
+                                plan,
+                                plan.seed(),
+                                actor,
+                                createdAt,
+                                createdAt,
+                                expiresAt,
+                                Optional.ofNullable(terminalAt),
+                                Optional.ofNullable(terminalReason),
+                                matched,
+                                activated,
+                                skippedActivation,
+                                skippedConcurrent,
+                                skippedBudget,
+                                inFlight,
+                                completed);
+    }
+
+    record Activation(ChaosEffect effect) {
+    }
+
+    private void cancelTasks() {
+        if (completionTask != null) {
+            completionTask.cancel();
+        }
+        if (expirationTask != null) {
+            expirationTask.cancel();
+        }
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRun.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRun.java
@@ -157,9 +157,6 @@ final class ChaosRun {
                                 completed);
     }
 
-    record Activation(ChaosEffect effect) {
-    }
-
     private void cancelTasks() {
         if (completionTask != null) {
             completionTask.cancel();
@@ -167,5 +164,8 @@ final class ChaosRun {
         if (expirationTask != null) {
             expirationTask.cancel();
         }
+    }
+
+    record Activation(ChaosEffect effect) {
     }
 }

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunEngine.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunEngine.java
@@ -111,9 +111,9 @@ final class ChaosRunEngine implements AutoCloseable {
                                                                                                 EXPIRED,
                                                                                                 REASON_EXPIRED));
                 run.tasks(completionTask, expirationTask);
-            } catch (RuntimeException e) {
+            } catch (RuntimeException exception) {
                 completionTask.cancel();
-                throw e;
+                throw exception;
             }
             runs.put(id, run);
             return run.view();

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunEngine.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunEngine.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 import static io.helidon.extensions.chaos.ChaosRunState.COMPLETED;
@@ -51,6 +52,7 @@ final class ChaosRunEngine implements AutoCloseable {
     private final ChaosScheduler scheduler;
     private final Supplier<UUID> idSupplier;
     private final Map<UUID, ChaosRun> runs = new LinkedHashMap<>();
+    private final ReentrantLock lock = new ReentrantLock();
 
     private long sequence;
     private boolean closed;
@@ -79,110 +81,150 @@ final class ChaosRunEngine implements AutoCloseable {
         return new ChaosRunEngine(limits, clock, scheduler, idSupplier);
     }
 
-    synchronized ChaosRunView create(ChaosRunPlan plan, String actor) {
-        Objects.requireNonNull(plan);
-        Objects.requireNonNull(actor);
-        ensureOpen();
-        evictExpiredTerminalRuns();
-
-        List<ChaosRun> activeRuns = activeRuns();
-        if (activeRuns.size() >= limits.maximumActiveRuns()) {
-            throw new ConflictException("The maximum number of active chaos runs has been reached");
-        }
-        ChaosHttpScope requestedScope = plan.stage().disruption().scope();
-        if (activeRuns.stream().anyMatch(run -> overlaps(run.scope(), requestedScope))) {
-            throw new ConflictException("The requested scope overlaps an active chaos disruption");
-        }
-        evictForCapacity();
-
-        UUID id = nextId();
-        ChaosRun run = new ChaosRun(id, ++sequence, plan, actor, clock.instant());
-        ChaosScheduler.Cancellable completionTask = scheduler.schedule(plan.stage().duration(),
-                                                                       () -> terminate(id,
-                                                                                       COMPLETED,
-                                                                                       REASON_COMPLETED));
+    ChaosRunView create(ChaosRunPlan plan, String actor) {
+        lock.lock();
         try {
-            ChaosScheduler.Cancellable expirationTask = scheduler.schedule(plan.maximumDuration(),
-                                                                            () -> terminate(id,
-                                                                                            EXPIRED,
-                                                                                            REASON_EXPIRED));
-            run.tasks(completionTask, expirationTask);
-        } catch (RuntimeException e) {
-            completionTask.cancel();
-            throw e;
-        }
-        runs.put(id, run);
-        return run.view();
-    }
+            Objects.requireNonNull(plan);
+            Objects.requireNonNull(actor);
+            ensureOpen();
+            evictExpiredTerminalRuns();
 
-    synchronized Optional<Reservation> reserve(String method, String requestPath) {
-        Objects.requireNonNull(method);
-        Objects.requireNonNull(requestPath);
-        if (closed) {
-            return Optional.empty();
-        }
-        for (ChaosRun run : runs.values()) {
-            Optional<ChaosRun.Activation> activation = run.reserve(method, requestPath);
-            if (activation.isPresent()) {
-                return Optional.of(new Reservation(this, run.id(), activation.orElseThrow()));
+            List<ChaosRun> activeRuns = activeRuns();
+            if (activeRuns.size() >= limits.maximumActiveRuns()) {
+                throw new ConflictException("The maximum number of active chaos runs has been reached");
             }
+            ChaosHttpScope requestedScope = plan.stage().disruption().scope();
+            if (activeRuns.stream().anyMatch(run -> overlaps(run.scope(), requestedScope))) {
+                throw new ConflictException("The requested scope overlaps an active chaos disruption");
+            }
+            evictForCapacity();
+
+            UUID id = nextId();
+            ChaosRun run = new ChaosRun(id, ++sequence, plan, actor, clock.instant());
+            ChaosScheduler.Cancellable completionTask = scheduler.schedule(plan.stage().duration(),
+                                                                           () -> terminate(id,
+                                                                                           COMPLETED,
+                                                                                           REASON_COMPLETED));
+            try {
+                ChaosScheduler.Cancellable expirationTask = scheduler.schedule(plan.maximumDuration(),
+                                                                                () -> terminate(id,
+                                                                                                EXPIRED,
+                                                                                                REASON_EXPIRED));
+                run.tasks(completionTask, expirationTask);
+            } catch (RuntimeException e) {
+                completionTask.cancel();
+                throw e;
+            }
+            runs.put(id, run);
+            return run.view();
+        } finally {
+            lock.unlock();
         }
-        return Optional.empty();
     }
 
-    synchronized Optional<ChaosRunView> get(UUID id) {
-        Objects.requireNonNull(id);
-        evictExpiredTerminalRuns();
-        return Optional.ofNullable(runs.get(id)).map(ChaosRun::view);
+    Optional<Reservation> reserve(String method, String requestPath) {
+        lock.lock();
+        try {
+            Objects.requireNonNull(method);
+            Objects.requireNonNull(requestPath);
+            if (closed) {
+                return Optional.empty();
+            }
+            for (ChaosRun run : runs.values()) {
+                Optional<ChaosRun.Activation> activation = run.reserve(method, requestPath);
+                if (activation.isPresent()) {
+                    return Optional.of(new Reservation(this, run.id(), activation.orElseThrow()));
+                }
+            }
+            return Optional.empty();
+        } finally {
+            lock.unlock();
+        }
     }
 
-    synchronized List<ChaosRunView> list() {
-        evictExpiredTerminalRuns();
-        return runs.values()
-                .stream()
-                .sorted(Comparator.comparingLong(ChaosRun::sequence).reversed())
-                .map(ChaosRun::view)
-                .toList();
+    Optional<ChaosRunView> get(UUID id) {
+        lock.lock();
+        try {
+            Objects.requireNonNull(id);
+            evictExpiredTerminalRuns();
+            return Optional.ofNullable(runs.get(id)).map(ChaosRun::view);
+        } finally {
+            lock.unlock();
+        }
     }
 
-    synchronized ChaosRunView stop(UUID id) {
-        Objects.requireNonNull(id);
-        evictExpiredTerminalRuns();
-        ChaosRun run = runs.get(id);
-        if (run == null) {
-            throw new NotFoundException(id);
+    List<ChaosRunView> list() {
+        lock.lock();
+        try {
+            evictExpiredTerminalRuns();
+            return runs.values()
+                    .stream()
+                    .sorted(Comparator.comparingLong(ChaosRun::sequence).reversed())
+                    .map(ChaosRun::view)
+                    .toList();
+        } finally {
+            lock.unlock();
         }
-        if (run.running()) {
-            run.terminate(STOPPED, REASON_STOPPED, clock.instant());
+    }
+
+    ChaosRunView stop(UUID id) {
+        lock.lock();
+        try {
+            Objects.requireNonNull(id);
+            evictExpiredTerminalRuns();
+            ChaosRun run = runs.get(id);
+            if (run == null) {
+                throw new NotFoundException(id);
+            }
+            if (run.running()) {
+                run.terminate(STOPPED, REASON_STOPPED, clock.instant());
+            }
+            return run.view();
+        } finally {
+            lock.unlock();
         }
-        return run.view();
     }
 
     @Override
-    public synchronized void close() {
-        if (closed) {
-            return;
-        }
-        closed = true;
-        for (ChaosRun run : runs.values()) {
-            if (run.running()) {
-                run.terminate(STOPPED, "engine-closed", clock.instant());
+    public void close() {
+        lock.lock();
+        try {
+            if (closed) {
+                return;
             }
+            closed = true;
+            for (ChaosRun run : runs.values()) {
+                if (run.running()) {
+                    run.terminate(STOPPED, "engine-closed", clock.instant());
+                }
+            }
+            scheduler.close();
+        } finally {
+            lock.unlock();
         }
-        scheduler.close();
     }
 
-    private synchronized void terminate(UUID id, ChaosRunState state, String reason) {
-        ChaosRun run = runs.get(id);
-        if (run != null && run.running()) {
-            run.terminate(state, reason, clock.instant());
+    private void terminate(UUID id, ChaosRunState state, String reason) {
+        lock.lock();
+        try {
+            ChaosRun run = runs.get(id);
+            if (run != null && run.running()) {
+                run.terminate(state, reason, clock.instant());
+            }
+        } finally {
+            lock.unlock();
         }
     }
 
-    private synchronized void release(UUID id) {
-        ChaosRun run = runs.get(id);
-        if (run != null) {
-            run.release(clock.instant());
+    private void release(UUID id) {
+        lock.lock();
+        try {
+            ChaosRun run = runs.get(id);
+            if (run != null) {
+                run.release(clock.instant());
+            }
+        } finally {
+            lock.unlock();
         }
     }
 

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunEngine.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunEngine.java
@@ -204,6 +204,30 @@ final class ChaosRunEngine implements AutoCloseable {
         }
     }
 
+    private static boolean overlaps(ChaosHttpScope first, ChaosHttpScope second) {
+        if (!methodsOverlap(first.methods(), second.methods())) {
+            return false;
+        }
+        return switch (first.pathMatch()) {
+        case EXACT -> switch (second.pathMatch()) {
+            case EXACT -> first.path().equals(second.path());
+            case PREFIX -> prefixContains(second.path(), first.path());
+        };
+        case PREFIX -> switch (second.pathMatch()) {
+            case EXACT -> prefixContains(first.path(), second.path());
+            case PREFIX -> prefixContains(first.path(), second.path()) || prefixContains(second.path(), first.path());
+        };
+        };
+    }
+
+    private static boolean methodsOverlap(Set<String> first, Set<String> second) {
+        return first.stream().anyMatch(second::contains);
+    }
+
+    private static boolean prefixContains(String prefix, String path) {
+        return prefix.equals("/") || path.equals(prefix) || path.startsWith(prefix + "/");
+    }
+
     private void terminate(UUID id, ChaosRunState state, String reason) {
         lock.lock();
         try {
@@ -265,30 +289,6 @@ final class ChaosRunEngine implements AutoCloseable {
             }
             runs.remove(candidates.next().id());
         }
-    }
-
-    private static boolean overlaps(ChaosHttpScope first, ChaosHttpScope second) {
-        if (!methodsOverlap(first.methods(), second.methods())) {
-            return false;
-        }
-        return switch (first.pathMatch()) {
-        case EXACT -> switch (second.pathMatch()) {
-            case EXACT -> first.path().equals(second.path());
-            case PREFIX -> prefixContains(second.path(), first.path());
-        };
-        case PREFIX -> switch (second.pathMatch()) {
-            case EXACT -> prefixContains(first.path(), second.path());
-            case PREFIX -> prefixContains(first.path(), second.path()) || prefixContains(second.path(), first.path());
-        };
-        };
-    }
-
-    private static boolean methodsOverlap(Set<String> first, Set<String> second) {
-        return first.stream().anyMatch(second::contains);
-    }
-
-    private static boolean prefixContains(String prefix, String path) {
-        return prefix.equals("/") || path.equals(prefix) || path.startsWith(prefix + "/");
     }
 
     /**

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunEngine.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunEngine.java
@@ -1,0 +1,296 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+
+import static io.helidon.extensions.chaos.ChaosRunState.COMPLETED;
+import static io.helidon.extensions.chaos.ChaosRunState.EXPIRED;
+import static io.helidon.extensions.chaos.ChaosRunState.STOPPED;
+
+/**
+ * Bounded in-process lifecycle and activation engine.
+ *
+ * <p>All mutations are deliberately serialized. The critical section contains
+ * no user code, blocking work, or sleeps, making the safety checks and
+ * lifecycle races atomic while keeping request-path work bounded.</p>
+ */
+final class ChaosRunEngine implements AutoCloseable {
+    private static final String REASON_COMPLETED = "stage-duration-completed";
+    private static final String REASON_EXPIRED = "maximum-duration-expired";
+    private static final String REASON_STOPPED = "operator-stopped";
+    private static final int ID_ATTEMPTS = 16;
+
+    private final ChaosLimitsConfig limits;
+    private final Clock clock;
+    private final ChaosScheduler scheduler;
+    private final Supplier<UUID> idSupplier;
+    private final Map<UUID, ChaosRun> runs = new LinkedHashMap<>();
+
+    private long sequence;
+    private boolean closed;
+
+    private ChaosRunEngine(ChaosLimitsConfig limits,
+                           Clock clock,
+                           ChaosScheduler scheduler,
+                           Supplier<UUID> idSupplier) {
+        this.limits = Objects.requireNonNull(limits);
+        this.clock = Objects.requireNonNull(clock);
+        this.scheduler = Objects.requireNonNull(scheduler);
+        this.idSupplier = Objects.requireNonNull(idSupplier);
+    }
+
+    static ChaosRunEngine create(ChaosLimitsConfig limits) {
+        return new ChaosRunEngine(limits,
+                                  Clock.systemUTC(),
+                                  ChaosScheduler.create(),
+                                  UUID::randomUUID);
+    }
+
+    static ChaosRunEngine create(ChaosLimitsConfig limits,
+                                 Clock clock,
+                                 ChaosScheduler scheduler,
+                                 Supplier<UUID> idSupplier) {
+        return new ChaosRunEngine(limits, clock, scheduler, idSupplier);
+    }
+
+    synchronized ChaosRunView create(ChaosRunPlan plan, String actor) {
+        Objects.requireNonNull(plan);
+        Objects.requireNonNull(actor);
+        ensureOpen();
+        evictExpiredTerminalRuns();
+
+        List<ChaosRun> activeRuns = activeRuns();
+        if (activeRuns.size() >= limits.maximumActiveRuns()) {
+            throw new ConflictException("The maximum number of active chaos runs has been reached");
+        }
+        ChaosHttpScope requestedScope = plan.stage().disruption().scope();
+        if (activeRuns.stream().anyMatch(run -> overlaps(run.scope(), requestedScope))) {
+            throw new ConflictException("The requested scope overlaps an active chaos disruption");
+        }
+        evictForCapacity();
+
+        UUID id = nextId();
+        ChaosRun run = new ChaosRun(id, ++sequence, plan, actor, clock.instant());
+        ChaosScheduler.Cancellable completionTask = scheduler.schedule(plan.stage().duration(),
+                                                                       () -> terminate(id,
+                                                                                       COMPLETED,
+                                                                                       REASON_COMPLETED));
+        try {
+            ChaosScheduler.Cancellable expirationTask = scheduler.schedule(plan.maximumDuration(),
+                                                                            () -> terminate(id,
+                                                                                            EXPIRED,
+                                                                                            REASON_EXPIRED));
+            run.tasks(completionTask, expirationTask);
+        } catch (RuntimeException e) {
+            completionTask.cancel();
+            throw e;
+        }
+        runs.put(id, run);
+        return run.view();
+    }
+
+    synchronized Optional<Reservation> reserve(String method, String requestPath) {
+        Objects.requireNonNull(method);
+        Objects.requireNonNull(requestPath);
+        if (closed) {
+            return Optional.empty();
+        }
+        for (ChaosRun run : runs.values()) {
+            Optional<ChaosRun.Activation> activation = run.reserve(method, requestPath);
+            if (activation.isPresent()) {
+                return Optional.of(new Reservation(this, run.id(), activation.orElseThrow()));
+            }
+        }
+        return Optional.empty();
+    }
+
+    synchronized Optional<ChaosRunView> get(UUID id) {
+        Objects.requireNonNull(id);
+        evictExpiredTerminalRuns();
+        return Optional.ofNullable(runs.get(id)).map(ChaosRun::view);
+    }
+
+    synchronized List<ChaosRunView> list() {
+        evictExpiredTerminalRuns();
+        return runs.values()
+                .stream()
+                .sorted(Comparator.comparingLong(ChaosRun::sequence).reversed())
+                .map(ChaosRun::view)
+                .toList();
+    }
+
+    synchronized ChaosRunView stop(UUID id) {
+        Objects.requireNonNull(id);
+        evictExpiredTerminalRuns();
+        ChaosRun run = runs.get(id);
+        if (run == null) {
+            throw new NotFoundException(id);
+        }
+        if (run.running()) {
+            run.terminate(STOPPED, REASON_STOPPED, clock.instant());
+        }
+        return run.view();
+    }
+
+    @Override
+    public synchronized void close() {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        for (ChaosRun run : runs.values()) {
+            if (run.running()) {
+                run.terminate(STOPPED, "engine-closed", clock.instant());
+            }
+        }
+        scheduler.close();
+    }
+
+    private synchronized void terminate(UUID id, ChaosRunState state, String reason) {
+        ChaosRun run = runs.get(id);
+        if (run != null && run.running()) {
+            run.terminate(state, reason, clock.instant());
+        }
+    }
+
+    private synchronized void release(UUID id) {
+        ChaosRun run = runs.get(id);
+        if (run != null) {
+            run.release(clock.instant());
+        }
+    }
+
+    private List<ChaosRun> activeRuns() {
+        return runs.values().stream().filter(ChaosRun::running).toList();
+    }
+
+    private UUID nextId() {
+        for (int attempt = 0; attempt < ID_ATTEMPTS; attempt++) {
+            UUID candidate = Objects.requireNonNull(idSupplier.get());
+            if (!runs.containsKey(candidate)) {
+                return candidate;
+            }
+        }
+        throw new IllegalStateException("Unable to allocate a unique chaos run identifier");
+    }
+
+    private void ensureOpen() {
+        if (closed) {
+            throw new ConflictException("The chaos run engine is closed");
+        }
+    }
+
+    private void evictExpiredTerminalRuns() {
+        Instant oldestRetained = clock.instant().minus(limits.terminalRunRetention());
+        runs.values().removeIf(run -> run.terminalAtOrBefore(oldestRetained));
+    }
+
+    private void evictForCapacity() {
+        while (runs.size() >= limits.maximumRetainedRuns()) {
+            Iterator<ChaosRun> candidates = runs.values()
+                    .stream()
+                    .filter(ChaosRun::terminal)
+                    .sorted(Comparator.comparingLong(ChaosRun::sequence))
+                    .iterator();
+            if (!candidates.hasNext()) {
+                throw new ConflictException("The retained chaos run capacity has been reached");
+            }
+            runs.remove(candidates.next().id());
+        }
+    }
+
+    private static boolean overlaps(ChaosHttpScope first, ChaosHttpScope second) {
+        if (!methodsOverlap(first.methods(), second.methods())) {
+            return false;
+        }
+        return switch (first.pathMatch()) {
+        case EXACT -> switch (second.pathMatch()) {
+            case EXACT -> first.path().equals(second.path());
+            case PREFIX -> prefixContains(second.path(), first.path());
+        };
+        case PREFIX -> switch (second.pathMatch()) {
+            case EXACT -> prefixContains(first.path(), second.path());
+            case PREFIX -> prefixContains(first.path(), second.path()) || prefixContains(second.path(), first.path());
+        };
+        };
+    }
+
+    private static boolean methodsOverlap(Set<String> first, Set<String> second) {
+        return first.stream().anyMatch(second::contains);
+    }
+
+    private static boolean prefixContains(String prefix, String path) {
+        return prefix.equals("/") || path.equals(prefix) || path.startsWith(prefix + "/");
+    }
+
+    /**
+     * One accepted disruption activation. Closing it releases the concurrency budget.
+     */
+    static final class Reservation implements AutoCloseable {
+        private final ChaosRunEngine engine;
+        private final UUID runId;
+        private final ChaosEffect effect;
+        private final AtomicBoolean closed = new AtomicBoolean();
+
+        private Reservation(ChaosRunEngine engine, UUID runId, ChaosRun.Activation activation) {
+            this.engine = engine;
+            this.runId = runId;
+            this.effect = activation.effect();
+        }
+
+        ChaosEffect effect() {
+            return effect;
+        }
+
+        @Override
+        public void close() {
+            if (closed.compareAndSet(false, true)) {
+                engine.release(runId);
+            }
+        }
+    }
+
+    /**
+     * A requested run conflicts with a server-enforced lifecycle or scope limit.
+     */
+    static final class ConflictException extends RuntimeException {
+        private ConflictException(String message) {
+            super(message);
+        }
+    }
+
+    /**
+     * No retained run has the requested identifier.
+     */
+    static final class NotFoundException extends RuntimeException {
+        NotFoundException(UUID id) {
+            super("Chaos run not found: " + id);
+        }
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunJson.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunJson.java
@@ -85,7 +85,7 @@ final class ChaosRunJson {
     }
 
     private static JsonObject activation(ChaosActivation activation) {
-        if (activation instanceof ChaosActivation.Probability probability) {
+        if (activation instanceof ProbabilityActivation probability) {
             return JsonObject.builder()
                     .set("type", "probability")
                     .set("probability", probability.probability())

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunJson.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunJson.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import io.helidon.extensions.chaos.ChaosActivation.ProbabilityActivation;
 import io.helidon.json.JsonArray;
 import io.helidon.json.JsonObject;
 

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunJson.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunJson.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+
+/**
+ * Explicit JSON representation of retained chaos runs.
+ */
+final class ChaosRunJson {
+    private static final String RUN_PATH = "/chaos/v1/runs/";
+
+    private ChaosRunJson() {
+    }
+
+    static JsonObject toJson(ChaosRunView run) {
+        JsonObject.Builder result = JsonObject.builder()
+                .set("id", run.id().toString())
+                .set("name", run.name())
+                .set("state", run.state().name())
+                .set("plan", plan(run.plan()))
+                .set("seed", run.seed())
+                .set("actor", run.actor())
+                .set("createdAt", run.createdAt().toString())
+                .set("startedAt", run.startedAt().toString())
+                .set("expiresAt", run.expiresAt().toString())
+                .set("counters", counters(run))
+                .set("links", JsonObject.builder().set("self", RUN_PATH + run.id()).build());
+        run.terminalAt().ifPresent(value -> result.set("terminalAt", value.toString()));
+        run.terminalReason().ifPresent(value -> result.set("terminalReason", value));
+        return result.build();
+    }
+
+    static JsonArray toJson(List<ChaosRunView> runs) {
+        return JsonArray.create(runs.stream().map(ChaosRunJson::toJson).toList());
+    }
+
+    private static JsonObject plan(ChaosRunPlan plan) {
+        return JsonObject.builder()
+                .set("name", plan.name())
+                .set("maximumDuration", plan.maximumDuration().toString())
+                .set("seed", plan.seed())
+                .setValues("stages", List.of(stage(plan.stage())))
+                .build();
+    }
+
+    private static JsonObject stage(ChaosRunPlan.ChaosStage stage) {
+        return JsonObject.builder()
+                .set("name", stage.name())
+                .set("duration", stage.duration().toString())
+                .setValues("disruptions", List.of(disruption(stage.disruption())))
+                .build();
+    }
+
+    private static JsonObject disruption(ChaosRunPlan.ChaosDisruption disruption) {
+        return JsonObject.builder()
+                .set("name", disruption.name())
+                .set("scope", scope(disruption.scope()))
+                .set("activation", activation(disruption.activation()))
+                .set("effect", effect(disruption.effect()))
+                .set("budget", JsonObject.builder()
+                        .set("maximumActivations", disruption.budget().maximumActivations())
+                        .set("maximumConcurrent", disruption.budget().maximumConcurrent())
+                        .build())
+                .build();
+    }
+
+    private static JsonObject activation(ChaosActivation activation) {
+        if (activation instanceof ChaosActivation.Probability probability) {
+            return JsonObject.builder()
+                    .set("type", "probability")
+                    .set("probability", probability.probability())
+                    .build();
+        }
+        return JsonObject.builder()
+                .set("type", "always")
+                .build();
+    }
+
+    private static JsonObject scope(ChaosHttpScope scope) {
+        List<String> methods = new ArrayList<>(scope.methods());
+        return JsonObject.builder()
+                .set("type", "inbound-http")
+                .set("methods", JsonArray.createStrings(methods))
+                .set("path", JsonObject.builder()
+                        .set("match", scope.pathMatch().name().toLowerCase(Locale.ROOT))
+                        .set("value", scope.path())
+                        .build())
+                .build();
+    }
+
+    private static JsonObject effect(ChaosEffect effect) {
+        ChaosSyntheticResponse synthetic = (ChaosSyntheticResponse) effect;
+        JsonObject.Builder headers = JsonObject.builder();
+        synthetic.headers().forEach(headers::set);
+        JsonObject.Builder result = JsonObject.builder()
+                .set("type", "synthetic-http-response")
+                .set("status", synthetic.status())
+                .set("headers", headers.build())
+                .set("body", new String(synthetic.body(), StandardCharsets.UTF_8));
+        synthetic.mediaType().ifPresent(mediaType -> result.set("mediaType", mediaType.text()));
+        return result.build();
+    }
+
+    private static JsonObject counters(ChaosRunView run) {
+        return JsonObject.builder()
+                .set("matched", run.matched())
+                .set("activated", run.activated())
+                .set("skippedActivation", run.skippedActivation())
+                .set("skippedConcurrent", run.skippedConcurrent())
+                .set("skippedBudget", run.skippedBudget())
+                .set("inFlight", run.inFlight())
+                .set("completed", run.completed())
+                .build();
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunPlan.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunPlan.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Immutable normalized plan for the first Chaos vertical slice.
+ *
+ * @param name diagnostic run name
+ * @param maximumDuration run guard duration
+ * @param seed deterministic run seed
+ * @param stage single run stage
+ */
+record ChaosRunPlan(String name, Duration maximumDuration, long seed, ChaosStage stage) {
+
+    ChaosRunPlan {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(maximumDuration);
+        Objects.requireNonNull(stage);
+    }
+
+    /**
+     * Single stage in a run plan.
+     *
+     * @param name diagnostic stage name
+     * @param duration active stage duration
+     * @param disruption single disruption
+     */
+    record ChaosStage(String name, Duration duration, ChaosDisruption disruption) {
+        ChaosStage {
+            Objects.requireNonNull(name);
+            Objects.requireNonNull(duration);
+            Objects.requireNonNull(disruption);
+        }
+    }
+
+    /**
+     * Single inbound HTTP disruption.
+     *
+     * @param name diagnostic disruption name
+     * @param scope inbound request scope
+     * @param activation matched-invocation activation policy
+     * @param effect disruption effect
+     * @param budget cumulative and concurrent budget
+     */
+    record ChaosDisruption(String name,
+                           ChaosHttpScope scope,
+                           ChaosActivation activation,
+                           ChaosEffect effect,
+                           ChaosBudget budget) {
+        ChaosDisruption {
+            Objects.requireNonNull(name);
+            Objects.requireNonNull(scope);
+            Objects.requireNonNull(activation);
+            Objects.requireNonNull(effect);
+            Objects.requireNonNull(budget);
+        }
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunPlanJson.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunPlanJson.java
@@ -1,0 +1,421 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.math.BigDecimal;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.format.DateTimeParseException;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import io.helidon.common.media.type.MediaType;
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonValue;
+
+import static io.helidon.extensions.chaos.ChaosHttpScope.PathMatch.EXACT;
+import static io.helidon.extensions.chaos.ChaosHttpScope.PathMatch.PREFIX;
+
+/**
+ * Strict JSON boundary for the first Chaos run-plan slice.
+ */
+final class ChaosRunPlanJson {
+
+    private static final SecureRandom SEED_SOURCE = new SecureRandom();
+    private static final BigDecimal MINIMUM_PROBABILITY = BigDecimal.valueOf(0x1.0p-53);
+    private static final Pattern TOKEN = Pattern.compile("[!#$%&'*+.^_`|~0-9A-Za-z-]+");
+    private static final Set<String> FORBIDDEN_HEADERS = Set.of(
+            "connection",
+            "content-length",
+            "content-type",
+            "cookie",
+            "date",
+            "host",
+            "keep-alive",
+            "proxy-authenticate",
+            "proxy-authorization",
+            "server",
+            "set-cookie",
+            "te",
+            "trailer",
+            "transfer-encoding",
+            "upgrade",
+            "via",
+            "www-authenticate",
+            "x-forwarded-for",
+            "x-forwarded-host",
+            "x-forwarded-proto");
+
+    private ChaosRunPlanJson() {
+    }
+
+    static ChaosRunPlan parse(JsonObject json, ChaosLimitsConfig limits) {
+        rejectUnknown(json, "", Set.of("name", "maximumDuration", "seed", "stages"));
+        String name = requiredNonBlank(json, "name", "/name");
+        Duration maximumDuration = duration(json, "maximumDuration", "/maximumDuration");
+        requirePositive(maximumDuration, "/maximumDuration");
+        if (maximumDuration.compareTo(limits.maximumRunDuration()) > 0) {
+            throw invalid("/maximumDuration", "duration-limit", "maximumDuration exceeds the server limit.");
+        }
+        long seed = json.containsKey("seed") ? integer(json, "seed", "/seed") : SEED_SOURCE.nextLong();
+
+        JsonArray stages = requiredArray(json, "stages", "/stages");
+        if (stages.size() != 1) {
+            throw invalid("/stages", "stage-count", "Exactly one stage is supported.");
+        }
+        ChaosRunPlan.ChaosStage stage = stage(requiredObject(stages.get(0).orElseThrow(), "/stages/0"),
+                                               maximumDuration,
+                                               limits);
+        return new ChaosRunPlan(name, maximumDuration, seed, stage);
+    }
+
+    private static ChaosRunPlan.ChaosStage stage(JsonObject json,
+                                                  Duration maximumDuration,
+                                                  ChaosLimitsConfig limits) {
+        String path = "/stages/0";
+        rejectUnknown(json, path, Set.of("name", "duration", "disruptions"));
+        String name = requiredNonBlank(json, "name", path + "/name");
+        Duration duration = duration(json, "duration", path + "/duration");
+        requirePositive(duration, path + "/duration");
+        if (duration.compareTo(maximumDuration) > 0) {
+            throw invalid(path + "/duration", "duration-limit", "Stage duration exceeds maximumDuration.");
+        }
+
+        JsonArray disruptions = requiredArray(json, "disruptions", path + "/disruptions");
+        if (disruptions.size() != 1) {
+            throw invalid(path + "/disruptions", "disruption-count", "Exactly one disruption is supported.");
+        }
+        return new ChaosRunPlan.ChaosStage(name,
+                                           duration,
+                                           disruption(requiredObject(disruptions.get(0).orElseThrow(),
+                                                                     path + "/disruptions/0"),
+                                                      limits));
+    }
+
+    private static ChaosRunPlan.ChaosDisruption disruption(JsonObject json, ChaosLimitsConfig limits) {
+        String path = "/stages/0/disruptions/0";
+        rejectUnknown(json, path, Set.of("name", "scope", "activation", "effect", "budget"));
+        String name = requiredNonBlank(json, "name", path + "/name");
+        ChaosHttpScope scope = scope(requiredObject(json, "scope", path + "/scope"), path + "/scope");
+        ChaosActivation activation = activation(requiredObject(json, "activation", path + "/activation"),
+                                                  path + "/activation");
+        ChaosEffect effect = effect(requiredObject(json, "effect", path + "/effect"),
+                                    path + "/effect",
+                                    limits);
+        ChaosBudget budget = budget(requiredObject(json, "budget", path + "/budget"), path + "/budget", limits);
+        return new ChaosRunPlan.ChaosDisruption(name, scope, activation, effect, budget);
+    }
+
+    private static ChaosHttpScope scope(JsonObject json, String path) {
+        rejectUnknown(json, path, Set.of("type", "methods", "path"));
+        requireType(json, "type", "inbound-http", path + "/type");
+        JsonArray methodsJson = requiredArray(json, "methods", path + "/methods");
+        if (methodsJson.size() == 0) {
+            throw invalid(path + "/methods", "empty-methods", "At least one HTTP method is required.");
+        }
+        Set<String> methods = new LinkedHashSet<>();
+        for (int i = 0; i < methodsJson.size(); i++) {
+            String method = requiredString(methodsJson.get(i).orElseThrow(), path + "/methods/" + i)
+                    .toUpperCase(Locale.ROOT);
+            if (!TOKEN.matcher(method).matches()) {
+                throw invalid(path + "/methods/" + i, "invalid-method", "HTTP method is not a valid token.");
+            }
+            methods.add(method);
+        }
+
+        JsonObject pathJson = requiredObject(json, "path", path + "/path");
+        rejectUnknown(pathJson, path + "/path", Set.of("match", "value"));
+        String match = requiredString(pathJson, "match", path + "/path/match");
+        ChaosHttpScope.PathMatch pathMatch = switch (match) {
+        case "exact" -> EXACT;
+        case "prefix" -> PREFIX;
+        default -> throw invalid(path + "/path/match", "unsupported-path-match",
+                                 "Path match must be exact or prefix.");
+        };
+        String value = requiredString(pathJson, "value", path + "/path/value");
+        validatePath(value, path + "/path/value");
+        return new ChaosHttpScope(methods, pathMatch, value);
+    }
+
+    private static ChaosActivation activation(JsonObject json, String path) {
+        rejectUnknown(json, path, Set.of("type", "probability"));
+        String type = requiredString(json, "type", path + "/type");
+        return switch (type) {
+        case "always" -> {
+            rejectUnknown(json, path, Set.of("type"));
+            yield ChaosActivation.always();
+        }
+        case "probability" -> {
+            rejectUnknown(json, path, Set.of("type", "probability"));
+            BigDecimal probability = number(json, "probability", path + "/probability");
+            if (probability.compareTo(BigDecimal.ZERO) <= 0 || probability.compareTo(BigDecimal.ONE) > 0) {
+                throw invalid(path + "/probability", "invalid-probability",
+                              "probability must be greater than zero and at most one.");
+            }
+            if (probability.compareTo(MINIMUM_PROBABILITY) < 0) {
+                throw invalid(path + "/probability", "probability-precision",
+                              "probability must be at least 2^-53.");
+            }
+            double normalized = probability.doubleValue();
+            if (normalized == 1 && probability.compareTo(BigDecimal.ONE) < 0) {
+                throw invalid(path + "/probability", "probability-precision",
+                              "probability is too close to one for the supported numeric precision.");
+            }
+            yield new ChaosActivation.Probability(normalized);
+        }
+        default -> throw invalid(path + "/type", "unsupported-type",
+                                 "Activation type must be always or probability.");
+        };
+    }
+
+    private static ChaosEffect effect(JsonObject json, String path, ChaosLimitsConfig limits) {
+        rejectUnknown(json, path, Set.of("type", "status", "headers", "mediaType", "body"));
+        String type = requiredString(json, "type", path + "/type");
+        return switch (type) {
+        case "synthetic-http-response" -> syntheticResponse(json, path, limits);
+        default -> throw invalid(path + "/type", "unsupported-type",
+                                 "Effect type must be synthetic-http-response.");
+        };
+    }
+
+    private static ChaosSyntheticResponse syntheticResponse(JsonObject json, String path, ChaosLimitsConfig limits) {
+        rejectUnknown(json, path, Set.of("type", "status", "headers", "mediaType", "body"));
+        long statusValue = integer(json, "status", path + "/status");
+        if (statusValue < 400 || statusValue > 599) {
+            throw invalid(path + "/status", "invalid-status", "Synthetic status must be between 400 and 599.");
+        }
+
+        Map<String, String> headers = new LinkedHashMap<>();
+        if (json.containsKey("headers")) {
+            JsonObject headerJson = requiredObject(json, "headers", path + "/headers");
+            for (String name : headerJson.keysAsStrings()) {
+                String headerPath = path + "/headers/" + pointerToken(name);
+                validateHeaderName(name, headerPath);
+                String value = requiredString(headerJson, name, headerPath);
+                validateHeaderValue(value, headerPath);
+                headers.put(name, value);
+            }
+        }
+
+        Optional<MediaType> mediaType = Optional.empty();
+        if (json.containsKey("mediaType")) {
+            String value = requiredString(json, "mediaType", path + "/mediaType");
+            try {
+                mediaType = Optional.of(MediaTypes.create(value));
+            } catch (RuntimeException e) {
+                throw invalid(path + "/mediaType", "invalid-media-type", "mediaType is not valid.");
+            }
+        }
+
+        String body = json.containsKey("body") ? requiredString(json, "body", path + "/body") : "";
+        byte[] bodyBytes = body.getBytes(StandardCharsets.UTF_8);
+        if (bodyBytes.length > limits.maximumSyntheticBodyBytes()) {
+            throw invalid(path + "/body", "body-limit", "Synthetic body exceeds the server byte limit.");
+        }
+        return new ChaosSyntheticResponse((int) statusValue, headers, mediaType, bodyBytes);
+    }
+
+    private static ChaosBudget budget(JsonObject json, String path, ChaosLimitsConfig limits) {
+        rejectUnknown(json, path, Set.of("maximumActivations", "maximumConcurrent"));
+        long maximumActivations = integer(json, "maximumActivations", path + "/maximumActivations");
+        long maximumConcurrent = integer(json, "maximumConcurrent", path + "/maximumConcurrent");
+        if (maximumActivations <= 0) {
+            throw invalid(path + "/maximumActivations", "invalid-budget", "maximumActivations must be positive.");
+        }
+        if (maximumActivations > limits.maximumActivationsPerDisruption()) {
+            throw invalid(path + "/maximumActivations", "budget-limit",
+                          "maximumActivations exceeds the server limit.");
+        }
+        if (maximumConcurrent <= 0) {
+            throw invalid(path + "/maximumConcurrent", "invalid-budget", "maximumConcurrent must be positive.");
+        }
+        if (maximumConcurrent > limits.maximumConcurrentActivationsPerDisruption()) {
+            throw invalid(path + "/maximumConcurrent", "budget-limit",
+                          "maximumConcurrent exceeds the server limit.");
+        }
+        if (maximumConcurrent > Integer.MAX_VALUE) {
+            throw invalid(path + "/maximumConcurrent", "integer-range", "maximumConcurrent is too large.");
+        }
+        return new ChaosBudget(maximumActivations, (int) maximumConcurrent);
+    }
+
+    private static void requireType(JsonObject json, String name, String expected, String path) {
+        String actual = requiredString(json, name, path);
+        if (!expected.equals(actual)) {
+            throw invalid(path, "unsupported-type", "Only " + expected + " is supported in this release.");
+        }
+    }
+
+    private static void validatePath(String value, String path) {
+        if (!value.startsWith("/") || value.contains("?") || value.contains("#") || value.contains("%")) {
+            throw invalid(path, "invalid-path", "Path must be an absolute decoded path without query or fragment.");
+        }
+        try {
+            URI uri = URI.create(value);
+            if (!value.equals(uri.normalize().getPath()) || value.contains("//")) {
+                throw invalid(path, "non-normalized-path", "Path must be normalized.");
+            }
+        } catch (IllegalArgumentException e) {
+            throw invalid(path, "invalid-path", "Path must be a valid absolute path.");
+        }
+        if (value.equals("/chaos") || value.startsWith("/chaos/")) {
+            throw invalid(path, "control-path", "Chaos control paths cannot be disrupted.");
+        }
+    }
+
+    private static void validateHeaderName(String name, String path) {
+        String normalized = name.toLowerCase(Locale.ROOT);
+        if (!TOKEN.matcher(name).matches()) {
+            throw invalid(path, "invalid-header-name", "Header name is not a valid HTTP token.");
+        }
+        if (FORBIDDEN_HEADERS.contains(normalized)) {
+            throw invalid(path, "forbidden-header", "Header is controlled by the server and cannot be supplied.");
+        }
+    }
+
+    private static void validateHeaderValue(String value, String path) {
+        for (int i = 0; i < value.length(); i++) {
+            char character = value.charAt(i);
+            if ((character <= 0x1f && character != '\t') || character == 0x7f) {
+                throw invalid(path, "invalid-header-value", "Header value contains a forbidden control character.");
+            }
+        }
+    }
+
+    private static Duration duration(JsonObject json, String name, String path) {
+        String value = requiredString(json, name, path);
+        try {
+            return Duration.parse(value);
+        } catch (DateTimeParseException e) {
+            throw invalid(path, "invalid-duration", "Value must be an ISO-8601 duration.");
+        }
+    }
+
+    private static void requirePositive(Duration value, String path) {
+        if (value.isZero() || value.isNegative()) {
+            throw invalid(path, "invalid-duration", "Duration must be positive.");
+        }
+    }
+
+    private static long integer(JsonObject json, String name, String path) {
+        JsonValue value = requiredValue(json, name, path);
+        try {
+            BigDecimal number = value.asNumber().bigDecimalValue();
+            return number.longValueExact();
+        } catch (RuntimeException e) {
+            throw bad(path, "invalid-type", "Value must be an integer.");
+        }
+    }
+
+    private static BigDecimal number(JsonObject json, String name, String path) {
+        JsonValue value = requiredValue(json, name, path);
+        try {
+            return value.asNumber().bigDecimalValue();
+        } catch (RuntimeException e) {
+            throw bad(path, "invalid-type", "Value must be a number.");
+        }
+    }
+
+    private static String requiredNonBlank(JsonObject json, String name, String path) {
+        String value = requiredString(json, name, path);
+        if (value.isBlank()) {
+            throw invalid(path, "blank-value", "Value must not be blank.");
+        }
+        return value;
+    }
+
+    private static String requiredString(JsonObject json, String name, String path) {
+        return requiredString(requiredValue(json, name, path), path);
+    }
+
+    private static String requiredString(JsonValue value, String path) {
+        String result;
+        try {
+            result = value.asString().value();
+        } catch (RuntimeException e) {
+            throw bad(path, "invalid-type", "Value must be a string.");
+        }
+        validateUnicode(result, path);
+        return result;
+    }
+
+    private static void validateUnicode(String value, String path) {
+        for (int i = 0; i < value.length(); i++) {
+            char character = value.charAt(i);
+            if (Character.isHighSurrogate(character)) {
+                if (++i >= value.length() || !Character.isLowSurrogate(value.charAt(i))) {
+                    throw invalid(path, "invalid-unicode", "String contains an unpaired Unicode surrogate.");
+                }
+            } else if (Character.isLowSurrogate(character)) {
+                throw invalid(path, "invalid-unicode", "String contains an unpaired Unicode surrogate.");
+            }
+        }
+    }
+
+    private static JsonArray requiredArray(JsonObject json, String name, String path) {
+        JsonValue value = requiredValue(json, name, path);
+        try {
+            return value.asArray();
+        } catch (RuntimeException e) {
+            throw bad(path, "invalid-type", "Value must be an array.");
+        }
+    }
+
+    private static JsonObject requiredObject(JsonObject json, String name, String path) {
+        return requiredObject(requiredValue(json, name, path), path);
+    }
+
+    private static JsonObject requiredObject(JsonValue value, String path) {
+        try {
+            return value.asObject();
+        } catch (RuntimeException e) {
+            throw bad(path, "invalid-type", "Value must be an object.");
+        }
+    }
+
+    private static JsonValue requiredValue(JsonObject json, String name, String path) {
+        return json.value(name).orElseThrow(() -> bad(path, "required-property", "Required property is missing."));
+    }
+
+    private static void rejectUnknown(JsonObject json, String path, Set<String> allowed) {
+        for (String key : json.keysAsStrings()) {
+            if (!allowed.contains(key)) {
+                throw bad(path + "/" + pointerToken(key), "unknown-property", "Unknown property is not allowed.");
+            }
+        }
+    }
+
+    private static String pointerToken(String value) {
+        return value.replace("~", "~0").replace("/", "~1");
+    }
+
+    private static ChaosRequestException bad(String path, String code, String message) {
+        return ChaosRequestException.badRequest(path, code, message);
+    }
+
+    private static ChaosRequestException invalid(String path, String code, String message) {
+        return ChaosRequestException.invalidPlan(path, code, message);
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunPlanJson.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunPlanJson.java
@@ -225,7 +225,7 @@ final class ChaosRunPlanJson {
             try {
                 mediaType = Optional.of(MediaTypes.create(value));
             } catch (RuntimeException e) {
-                throw invalid(path + "/mediaType", "invalid-media-type", "mediaType is not valid.");
+                throw invalid(path + "/mediaType", "invalid-media-type", "mediaType is not valid.", e);
             }
         }
 
@@ -278,7 +278,7 @@ final class ChaosRunPlanJson {
                 throw invalid(path, "non-normalized-path", "Path must be normalized.");
             }
         } catch (IllegalArgumentException e) {
-            throw invalid(path, "invalid-path", "Path must be a valid absolute path.");
+            throw invalid(path, "invalid-path", "Path must be a valid absolute path.", e);
         }
         if (value.equals("/chaos") || value.startsWith("/chaos/")) {
             throw invalid(path, "control-path", "Chaos control paths cannot be disrupted.");
@@ -309,7 +309,7 @@ final class ChaosRunPlanJson {
         try {
             return Duration.parse(value);
         } catch (DateTimeParseException e) {
-            throw invalid(path, "invalid-duration", "Value must be an ISO-8601 duration.");
+            throw invalid(path, "invalid-duration", "Value must be an ISO-8601 duration.", e);
         }
     }
 
@@ -325,7 +325,7 @@ final class ChaosRunPlanJson {
             BigDecimal number = value.asNumber().bigDecimalValue();
             return number.longValueExact();
         } catch (RuntimeException e) {
-            throw bad(path, "invalid-type", "Value must be an integer.");
+            throw bad(path, "invalid-type", "Value must be an integer.", e);
         }
     }
 
@@ -334,7 +334,7 @@ final class ChaosRunPlanJson {
         try {
             return value.asNumber().bigDecimalValue();
         } catch (RuntimeException e) {
-            throw bad(path, "invalid-type", "Value must be a number.");
+            throw bad(path, "invalid-type", "Value must be a number.", e);
         }
     }
 
@@ -355,7 +355,7 @@ final class ChaosRunPlanJson {
         try {
             result = value.asString().value();
         } catch (RuntimeException e) {
-            throw bad(path, "invalid-type", "Value must be a string.");
+            throw bad(path, "invalid-type", "Value must be a string.", e);
         }
         validateUnicode(result, path);
         return result;
@@ -379,7 +379,7 @@ final class ChaosRunPlanJson {
         try {
             return value.asArray();
         } catch (RuntimeException e) {
-            throw bad(path, "invalid-type", "Value must be an array.");
+            throw bad(path, "invalid-type", "Value must be an array.", e);
         }
     }
 
@@ -391,7 +391,7 @@ final class ChaosRunPlanJson {
         try {
             return value.asObject();
         } catch (RuntimeException e) {
-            throw bad(path, "invalid-type", "Value must be an object.");
+            throw bad(path, "invalid-type", "Value must be an object.", e);
         }
     }
 
@@ -415,7 +415,15 @@ final class ChaosRunPlanJson {
         return ChaosRequestException.badRequest(path, code, message);
     }
 
+    private static ChaosRequestException bad(String path, String code, String message, Throwable cause) {
+        return ChaosRequestException.badRequest(path, code, message, cause);
+    }
+
     private static ChaosRequestException invalid(String path, String code, String message) {
         return ChaosRequestException.invalidPlan(path, code, message);
+    }
+
+    private static ChaosRequestException invalid(String path, String code, String message, Throwable cause) {
+        return ChaosRequestException.invalidPlan(path, code, message, cause);
     }
 }

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunPlanJson.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunPlanJson.java
@@ -31,6 +31,7 @@ import java.util.regex.Pattern;
 
 import io.helidon.common.media.type.MediaType;
 import io.helidon.common.media.type.MediaTypes;
+import io.helidon.extensions.chaos.ChaosActivation.ProbabilityActivation;
 import io.helidon.json.JsonArray;
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonValue;

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunPlanJson.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunPlanJson.java
@@ -183,7 +183,7 @@ final class ChaosRunPlanJson {
                 throw invalid(path + "/probability", "probability-precision",
                               "probability is too close to one for the supported numeric precision.");
             }
-            yield new ChaosActivation.Probability(normalized);
+            yield new ProbabilityActivation(normalized);
         }
         default -> throw invalid(path + "/type", "unsupported-type",
                                  "Activation type must be always or probability.");

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunPlanJson.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunPlanJson.java
@@ -208,11 +208,15 @@ final class ChaosRunPlanJson {
         }
 
         Map<String, String> headers = new LinkedHashMap<>();
+        Set<String> headerNames = new LinkedHashSet<>();
         if (json.containsKey("headers")) {
             JsonObject headerJson = requiredObject(json, "headers", path + "/headers");
             for (String name : headerJson.keysAsStrings()) {
                 String headerPath = path + "/headers/" + pointerToken(name);
                 validateHeaderName(name, headerPath);
+                if (!headerNames.add(name.toLowerCase(Locale.ROOT))) {
+                    throw invalid(headerPath, "duplicate-header", "Header name must be unique ignoring case.");
+                }
                 String value = requiredString(headerJson, name, headerPath);
                 validateHeaderValue(value, headerPath);
                 headers.put(name, value);
@@ -224,8 +228,8 @@ final class ChaosRunPlanJson {
             String value = requiredString(json, "mediaType", path + "/mediaType");
             try {
                 mediaType = Optional.of(MediaTypes.create(value));
-            } catch (RuntimeException e) {
-                throw invalid(path + "/mediaType", "invalid-media-type", "mediaType is not valid.", e);
+            } catch (RuntimeException exception) {
+                throw invalid(path + "/mediaType", "invalid-media-type", "mediaType is not valid.", exception);
             }
         }
 
@@ -277,8 +281,8 @@ final class ChaosRunPlanJson {
             if (!value.equals(uri.normalize().getPath()) || value.contains("//")) {
                 throw invalid(path, "non-normalized-path", "Path must be normalized.");
             }
-        } catch (IllegalArgumentException e) {
-            throw invalid(path, "invalid-path", "Path must be a valid absolute path.", e);
+        } catch (IllegalArgumentException exception) {
+            throw invalid(path, "invalid-path", "Path must be a valid absolute path.", exception);
         }
         if (value.equals("/chaos") || value.startsWith("/chaos/")) {
             throw invalid(path, "control-path", "Chaos control paths cannot be disrupted.");
@@ -308,8 +312,8 @@ final class ChaosRunPlanJson {
         String value = requiredString(json, name, path);
         try {
             return Duration.parse(value);
-        } catch (DateTimeParseException e) {
-            throw invalid(path, "invalid-duration", "Value must be an ISO-8601 duration.", e);
+        } catch (DateTimeParseException exception) {
+            throw invalid(path, "invalid-duration", "Value must be an ISO-8601 duration.", exception);
         }
     }
 
@@ -324,8 +328,8 @@ final class ChaosRunPlanJson {
         try {
             BigDecimal number = value.asNumber().bigDecimalValue();
             return number.longValueExact();
-        } catch (RuntimeException e) {
-            throw bad(path, "invalid-type", "Value must be an integer.", e);
+        } catch (RuntimeException exception) {
+            throw bad(path, "invalid-type", "Value must be an integer.", exception);
         }
     }
 
@@ -333,8 +337,8 @@ final class ChaosRunPlanJson {
         JsonValue value = requiredValue(json, name, path);
         try {
             return value.asNumber().bigDecimalValue();
-        } catch (RuntimeException e) {
-            throw bad(path, "invalid-type", "Value must be a number.", e);
+        } catch (RuntimeException exception) {
+            throw bad(path, "invalid-type", "Value must be a number.", exception);
         }
     }
 
@@ -354,8 +358,8 @@ final class ChaosRunPlanJson {
         String result;
         try {
             result = value.asString().value();
-        } catch (RuntimeException e) {
-            throw bad(path, "invalid-type", "Value must be a string.", e);
+        } catch (RuntimeException exception) {
+            throw bad(path, "invalid-type", "Value must be a string.", exception);
         }
         validateUnicode(result, path);
         return result;
@@ -378,8 +382,8 @@ final class ChaosRunPlanJson {
         JsonValue value = requiredValue(json, name, path);
         try {
             return value.asArray();
-        } catch (RuntimeException e) {
-            throw bad(path, "invalid-type", "Value must be an array.", e);
+        } catch (RuntimeException exception) {
+            throw bad(path, "invalid-type", "Value must be an array.", exception);
         }
     }
 
@@ -390,8 +394,8 @@ final class ChaosRunPlanJson {
     private static JsonObject requiredObject(JsonValue value, String path) {
         try {
             return value.asObject();
-        } catch (RuntimeException e) {
-            throw bad(path, "invalid-type", "Value must be an object.", e);
+        } catch (RuntimeException exception) {
+            throw bad(path, "invalid-type", "Value must be an object.", exception);
         }
     }
 

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunState.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunState.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+/**
+ * Lifecycle state of a local chaos run.
+ */
+enum ChaosRunState {
+    /** The run can activate its disruption. */
+    RUNNING,
+    /** The run is inactive and is draining an in-flight activation. */
+    STOPPING,
+    /** The run was explicitly stopped. */
+    STOPPED,
+    /** The run completed its stage duration. */
+    COMPLETED,
+    /** The maximum run duration guard expired. */
+    EXPIRED,
+    /** The run failed internally. */
+    FAILED
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunView.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosRunView.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Immutable point-in-time representation of a chaos run.
+ *
+ * @param id run identifier
+ * @param name diagnostic run name
+ * @param state lifecycle state
+ * @param plan normalized run plan
+ * @param seed deterministic run seed
+ * @param actor authenticated actor that created the run
+ * @param createdAt creation time
+ * @param startedAt activation time
+ * @param expiresAt maximum-duration guard time
+ * @param terminalAt terminal transition time, if terminal
+ * @param terminalReason stable machine-readable terminal reason
+ * @param matched matched inbound requests
+ * @param activated activated disruptions
+ * @param skippedActivation matches rejected by their activation policy
+ * @param skippedConcurrent matches skipped by the concurrency ceiling
+ * @param skippedBudget matches skipped by the cumulative ceiling
+ * @param inFlight activations not yet released
+ * @param completed released activations
+ */
+record ChaosRunView(UUID id,
+                    String name,
+                    ChaosRunState state,
+                    ChaosRunPlan plan,
+                    long seed,
+                    String actor,
+                    Instant createdAt,
+                    Instant startedAt,
+                    Instant expiresAt,
+                    Optional<Instant> terminalAt,
+                    Optional<String> terminalReason,
+                    long matched,
+                    long activated,
+                    long skippedActivation,
+                    long skippedConcurrent,
+                    long skippedBudget,
+                    long inFlight,
+                    long completed) {
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosScheduler.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosScheduler.java
@@ -26,6 +26,15 @@ import java.util.concurrent.TimeUnit;
 interface ChaosScheduler extends AutoCloseable {
 
     /**
+     * Creates the daemon scheduler used by a running server.
+     *
+     * @return scheduler
+     */
+    static ChaosScheduler create() {
+        return new SystemChaosScheduler();
+    }
+
+    /**
      * Schedules an action after a delay.
      *
      * @param delay non-negative delay
@@ -36,15 +45,6 @@ interface ChaosScheduler extends AutoCloseable {
 
     @Override
     void close();
-
-    /**
-     * Creates the daemon scheduler used by a running server.
-     *
-     * @return scheduler
-     */
-    static ChaosScheduler create() {
-        return new SystemChaosScheduler();
-    }
 
     /**
      * Handle for a scheduled transition.

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosScheduler.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosScheduler.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.time.Duration;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Schedules lifecycle transitions without making the engine sleep.
+ */
+interface ChaosScheduler extends AutoCloseable {
+
+    /**
+     * Schedules an action after a delay.
+     *
+     * @param delay non-negative delay
+     * @param action action to invoke
+     * @return cancellation handle
+     */
+    Cancellable schedule(Duration delay, Runnable action);
+
+    @Override
+    void close();
+
+    /**
+     * Creates the daemon scheduler used by a running server.
+     *
+     * @return scheduler
+     */
+    static ChaosScheduler create() {
+        return new SystemChaosScheduler();
+    }
+
+    /**
+     * Handle for a scheduled transition.
+     */
+    interface Cancellable {
+        /**
+         * Attempts to cancel the transition.
+         *
+         * @return whether cancellation succeeded
+         */
+        boolean cancel();
+    }
+
+    final class SystemChaosScheduler implements ChaosScheduler {
+        private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "helidon-chaos-lifecycle");
+            thread.setDaemon(true);
+            return thread;
+        });
+
+        @Override
+        public Cancellable schedule(Duration delay, Runnable action) {
+            var future = executor.schedule(action, delay.toNanos(), TimeUnit.NANOSECONDS);
+            return () -> future.cancel(false);
+        }
+
+        @Override
+        public void close() {
+            executor.shutdownNow();
+        }
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosSecurityConfigBlueprint.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosSecurityConfigBlueprint.java
@@ -35,11 +35,11 @@ interface ChaosSecurityConfigBlueprint {
     String requiredRole();
 
     /**
-     * Whether an explicitly loopback-bound listener may be used without authentication.
+     * Whether an explicitly local listener may be used without authentication.
      *
-     * @return whether anonymous loopback access is allowed
+     * @return whether anonymous local access is allowed
      */
     @Option.Configured
     @Option.DefaultBoolean(false)
-    boolean allowUnauthenticatedLoopback();
+    boolean allowUnauthenticatedLocal();
 }

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosSecurityConfigBlueprint.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosSecurityConfigBlueprint.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import io.helidon.builder.api.Option;
+import io.helidon.builder.api.Prototype;
+
+/**
+ * Security configuration for the Chaos control API.
+ */
+@Prototype.Blueprint(decorator = ChaosSecurityConfigSupport.BuilderDecorator.class)
+@Prototype.Configured
+interface ChaosSecurityConfigBlueprint {
+
+    /**
+     * Role required for every control operation.
+     *
+     * @return required role
+     */
+    @Option.Configured
+    @Option.Default("chaos-operator")
+    String requiredRole();
+
+    /**
+     * Whether an explicitly loopback-bound listener may be used without authentication.
+     *
+     * @return whether anonymous loopback access is allowed
+     */
+    @Option.Configured
+    @Option.DefaultBoolean(false)
+    boolean allowUnauthenticatedLoopback();
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosSecurityConfigSupport.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosSecurityConfigSupport.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import io.helidon.builder.api.Prototype;
+
+/**
+ * Validation for {@link ChaosSecurityConfig}.
+ */
+final class ChaosSecurityConfigSupport {
+
+    private ChaosSecurityConfigSupport() {
+    }
+
+    static final class BuilderDecorator implements Prototype.BuilderDecorator<ChaosSecurityConfig.BuilderBase<?, ?>> {
+
+        @Override
+        public void decorate(ChaosSecurityConfig.BuilderBase<?, ?> builder) {
+            if (builder.requiredRole().isBlank()) {
+                throw new IllegalArgumentException("Chaos security required-role must not be blank");
+            }
+        }
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosServerFeature.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosServerFeature.java
@@ -85,7 +85,7 @@ public final class ChaosServerFeature implements RuntimeType.Api<ChaosConfig>, S
         try {
             context.socket(policy.controlSocket())
                     .httpRouting()
-                    .register("/chaos/v1", new ChaosControlService(engine, prototype, policy.anonymousLoopback()));
+                    .register("/chaos/v1", new ChaosControlService(engine, prototype, policy.anonymousLocal()));
             policy.applicationSockets().forEach(socket -> context.socket(socket)
                     .httpRouting()
                     .addFilter(new ChaosApplicationFilter(engine)));

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosServerFeature.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosServerFeature.java
@@ -89,9 +89,9 @@ public final class ChaosServerFeature implements RuntimeType.Api<ChaosConfig>, S
             policy.applicationSockets().forEach(socket -> context.socket(socket)
                     .httpRouting()
                     .addFilter(new ChaosApplicationFilter(engine)));
-        } catch (RuntimeException e) {
+        } catch (RuntimeException exception) {
             engine.close();
-            throw e;
+            throw exception;
         }
     }
 

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosServerFeature.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosServerFeature.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import io.helidon.builder.api.RuntimeType;
+import io.helidon.common.Weighted;
+import io.helidon.webserver.spi.ServerFeature;
+
+/**
+ * Runtime type produced from {@link ChaosConfig}.
+ */
+public final class ChaosServerFeature implements RuntimeType.Api<ChaosConfig>, ServerFeature, Weighted {
+
+    static final String CHAOS_ID = "chaos";
+
+    private final ChaosConfig prototype;
+
+    private ChaosServerFeature(ChaosConfig prototype) {
+        this.prototype = Objects.requireNonNull(prototype);
+    }
+
+    /**
+     * Creates the runtime type.
+     *
+     * @param prototype startup configuration
+     * @return runtime type
+     */
+    public static ChaosServerFeature create(ChaosConfig prototype) {
+        return new ChaosServerFeature(prototype);
+    }
+
+    /**
+     * Returns the configuration builder for this runtime type.
+     *
+     * @return configuration builder
+     */
+    public static ChaosConfig.Builder builder() {
+        return ChaosConfig.builder();
+    }
+
+    /**
+     * Creates the runtime type after updating its configuration builder.
+     *
+     * @param builderConsumer builder updates
+     * @return runtime type
+     */
+    public static ChaosServerFeature create(Consumer<ChaosConfig.Builder> builderConsumer) {
+        return builder().update(builderConsumer).build();
+    }
+
+    @Override
+    public String name() {
+        return prototype.name();
+    }
+
+    @Override
+    public ChaosConfig prototype() {
+        return prototype;
+    }
+
+    @Override
+    public void setup(ServerFeatureContext context) {
+        if (!prototype.enabled()) {
+            return;
+        }
+        ChaosSocketPolicy.Result policy = ChaosSocketPolicy.validate(prototype, context);
+        ChaosRunEngine engine = ChaosRunEngine.create(prototype.limits());
+        try {
+            context.socket(policy.controlSocket())
+                    .httpRouting()
+                    .register("/chaos/v1", new ChaosControlService(engine, prototype, policy.anonymousLoopback()));
+            policy.applicationSockets().forEach(socket -> context.socket(socket)
+                    .httpRouting()
+                    .addFilter(new ChaosApplicationFilter(engine)));
+        } catch (RuntimeException e) {
+            engine.close();
+            throw e;
+        }
+    }
+
+    @Override
+    public String type() {
+        return CHAOS_ID;
+    }
+
+    @Override
+    public double weight() {
+        return prototype.weight();
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosServerFeature.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosServerFeature.java
@@ -42,7 +42,7 @@ public final class ChaosServerFeature implements RuntimeType.Api<ChaosConfig>, S
      * @return runtime type
      */
     public static ChaosServerFeature create(ChaosConfig prototype) {
-        return new ChaosServerFeature(prototype);
+        return new ChaosServerFeature(Objects.requireNonNull(prototype));
     }
 
     /**
@@ -61,7 +61,7 @@ public final class ChaosServerFeature implements RuntimeType.Api<ChaosConfig>, S
      * @return runtime type
      */
     public static ChaosServerFeature create(Consumer<ChaosConfig.Builder> builderConsumer) {
-        return builder().update(builderConsumer).build();
+        return builder().update(Objects.requireNonNull(builderConsumer)).build();
     }
 
     @Override
@@ -76,6 +76,7 @@ public final class ChaosServerFeature implements RuntimeType.Api<ChaosConfig>, S
 
     @Override
     public void setup(ServerFeatureContext context) {
+        Objects.requireNonNull(context);
         if (!prototype.enabled()) {
             return;
         }

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosServerFeatureProvider.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosServerFeatureProvider.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import io.helidon.common.Api;
+import io.helidon.config.Config;
+import io.helidon.webserver.spi.ServerFeatureProvider;
+
+/**
+ * Configured-provider entry point for the Chaos server feature.
+ */
+public final class ChaosServerFeatureProvider implements ServerFeatureProvider<ChaosServerFeature> {
+
+    /**
+     * Required public constructor for service loading.
+     */
+    @Api.Internal
+    public ChaosServerFeatureProvider() {
+    }
+
+    @Override
+    public String configKey() {
+        return ChaosServerFeature.CHAOS_ID;
+    }
+
+    @Override
+    public ChaosServerFeature create(Config config, String name) {
+        return ChaosConfig.builder()
+                .config(config)
+                .name(name)
+                .build();
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosServerFeatureProvider.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosServerFeatureProvider.java
@@ -15,6 +15,8 @@
  */
 package io.helidon.extensions.chaos;
 
+import java.util.Objects;
+
 import io.helidon.common.Api;
 import io.helidon.config.Config;
 import io.helidon.webserver.spi.ServerFeatureProvider;
@@ -39,8 +41,8 @@ public final class ChaosServerFeatureProvider implements ServerFeatureProvider<C
     @Override
     public ChaosServerFeature create(Config config, String name) {
         return ChaosConfig.builder()
-                .config(config)
-                .name(name)
+                .config(Objects.requireNonNull(config))
+                .name(Objects.requireNonNull(name))
                 .build();
     }
 }

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosSocketPolicy.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosSocketPolicy.java
@@ -16,12 +16,17 @@
 package io.helidon.extensions.chaos;
 
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.UnixDomainSocketAddress;
 import java.util.Collections;
 import java.util.LinkedHashSet;
+import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 
 import io.helidon.webserver.ListenerConfig;
+import io.helidon.webserver.WebServer;
 import io.helidon.webserver.security.SecurityFeature;
 import io.helidon.webserver.spi.ServerFeature;
 
@@ -47,17 +52,16 @@ final class ChaosSocketPolicy {
             }
         }
 
-        boolean anonymousLoopback = config.security().allowUnauthenticatedLoopback();
-        if (anonymousLoopback) {
-            InetAddress address = controlListener.address();
-            if (address == null || address.isAnyLocalAddress() || !address.isLoopbackAddress()) {
-                throw new IllegalStateException("Anonymous chaos control access requires an explicit loopback binding");
+        boolean anonymousLocal = config.security().allowUnauthenticatedLocal();
+        if (anonymousLocal) {
+            if (!isLocal(controlListener)) {
+                throw new IllegalStateException("Anonymous chaos control access requires an explicit local binding");
             }
         } else if (!hasEnabledSecurityFeature(context)) {
             throw new IllegalStateException("Enabled chaos requires an enabled Helidon SecurityFeature");
         }
 
-        return new Result(controlSocket, config.applicationSockets(), anonymousLoopback);
+        return new Result(controlSocket, config.applicationSockets(), anonymousLocal);
     }
 
     private static void validateControlPayloadLimit(ChaosLimitsConfig limits, ListenerConfig listener) {
@@ -72,7 +76,31 @@ final class ChaosSocketPolicy {
     }
 
     private static ListenerConfig listener(ServerFeature.ServerFeatureContext context, String socket) {
-        return context.socket(socket).listener();
+        if (WebServer.DEFAULT_SOCKET_NAME.equals(socket)) {
+            return context.serverConfig();
+        }
+        ListenerConfig listener = context.serverConfig().sockets().get(socket);
+        if (listener == null) {
+            throw new NoSuchElementException("There is no socket configuration for socket named \"" + socket + "\"");
+        }
+        return listener;
+    }
+
+    private static boolean isLocal(ListenerConfig listener) {
+        return listener.bindAddress()
+                .map(ChaosSocketPolicy::isLocal)
+                .orElseGet(() -> isLoopback(listener.address()));
+    }
+
+    private static boolean isLocal(SocketAddress address) {
+        if (address instanceof InetSocketAddress inetAddress) {
+            return isLoopback(inetAddress.getAddress());
+        }
+        return address instanceof UnixDomainSocketAddress;
+    }
+
+    private static boolean isLoopback(InetAddress address) {
+        return address != null && !address.isAnyLocalAddress() && address.isLoopbackAddress();
     }
 
     private static boolean hasEnabledSecurityFeature(ServerFeature.ServerFeatureContext context) {
@@ -88,9 +116,9 @@ final class ChaosSocketPolicy {
      *
      * @param controlSocket dedicated control socket
      * @param applicationSockets sockets eligible for disruption
-     * @param anonymousLoopback whether explicit anonymous loopback mode is active
+     * @param anonymousLocal whether explicit anonymous local mode is active
      */
-    record Result(String controlSocket, Set<String> applicationSockets, boolean anonymousLoopback) {
+    record Result(String controlSocket, Set<String> applicationSockets, boolean anonymousLocal) {
         Result {
             applicationSockets = Collections.unmodifiableSet(new LinkedHashSet<>(applicationSockets));
         }

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosSocketPolicy.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosSocketPolicy.java
@@ -22,7 +22,6 @@ import java.util.Objects;
 import java.util.Set;
 
 import io.helidon.webserver.ListenerConfig;
-import io.helidon.webserver.WebServer;
 import io.helidon.webserver.security.SecurityFeature;
 import io.helidon.webserver.spi.ServerFeature;
 
@@ -39,11 +38,10 @@ final class ChaosSocketPolicy {
         Objects.requireNonNull(context);
         String controlSocket = config.controlSocket()
                 .orElseThrow(() -> new IllegalStateException("Enabled chaos requires a control socket"));
-        requireSocket(context, controlSocket, "control");
-        ListenerConfig controlListener = controlListener(context, controlSocket);
+        ListenerConfig controlListener = listener(context, controlSocket);
         validateControlPayloadLimit(config.limits(), controlListener);
         for (String applicationSocket : config.applicationSockets()) {
-            requireSocket(context, applicationSocket, "application");
+            listener(context, applicationSocket);
             if (controlSocket.equals(applicationSocket)) {
                 throw new IllegalStateException("The chaos control socket cannot carry application traffic");
             }
@@ -73,19 +71,8 @@ final class ChaosSocketPolicy {
         }
     }
 
-    private static ListenerConfig controlListener(ServerFeature.ServerFeatureContext context, String controlSocket) {
-        if (WebServer.DEFAULT_SOCKET_NAME.equals(controlSocket)) {
-            return context.serverConfig();
-        }
-        // The server prototype is the authority for a named listener's actual binding configuration.
-        return Objects.requireNonNull(context.serverConfig().sockets().get(controlSocket),
-                                      "Missing named listener configuration: " + controlSocket);
-    }
-
-    private static void requireSocket(ServerFeature.ServerFeatureContext context, String socket, String purpose) {
-        if (!context.socketExists(socket)) {
-            throw new IllegalStateException("Configured chaos " + purpose + " socket does not exist: " + socket);
-        }
+    private static ListenerConfig listener(ServerFeature.ServerFeatureContext context, String socket) {
+        return context.socket(socket).listener();
     }
 
     private static boolean hasEnabledSecurityFeature(ServerFeature.ServerFeatureContext context) {

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosSocketPolicy.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosSocketPolicy.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.net.InetAddress;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Objects;
+import java.util.Set;
+
+import io.helidon.webserver.ListenerConfig;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.security.SecurityFeature;
+import io.helidon.webserver.spi.ServerFeature;
+
+/**
+ * Validates socket isolation and control-plane security before installation.
+ */
+final class ChaosSocketPolicy {
+
+    private ChaosSocketPolicy() {
+    }
+
+    static Result validate(ChaosConfig config, ServerFeature.ServerFeatureContext context) {
+        Objects.requireNonNull(config);
+        Objects.requireNonNull(context);
+        String controlSocket = config.controlSocket()
+                .orElseThrow(() -> new IllegalStateException("Enabled chaos requires a control socket"));
+        requireSocket(context, controlSocket, "control");
+        ListenerConfig controlListener = controlListener(context, controlSocket);
+        validateControlPayloadLimit(config.limits(), controlListener);
+        for (String applicationSocket : config.applicationSockets()) {
+            requireSocket(context, applicationSocket, "application");
+            if (controlSocket.equals(applicationSocket)) {
+                throw new IllegalStateException("The chaos control socket cannot carry application traffic");
+            }
+        }
+
+        boolean anonymousLoopback = config.security().allowUnauthenticatedLoopback();
+        if (anonymousLoopback) {
+            InetAddress address = controlListener.address();
+            if (address == null || address.isAnyLocalAddress() || !address.isLoopbackAddress()) {
+                throw new IllegalStateException("Anonymous chaos control access requires an explicit loopback binding");
+            }
+        } else if (!hasEnabledSecurityFeature(context)) {
+            throw new IllegalStateException("Enabled chaos requires an enabled Helidon SecurityFeature");
+        }
+
+        return new Result(controlSocket, config.applicationSockets(), anonymousLoopback);
+    }
+
+    private static void validateControlPayloadLimit(ChaosLimitsConfig limits, ListenerConfig listener) {
+        long maximumPayloadSize = listener.maxPayloadSize();
+        if (maximumPayloadSize <= 0) {
+            throw new IllegalStateException("The chaos control socket requires a finite max-payload-size");
+        }
+        if (maximumPayloadSize > limits.maximumControlRequestBytes()) {
+            throw new IllegalStateException("The chaos control socket max-payload-size exceeds "
+                                                    + "maximum-control-request-bytes");
+        }
+    }
+
+    private static ListenerConfig controlListener(ServerFeature.ServerFeatureContext context, String controlSocket) {
+        if (WebServer.DEFAULT_SOCKET_NAME.equals(controlSocket)) {
+            return context.serverConfig();
+        }
+        // The server prototype is the authority for a named listener's actual binding configuration.
+        return Objects.requireNonNull(context.serverConfig().sockets().get(controlSocket),
+                                      "Missing named listener configuration: " + controlSocket);
+    }
+
+    private static void requireSocket(ServerFeature.ServerFeatureContext context, String socket, String purpose) {
+        if (!context.socketExists(socket)) {
+            throw new IllegalStateException("Configured chaos " + purpose + " socket does not exist: " + socket);
+        }
+    }
+
+    private static boolean hasEnabledSecurityFeature(ServerFeature.ServerFeatureContext context) {
+        return context.serverConfig().features().stream()
+                .filter(SecurityFeature.class::isInstance)
+                .map(SecurityFeature.class::cast)
+                .map(feature -> feature.prototype().security())
+                .anyMatch(security -> security.enabled() && security.resolveAtnProvider(null).isPresent());
+    }
+
+    /**
+     * Validated installation targets.
+     *
+     * @param controlSocket dedicated control socket
+     * @param applicationSockets sockets eligible for disruption
+     * @param anonymousLoopback whether explicit anonymous loopback mode is active
+     */
+    record Result(String controlSocket, Set<String> applicationSockets, boolean anonymousLoopback) {
+        Result {
+            applicationSockets = Collections.unmodifiableSet(new LinkedHashSet<>(applicationSockets));
+        }
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosSyntheticResponse.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosSyntheticResponse.java
@@ -37,9 +37,9 @@ record ChaosSyntheticResponse(int status,
                               byte[] body) implements ChaosEffect {
 
     ChaosSyntheticResponse {
-        headers = Collections.unmodifiableMap(new LinkedHashMap<>(headers));
-        mediaType = Objects.requireNonNull(mediaType);
-        body = body.clone();
+        headers = Collections.unmodifiableMap(new LinkedHashMap<>(Objects.requireNonNull(headers, "headers is null")));
+        Objects.requireNonNull(mediaType, "mediaType is null");
+        body = Objects.requireNonNull(body, "body is null").clone();
     }
 
     @Override

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosSyntheticResponse.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosSyntheticResponse.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+import io.helidon.common.media.type.MediaType;
+
+/**
+ * Synthetic HTTP response applied to a matched request.
+ *
+ * @param status HTTP status code
+ * @param headers response headers
+ * @param mediaType optional response media type
+ * @param body response body bytes
+ */
+record ChaosSyntheticResponse(int status,
+                              Map<String, String> headers,
+                              Optional<MediaType> mediaType,
+                              byte[] body) implements ChaosEffect {
+
+    ChaosSyntheticResponse {
+        headers = Collections.unmodifiableMap(new LinkedHashMap<>(headers));
+        mediaType = Objects.requireNonNull(mediaType);
+        body = body.clone();
+    }
+
+    @Override
+    public byte[] body() {
+        return body.clone();
+    }
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosViolation.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/ChaosViolation.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+/**
+ * Stable machine-readable request violation.
+ *
+ * @param path JSON Pointer path
+ * @param code stable violation code
+ * @param message human-readable explanation
+ */
+record ChaosViolation(String path, String code, String message) {
+}

--- a/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/package-info.java
+++ b/extensions/chaos/modules/chaos/src/main/java/io/helidon/extensions/chaos/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Bounded local chaos engineering for Helidon WebServer.
+ */
+package io.helidon.extensions.chaos;

--- a/extensions/chaos/modules/chaos/src/main/java/module-info.java
+++ b/extensions/chaos/modules/chaos/src/main/java/module-info.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import io.helidon.common.features.api.Features;
+import io.helidon.common.features.api.HelidonFlavor;
+
+/**
+ * Bounded local chaos engineering for Helidon WebServer.
+ */
+@Features.Name("Chaos")
+@Features.Description("Bounded local chaos engineering for Helidon WebServer")
+@Features.Flavor({HelidonFlavor.SE, HelidonFlavor.MP})
+@Features.Path({"WebServer", "Chaos"})
+@Features.Preview
+module io.helidon.extensions.chaos {
+    requires transitive io.helidon.builder.api;
+    requires transitive io.helidon.common.media.type;
+    requires transitive io.helidon.config;
+    requires transitive io.helidon.json;
+    requires transitive io.helidon.webserver;
+
+    requires io.helidon.security;
+    requires io.helidon.service.registry;
+    requires io.helidon.webserver.security;
+
+    requires static io.helidon.common.features.api;
+    requires static io.helidon.config.metadata;
+
+    exports io.helidon.extensions.chaos;
+
+    provides io.helidon.webserver.spi.ServerFeatureProvider
+            with io.helidon.extensions.chaos.ChaosServerFeatureProvider;
+}

--- a/extensions/chaos/modules/chaos/src/main/java/module-info.java
+++ b/extensions/chaos/modules/chaos/src/main/java/module-info.java
@@ -27,11 +27,14 @@ import io.helidon.common.features.api.HelidonFlavor;
 @Features.Preview
 module io.helidon.extensions.chaos {
     requires transitive io.helidon.builder.api;
-    requires transitive io.helidon.common.media.type;
+    requires transitive io.helidon.common;
     requires transitive io.helidon.config;
-    requires transitive io.helidon.json;
     requires transitive io.helidon.webserver;
 
+    requires io.helidon.common.media.type;
+    requires io.helidon.http;
+    requires io.helidon.http.media.json;
+    requires io.helidon.json;
     requires io.helidon.security;
     requires io.helidon.service.registry;
     requires io.helidon.webserver.security;

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosApplicationFilterTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosApplicationFilterTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.http.HeaderName;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Status;
+import io.helidon.webclient.api.ClientResponseTyped;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.http.ServerResponse;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.extensions.chaos.ChaosHttpScope.PathMatch.EXACT;
+import static io.helidon.extensions.chaos.ChaosHttpScope.PathMatch.PREFIX;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@ServerTest
+class ChaosApplicationFilterTest {
+    private static final AtomicInteger APPLICATION_INVOCATIONS = new AtomicInteger();
+    private static final HeaderName APPLICATION_HEADER = HeaderNames.create("X-Application");
+    private static ChaosRunEngine engine;
+
+    private final WebClient client;
+
+    ChaosApplicationFilterTest(WebClient client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    static void setUpRoute(HttpRouting.Builder routing) {
+        engine = ChaosRunEngine.create(ChaosLimitsConfig.builder().build());
+        routing.addFilter(new ChaosApplicationFilter(engine))
+                .get("/orders/42", ChaosApplicationFilterTest::application)
+                .get("/orders-old", ChaosApplicationFilterTest::application)
+                .post("/orders/42", ChaosApplicationFilterTest::application);
+    }
+
+    @BeforeEach
+    void resetRuns() {
+        engine.list().stream()
+                .filter(run -> run.state() == ChaosRunState.RUNNING)
+                .forEach(run -> engine.stop(run.id()));
+        APPLICATION_INVOCATIONS.set(0);
+    }
+
+    @Test
+    void prefixMatchSendsSyntheticResponseWithoutInvokingApplication() {
+        engine.create(plan(PREFIX, "/orders", Set.of("GET"), 20, 2), "alice");
+
+        ClientResponseTyped<byte[]> disrupted = client.get("/orders/42").request(byte[].class);
+        assertThat(disrupted.status(), is(Status.SERVICE_UNAVAILABLE_503));
+        assertThat(disrupted.entity(), is("failure".getBytes(StandardCharsets.UTF_8)));
+        assertThat(disrupted.headers().first(HeaderNames.RETRY_AFTER).orElseThrow(), is("1"));
+        assertThat(disrupted.headers().contentType().orElseThrow().mediaType(), is(MediaTypes.TEXT_PLAIN));
+        assertThat(disrupted.headers().contentLength().orElseThrow(), is(7L));
+        disrupted.close();
+        assertThat(APPLICATION_INVOCATIONS.get(), is(0));
+
+        ClientResponseTyped<String> adjacent = client.get("/orders-old").request(String.class);
+        assertThat(adjacent.status(), is(Status.OK_200));
+        assertThat(adjacent.entity(), is("application"));
+        adjacent.close();
+        assertThat(APPLICATION_INVOCATIONS.get(), is(1));
+    }
+
+    @Test
+    void exactMatchDoesNotSelectChildPath() {
+        engine.create(plan(EXACT, "/orders", Set.of("GET"), 20, 2), "alice");
+
+        ClientResponseTyped<String> response = client.get("/orders/42").request(String.class);
+        assertThat(response.status(), is(Status.OK_200));
+        response.close();
+        assertThat(APPLICATION_INVOCATIONS.get(), is(1));
+    }
+
+    @Test
+    void nonMatchingMethodReachesApplication() {
+        engine.create(plan(PREFIX, "/orders", Set.of("GET"), 20, 2), "alice");
+
+        ClientResponseTyped<String> response = client.post("/orders/42").request(String.class);
+        assertThat(response.status(), is(Status.OK_200));
+        response.close();
+        assertThat(APPLICATION_INVOCATIONS.get(), is(1));
+    }
+
+    @Test
+    void exhaustedActivationBudgetFallsThrough() {
+        ChaosRunView created = engine.create(plan(PREFIX, "/orders", Set.of("GET"), 1, 1), "alice");
+
+        ClientResponseTyped<String> first = client.get("/orders/42").request(String.class);
+        assertThat(first.status(), is(Status.SERVICE_UNAVAILABLE_503));
+        first.close();
+        ClientResponseTyped<String> second = client.get("/orders/42").request(String.class);
+        assertThat(second.status(), is(Status.OK_200));
+        second.close();
+
+        ChaosRunView view = engine.get(created.id()).orElseThrow();
+        assertThat(view.matched(), is(2L));
+        assertThat(view.activated(), is(1L));
+        assertThat(view.skippedBudget(), is(1L));
+        assertThat(view.completed(), is(1L));
+        assertThat(APPLICATION_INVOCATIONS.get(), is(1));
+    }
+
+    private static void application(ServerRequest request, ServerResponse response) {
+        APPLICATION_INVOCATIONS.incrementAndGet();
+        response.header(APPLICATION_HEADER, "reached");
+        response.send("application");
+    }
+
+    private static ChaosRunPlan plan(ChaosHttpScope.PathMatch pathMatch,
+                                     String path,
+                                     Set<String> methods,
+                                     long maximumActivations,
+                                     int maximumConcurrent) {
+        ChaosSyntheticResponse effect = new ChaosSyntheticResponse(503,
+                                                                    Map.of("Retry-After", "1"),
+                                                                    Optional.of(MediaTypes.TEXT_PLAIN),
+                                                                    "failure".getBytes(StandardCharsets.UTF_8));
+        return plan(pathMatch, path, methods, maximumActivations, maximumConcurrent, effect, "synthetic");
+    }
+
+    private static ChaosRunPlan plan(ChaosHttpScope.PathMatch pathMatch,
+                                     String path,
+                                     Set<String> methods,
+                                     long maximumActivations,
+                                     int maximumConcurrent,
+                                     ChaosEffect effect,
+                                     String disruptionName) {
+        ChaosHttpScope scope = new ChaosHttpScope(methods, pathMatch, path);
+        ChaosBudget budget = new ChaosBudget(maximumActivations, maximumConcurrent);
+        ChaosRunPlan.ChaosDisruption disruption =
+                new ChaosRunPlan.ChaosDisruption(disruptionName, scope, ChaosActivation.always(), effect, budget);
+        ChaosRunPlan.ChaosStage stage =
+                new ChaosRunPlan.ChaosStage("stage", Duration.ofSeconds(30), disruption);
+        return new ChaosRunPlan("run", Duration.ofMinutes(1), 42, stage);
+    }
+}

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosConfigTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosConfigTest.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ChaosConfigTest {
+
+    @Test
+    void defaultsAreDisabledAndBounded() {
+        ChaosConfig config = ChaosConfig.builder().buildPrototype();
+
+        assertThat(config.enabled(), is(false));
+        assertThat(config.security().requiredRole(), is("chaos-operator"));
+        assertThat(config.security().allowUnauthenticatedLoopback(), is(false));
+        assertThat(config.limits().maximumActiveRuns(), is(1));
+        assertThat(config.limits().maximumRunDuration(), is(Duration.ofMinutes(15)));
+        assertThat(config.limits().maximumActivationsPerDisruption(), is(10_000L));
+        assertThat(config.limits().maximumConcurrentActivationsPerDisruption(), is(64));
+        assertThat(config.limits().maximumSyntheticBodyBytes(), is(65_536));
+        assertThat(config.limits().maximumControlRequestBytes(), is(65_536L));
+        assertThat(config.limits().maximumConcurrentControlRequests(), is(16));
+        assertThat(config.limits().maximumRetainedRuns(), is(32));
+        assertThat(config.limits().terminalRunRetention(), is(Duration.ofMinutes(15)));
+    }
+
+    @Test
+    void disabledConfigurationDoesNotRequireSockets() {
+        assertDoesNotThrow(() -> ChaosConfig.builder().enabled(false).buildPrototype());
+    }
+
+    @Test
+    void enabledConfigurationRequiresControlSocket() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> ChaosConfig.builder()
+                             .enabled(true)
+                             .addApplicationSocket("@default")
+                             .buildPrototype());
+    }
+
+    @Test
+    void enabledConfigurationRequiresApplicationSocket() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> ChaosConfig.builder()
+                             .enabled(true)
+                             .controlSocket("chaos-control")
+                             .buildPrototype());
+    }
+
+    @Test
+    void rejectsOverlappingControlAndApplicationSockets() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> ChaosConfig.builder()
+                             .enabled(true)
+                             .controlSocket("chaos-control")
+                             .addApplicationSocket("chaos-control")
+                             .buildPrototype());
+    }
+
+    @Test
+    void acceptsDistinctSockets() {
+        ChaosConfig config = ChaosConfig.builder()
+                .enabled(true)
+                .controlSocket("chaos-control")
+                .addApplicationSocket("@default")
+                .buildPrototype();
+
+        assertThat(config.controlSocket().orElseThrow(), is("chaos-control"));
+        assertThat(config.applicationSockets(), contains("@default"));
+    }
+
+    @Test
+    void configBuildsItsRuntimeType() {
+        ChaosServerFeature feature = ChaosConfig.builder().build();
+
+        assertThat(feature.prototype().enabled(), is(false));
+    }
+
+    @Test
+    void rejectsBlankSecurityRole() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> ChaosSecurityConfig.builder().requiredRole(" ").build());
+    }
+
+    @Test
+    void rejectsNonPositiveLimits() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> ChaosLimitsConfig.builder().maximumActiveRuns(0).build());
+        assertThrows(IllegalArgumentException.class,
+                     () -> ChaosLimitsConfig.builder().maximumRunDuration(Duration.ZERO).build());
+        assertThrows(IllegalArgumentException.class,
+                     () -> ChaosLimitsConfig.builder().maximumActivationsPerDisruption(0).build());
+        assertThrows(IllegalArgumentException.class,
+                     () -> ChaosLimitsConfig.builder().maximumConcurrentActivationsPerDisruption(0).build());
+        assertThrows(IllegalArgumentException.class,
+                     () -> ChaosLimitsConfig.builder().maximumSyntheticBodyBytes(0).build());
+        assertThrows(IllegalArgumentException.class,
+                     () -> ChaosLimitsConfig.builder().maximumControlRequestBytes(0).build());
+        assertThrows(IllegalArgumentException.class,
+                     () -> ChaosLimitsConfig.builder().maximumConcurrentControlRequests(0).build());
+        assertThrows(IllegalArgumentException.class,
+                     () -> ChaosLimitsConfig.builder().maximumRetainedRuns(0).build());
+        assertThrows(IllegalArgumentException.class,
+                     () -> ChaosLimitsConfig.builder().terminalRunRetention(Duration.ZERO).build());
+    }
+
+    @Test
+    void retainedRunLimitCannotBeLowerThanActiveRunLimit() {
+        assertThrows(IllegalArgumentException.class,
+                     () -> ChaosLimitsConfig.builder()
+                             .maximumActiveRuns(2)
+                             .maximumRetainedRuns(1)
+                             .build());
+    }
+}

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosConfigTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosConfigTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ChaosConfigTest {
@@ -47,7 +46,7 @@ class ChaosConfigTest {
 
     @Test
     void disabledConfigurationDoesNotRequireSockets() {
-        assertDoesNotThrow(() -> ChaosConfig.builder().enabled(false).buildPrototype());
+        assertThat(ChaosConfig.builder().enabled(false).buildPrototype().enabled(), is(false));
     }
 
     @Test

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosConfigTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosConfigTest.java
@@ -32,7 +32,7 @@ class ChaosConfigTest {
 
         assertThat(config.enabled(), is(false));
         assertThat(config.security().requiredRole(), is("chaos-operator"));
-        assertThat(config.security().allowUnauthenticatedLoopback(), is(false));
+        assertThat(config.security().allowUnauthenticatedLocal(), is(false));
         assertThat(config.limits().maximumActiveRuns(), is(1));
         assertThat(config.limits().maximumRunDuration(), is(Duration.ofMinutes(15)));
         assertThat(config.limits().maximumActivationsPerDisruption(), is(10_000L));

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosControlServiceTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosControlServiceTest.java
@@ -168,12 +168,6 @@ class ChaosControlServiceTest {
         }
     }
 
-    private ClientResponseTyped<JsonObject> post(JsonObject plan) {
-        return client.post(RUNS)
-                .contentType(MediaTypes.APPLICATION_JSON)
-                .submit(plan, JsonObject.class);
-    }
-
     private static void assertProblem(ClientResponseTyped<String> response,
                                       Status status,
                                       String type) {
@@ -217,4 +211,11 @@ class ChaosControlServiceTest {
                 """.formatted(name);
         return JsonParser.create(json).readJsonObject();
     }
+
+    private ClientResponseTyped<JsonObject> post(JsonObject plan) {
+        return client.post(RUNS)
+                .contentType(MediaTypes.APPLICATION_JSON)
+                .submit(plan, JsonObject.class);
+    }
+
 }

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosControlServiceTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosControlServiceTest.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.util.UUID;
+import java.util.concurrent.Semaphore;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Status;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonParser;
+import io.helidon.webclient.api.ClientResponseTyped;
+import io.helidon.webclient.api.WebClient;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.extensions.chaos.ChaosRunState.RUNNING;
+import static io.helidon.extensions.chaos.ChaosRunState.STOPPED;
+import static io.helidon.extensions.chaos.ChaosRunState.STOPPING;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@ServerTest
+class ChaosControlServiceTest {
+    private static final String RUNS = "/chaos/v1/runs";
+    private static ChaosRunEngine engine;
+    private static Semaphore capacity;
+
+    private final WebClient client;
+
+    ChaosControlServiceTest(WebClient client) {
+        this.client = client;
+    }
+
+    @SetUpRoute
+    static void setUpRoute(HttpRouting.Builder routing) {
+        ChaosLimitsConfig limits = ChaosLimitsConfig.builder()
+                .maximumRetainedRuns(32)
+                .build();
+        ChaosConfig config = ChaosConfig.builder().limits(limits).buildPrototype();
+        engine = ChaosRunEngine.create(limits);
+        capacity = new Semaphore(limits.maximumConcurrentControlRequests(), true);
+        routing.register("/chaos/v1", new ChaosControlService(engine, config, true, capacity));
+    }
+
+    @BeforeEach
+    void stopActiveRuns() {
+        engine.list().stream()
+                .filter(run -> run.state() == RUNNING)
+                .forEach(run -> engine.stop(run.id()));
+    }
+
+    @Test
+    void createsReadsAndListsRuns() {
+        ClientResponseTyped<JsonObject> created = post(validPlan("orders"));
+        assertThat(created.status(), is(Status.CREATED_201));
+        JsonObject createdBody = created.entity();
+        String id = createdBody.stringValue("id").orElseThrow();
+        assertThat(createdBody.stringValue("state").orElseThrow(), is("RUNNING"));
+        assertThat(createdBody.stringValue("actor").orElseThrow(), is("anonymous-local"));
+        assertThat(created.headers().first(HeaderNames.LOCATION).orElseThrow(), is(RUNS + "/" + id));
+        assertJsonContentType(created);
+        created.close();
+
+        ClientResponseTyped<JsonObject> fetched = client.get(RUNS + "/" + id).request(JsonObject.class);
+        assertThat(fetched.status(), is(Status.OK_200));
+        assertThat(fetched.entity().stringValue("id").orElseThrow(), is(id));
+        fetched.close();
+
+        ClientResponseTyped<JsonArray> listed = client.get(RUNS).request(JsonArray.class);
+        assertThat(listed.status(), is(Status.OK_200));
+        assertThat(listed.entity().get(0).orElseThrow().asObject().stringValue("id").orElseThrow(), is(id));
+        listed.close();
+    }
+
+    @Test
+    void rejectsMalformedAndUnknownRunIds() {
+        ClientResponseTyped<String> malformed = client.get(RUNS + "/not-a-uuid").request(String.class);
+        assertProblem(malformed, Status.BAD_REQUEST_400, "invalid-request");
+        ClientResponseTyped<String> abbreviated = client.get(RUNS + "/1-1-1-1-1").request(String.class);
+        assertProblem(abbreviated, Status.BAD_REQUEST_400, "invalid-request");
+
+        ClientResponseTyped<String> unknown =
+                client.get(RUNS + "/" + UUID.randomUUID()).request(String.class);
+        assertProblem(unknown, Status.NOT_FOUND_404, "run-not-found");
+    }
+
+    @Test
+    void deleteReportsImmediateAndDrainingStops() {
+        ClientResponseTyped<JsonObject> firstCreated = post(validPlan("first"));
+        JsonObject first = firstCreated.entity();
+        firstCreated.close();
+        String firstId = first.stringValue("id").orElseThrow();
+        ClientResponseTyped<JsonObject> stopped = client.delete(RUNS + "/" + firstId).request(JsonObject.class);
+        assertThat(stopped.status(), is(Status.OK_200));
+        assertThat(stopped.entity().stringValue("state").orElseThrow(), is(STOPPED.name()));
+        stopped.close();
+
+        ClientResponseTyped<JsonObject> secondCreated = post(validPlan("second"));
+        JsonObject second = secondCreated.entity();
+        secondCreated.close();
+        UUID secondId = UUID.fromString(second.stringValue("id").orElseThrow());
+        ChaosRunEngine.Reservation reservation = engine.reserve("GET", "/orders/42").orElseThrow();
+        try {
+            ClientResponseTyped<JsonObject> stopping =
+                    client.delete(RUNS + "/" + secondId).request(JsonObject.class);
+            assertThat(stopping.status(), is(Status.ACCEPTED_202));
+            assertThat(stopping.entity().stringValue("state").orElseThrow(), is(STOPPING.name()));
+            stopping.close();
+        } finally {
+            reservation.close();
+        }
+        assertThat(engine.get(secondId).orElseThrow().state(), is(STOPPED));
+    }
+
+    @Test
+    void rejectsUnsupportedMediaTypeAndInvalidPlan() {
+        ClientResponseTyped<String> unsupported = client.post(RUNS)
+                .contentType(MediaTypes.TEXT_PLAIN)
+                .submit("not-json", String.class);
+        assertProblem(unsupported, Status.UNSUPPORTED_MEDIA_TYPE_415, "unsupported-media-type");
+
+        ClientResponseTyped<String> malformed = client.post(RUNS)
+                .contentType(MediaTypes.APPLICATION_JSON)
+                .submit("{", String.class);
+        assertProblem(malformed, Status.BAD_REQUEST_400, "invalid-request");
+
+        JsonObject invalid = JsonObject.builder()
+                .from(validPlan("too-long"))
+                .set("maximumDuration", "PT30M")
+                .build();
+        ClientResponseTyped<String> validation = client.post(RUNS)
+                .contentType(MediaTypes.APPLICATION_JSON)
+                .submit(invalid, String.class);
+        JsonObject validationBody = JsonParser.create(validation.entity()).readJsonObject();
+        assertThat(validationBody.arrayValue("violations").orElseThrow().size(), is(1));
+        assertProblem(validation, Status.UNPROCESSABLE_CONTENT_422, "invalid-plan");
+    }
+
+    @Test
+    void rejectsRequestsWhenControlCapacityIsExhausted() throws InterruptedException {
+        int acquired = capacity.availablePermits();
+        capacity.acquire(acquired);
+        try {
+            ClientResponseTyped<String> response = client.get(RUNS).request(String.class);
+            assertProblem(response, Status.TOO_MANY_REQUESTS_429, "control-capacity");
+        } finally {
+            capacity.release(acquired);
+        }
+    }
+
+    private ClientResponseTyped<JsonObject> post(JsonObject plan) {
+        return client.post(RUNS)
+                .contentType(MediaTypes.APPLICATION_JSON)
+                .submit(plan, JsonObject.class);
+    }
+
+    private static void assertProblem(ClientResponseTyped<String> response,
+                                      Status status,
+                                      String type) {
+        assertThat(response.status(), is(status));
+        JsonObject body = JsonParser.create(response.entity()).readJsonObject();
+        assertThat(body.stringValue("type").orElseThrow(), is("/chaos/v1/problems/" + type));
+        assertThat(response.headers().contentType().orElseThrow().fullType(), is("application/problem+json"));
+        response.close();
+    }
+
+    private static void assertJsonContentType(ClientResponseTyped<?> response) {
+        assertThat(response.headers().contentType().orElseThrow().mediaType(), is(MediaTypes.APPLICATION_JSON));
+    }
+
+    private static JsonObject validPlan(String name) {
+        String json = """
+                {
+                  "name": "%s",
+                  "maximumDuration": "PT30S",
+                  "seed": 148894,
+                  "stages": [{
+                    "name": "reject-orders",
+                    "duration": "PT10S",
+                    "disruptions": [{
+                      "name": "orders-503",
+                      "scope": {
+                        "type": "inbound-http",
+                        "methods": ["GET"],
+                        "path": {"match": "prefix", "value": "/orders"}
+                      },
+                      "activation": {"type": "always"},
+                      "effect": {
+                        "type": "synthetic-http-response",
+                        "status": 503,
+                        "body": "failure"
+                      },
+                      "budget": {"maximumActivations": 20, "maximumConcurrent": 2}
+                    }]
+                  }]
+                }
+                """.formatted(name);
+        return JsonParser.create(json).readJsonObject();
+    }
+}

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosHttpScopeTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosHttpScopeTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.extensions.chaos.ChaosHttpScope.PathMatch.EXACT;
+import static io.helidon.extensions.chaos.ChaosHttpScope.PathMatch.PREFIX;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class ChaosHttpScopeTest {
+
+    @Test
+    void exactMatchRequiresSameMethodAndPath() {
+        ChaosHttpScope scope = new ChaosHttpScope(Set.of("GET"), EXACT, "/orders");
+
+        assertThat(scope.matches("GET", "/orders"), is(true));
+        assertThat(scope.matches("POST", "/orders"), is(false));
+        assertThat(scope.matches("GET", "/orders/42"), is(false));
+    }
+
+    @Test
+    void prefixMatchIsPathSegmentAware() {
+        ChaosHttpScope scope = new ChaosHttpScope(Set.of("GET"), PREFIX, "/orders");
+
+        assertThat(scope.matches("GET", "/orders"), is(true));
+        assertThat(scope.matches("GET", "/orders/42"), is(true));
+        assertThat(scope.matches("GET", "/orders-old"), is(false));
+    }
+
+    @Test
+    void rootPrefixMatchesEveryAbsolutePath() {
+        ChaosHttpScope scope = new ChaosHttpScope(Set.of("GET"), PREFIX, "/");
+
+        assertThat(scope.matches("GET", "/"), is(true));
+        assertThat(scope.matches("GET", "/orders"), is(true));
+    }
+}

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunEngineTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunEngineTest.java
@@ -1,0 +1,360 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.common.media.type.MediaTypes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.extensions.chaos.ChaosHttpScope.PathMatch.PREFIX;
+import static io.helidon.extensions.chaos.ChaosRunState.COMPLETED;
+import static io.helidon.extensions.chaos.ChaosRunState.EXPIRED;
+import static io.helidon.extensions.chaos.ChaosRunState.RUNNING;
+import static io.helidon.extensions.chaos.ChaosRunState.STOPPED;
+import static io.helidon.extensions.chaos.ChaosRunState.STOPPING;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ChaosRunEngineTest {
+
+    private TestChaosScheduler scheduler;
+    private ChaosRunEngine engine;
+    private AtomicInteger ids;
+
+    @BeforeEach
+    void setUp() {
+        scheduler = new TestChaosScheduler();
+        ids = new AtomicInteger();
+        engine = engine(limits(1, 8, Duration.ofMinutes(5)));
+    }
+
+    @Test
+    void completesAtStageDuration() {
+        ChaosRunView created = engine.create(plan(10, 30, 20, 2, "/orders"), "alice");
+
+        scheduler.advance(Duration.ofSeconds(10));
+
+        ChaosRunView completed = engine.get(created.id()).orElseThrow();
+        assertThat(completed.state(), is(COMPLETED));
+        assertThat(completed.terminalReason().orElseThrow(), is("stage-duration-completed"));
+        assertThat(engine.reserve("GET", "/orders"), is(Optional.empty()));
+    }
+
+    @Test
+    void expirationGuardWinsIfItsTaskFiresFirst() {
+        ChaosRunView created = engine.create(plan(10, 30, 20, 2, "/orders"), "alice");
+
+        scheduler.fireLast();
+
+        assertThat(engine.get(created.id()).orElseThrow().state(), is(EXPIRED));
+    }
+
+    @Test
+    void cumulativeAndConcurrentBudgetsNeverOvershoot() {
+        ChaosRunView created = engine.create(plan(10, 30, 2, 1, "/orders"), "alice");
+        ChaosRunEngine.Reservation first = engine.reserve("GET", "/orders/42").orElseThrow();
+
+        assertThat(engine.reserve("GET", "/orders/43"), is(Optional.empty()));
+        first.close();
+        try (ChaosRunEngine.Reservation second = engine.reserve("GET", "/orders/44").orElseThrow()) {
+            assertThat(((ChaosSyntheticResponse) second.effect()).status(), is(503));
+        }
+        assertThat(engine.reserve("GET", "/orders/45"), is(Optional.empty()));
+
+        ChaosRunView view = engine.get(created.id()).orElseThrow();
+        assertThat(view.matched(), is(4L));
+        assertThat(view.activated(), is(2L));
+        assertThat(view.skippedConcurrent(), is(1L));
+        assertThat(view.skippedBudget(), is(1L));
+        assertThat(view.inFlight(), is(0L));
+        assertThat(view.completed(), is(2L));
+    }
+
+    @Test
+    void probabilityUsesStableSeededSequenceWithoutConsumingBudgetOnMisses() {
+        ChaosRunPlan plan = plan(10,
+                                 30,
+                                 20,
+                                 2,
+                                 "/orders",
+                                 new ChaosActivation.Probability(0.5),
+                                 42,
+                                 "synthetic");
+        ChaosRunView created = engine.create(plan, "alice");
+
+        List<Boolean> decisions = reserveSequence(engine, 8);
+
+        assertThat(decisions, is(List.of(false, false, false, false, true, false, false, true)));
+        ChaosRunView view = engine.get(created.id()).orElseThrow();
+        assertThat(view.matched(), is(8L));
+        assertThat(view.activated(), is(2L));
+        assertThat(view.skippedActivation(), is(6L));
+        assertThat(view.skippedConcurrent(), is(0L));
+        assertThat(view.skippedBudget(), is(0L));
+        assertThat(view.completed(), is(2L));
+    }
+
+    @Test
+    void probabilityStreamIncludesSeedAndStableDisruptionIdentity() {
+        ChaosRunEngine seedEngine = engine(limits(1, 8, Duration.ofMinutes(5)));
+        seedEngine.create(plan(10, 30, 20, 2, "/orders",
+                               new ChaosActivation.Probability(0.5), 44, "synthetic"), "alice");
+        assertThat(reserveSequence(seedEngine, 8),
+                   is(List.of(false, true, false, true, true, false, false, false)));
+
+        ChaosRunEngine identityEngine = engine(limits(1, 8, Duration.ofMinutes(5)));
+        identityEngine.create(plan(10, 30, 20, 2, "/orders",
+                                   new ChaosActivation.Probability(0.5), 42, "alternate"), "alice");
+        assertThat(reserveSequence(identityEngine, 8),
+                   is(List.of(false, true, true, true, true, false, false, true)));
+    }
+
+    @Test
+    void stableIdentityEncodingSeparatesEmbeddedNullCharacters() {
+        assertThat(ChaosActivationDecider.streamSeed(42, "a", "b\0c")
+                           == ChaosActivationDecider.streamSeed(42, "a\0b", "c"),
+                   is(false));
+    }
+
+    @Test
+    void reservationCloseIsIdempotent() {
+        ChaosRunView created = engine.create(plan(10, 30, 2, 1, "/orders"), "alice");
+        ChaosRunEngine.Reservation reservation = engine.reserve("GET", "/orders").orElseThrow();
+
+        reservation.close();
+        reservation.close();
+
+        ChaosRunView view = engine.get(created.id()).orElseThrow();
+        assertThat(view.inFlight(), is(0L));
+        assertThat(view.completed(), is(1L));
+    }
+
+    @Test
+    void deleteWaitsForInFlightReservation() {
+        ChaosRunView created = engine.create(plan(10, 30, 2, 1, "/orders"), "alice");
+        ChaosRunEngine.Reservation reservation = engine.reserve("GET", "/orders").orElseThrow();
+
+        assertThat(engine.stop(created.id()).state(), is(STOPPING));
+        assertThat(engine.reserve("GET", "/orders"), is(Optional.empty()));
+        reservation.close();
+
+        assertThat(engine.get(created.id()).orElseThrow().state(), is(STOPPED));
+        assertThat(engine.stop(created.id()).state(), is(STOPPED));
+    }
+
+    @Test
+    void rejectsActiveLimitAndOverlappingScopes() {
+        engine.create(plan(10, 30, 2, 1, "/orders"), "alice");
+        assertThrows(ChaosRunEngine.ConflictException.class,
+                     () -> engine.create(plan(10, 30, 2, 1, "/payments"), "bob"));
+
+        ChaosRunEngine twoRunEngine = engine(limits(2, 8, Duration.ofMinutes(5)));
+        twoRunEngine.create(plan(10, 30, 2, 1, "/orders"), "alice");
+        assertThrows(ChaosRunEngine.ConflictException.class,
+                     () -> twoRunEngine.create(plan(10, 30, 2, 1, "/orders/42"), "bob"));
+        assertThat(twoRunEngine.create(plan(10, 30, 2, 1, "/payments"), "bob").state(), is(RUNNING));
+    }
+
+    @Test
+    void listsNewestRunFirstAndRejectsUnknownStop() {
+        ChaosRunEngine twoRunEngine = engine(limits(2, 8, Duration.ofMinutes(5)));
+        ChaosRunView first = twoRunEngine.create(plan(10, 30, 2, 1, "/orders"), "alice");
+        ChaosRunView second = twoRunEngine.create(plan(10, 30, 2, 1, "/payments"), "bob");
+
+        assertThat(twoRunEngine.list(), hasSize(2));
+        assertThat(twoRunEngine.list().get(0).id(), is(second.id()));
+        assertThat(twoRunEngine.list().get(1).id(), is(first.id()));
+        assertThrows(ChaosRunEngine.NotFoundException.class, () -> twoRunEngine.stop(UUID.randomUUID()));
+    }
+
+    @Test
+    void evictsTerminalRunsByAgeAndCapacity() {
+        ChaosRunEngine retainedEngine = engine(limits(1, 2, Duration.ofSeconds(5)));
+        ChaosRunView first = retainedEngine.create(plan(10, 30, 2, 1, "/orders"), "alice");
+        retainedEngine.stop(first.id());
+        ChaosRunView second = retainedEngine.create(plan(10, 30, 2, 1, "/payments"), "bob");
+        retainedEngine.stop(second.id());
+        ChaosRunView third = retainedEngine.create(plan(10, 30, 2, 1, "/inventory"), "carol");
+
+        assertThat(retainedEngine.get(first.id()), is(Optional.empty()));
+        assertThat(retainedEngine.get(third.id()).isPresent(), is(true));
+
+        retainedEngine.stop(third.id());
+        scheduler.advance(Duration.ofSeconds(6));
+        assertThat(retainedEngine.list(), hasSize(0));
+    }
+
+    @Test
+    void concurrentReservationsRespectConcurrencyCeiling() throws InterruptedException {
+        engine.create(plan(10, 30, 100, 4, "/orders"), "alice");
+        int attempts = 20;
+        CountDownLatch start = new CountDownLatch(1);
+        CountDownLatch attempted = new CountDownLatch(attempts);
+        CountDownLatch release = new CountDownLatch(1);
+        AtomicInteger reserved = new AtomicInteger();
+        Queue<Throwable> failures = new ConcurrentLinkedQueue<>();
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (int i = 0; i < attempts; i++) {
+                executor.submit(() -> {
+                    Optional<ChaosRunEngine.Reservation> candidate = Optional.empty();
+                    try {
+                        if (!start.await(5, TimeUnit.SECONDS)) {
+                            throw new AssertionError("Timed out waiting to start reservation attempt");
+                        }
+                        candidate = engine.reserve("GET", "/orders");
+                        if (candidate.isPresent()) {
+                            reserved.incrementAndGet();
+                        }
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        failures.add(e);
+                    } catch (RuntimeException | AssertionError e) {
+                        failures.add(e);
+                    } finally {
+                        attempted.countDown();
+                    }
+                    if (candidate.isPresent()) {
+                        try {
+                            if (!release.await(5, TimeUnit.SECONDS)) {
+                                throw new AssertionError("Timed out waiting to release reservation");
+                            }
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            failures.add(e);
+                        } catch (AssertionError e) {
+                            failures.add(e);
+                        } finally {
+                            candidate.orElseThrow().close();
+                        }
+                    }
+                });
+            }
+            start.countDown();
+            try {
+                assertThat(attempted.await(5, TimeUnit.SECONDS), is(true));
+                assertThat(failures, is(empty()));
+                assertThat(reserved.get(), is(4));
+                assertThat(engine.list().getFirst().inFlight(), is(4L));
+            } finally {
+                release.countDown();
+            }
+        }
+
+        assertThat(failures, is(empty()));
+        assertThat(engine.list().getFirst().inFlight(), is(0L));
+    }
+
+    private ChaosRunEngine engine(ChaosLimitsConfig limits) {
+        return ChaosRunEngine.create(limits,
+                                     scheduler.clock(),
+                                     scheduler,
+                                     () -> new UUID(0, ids.incrementAndGet()));
+    }
+
+    private static ChaosLimitsConfig limits(int activeRuns, int retainedRuns, Duration retention) {
+        return ChaosLimitsConfig.builder()
+                .maximumActiveRuns(activeRuns)
+                .maximumRetainedRuns(retainedRuns)
+                .terminalRunRetention(retention)
+                .build();
+    }
+
+    private static ChaosRunPlan plan(int stageSeconds,
+                                     int maximumSeconds,
+                                     long maximumActivations,
+                                     int maximumConcurrent,
+                                     String path) {
+        return plan(stageSeconds,
+                    maximumSeconds,
+                    maximumActivations,
+                    maximumConcurrent,
+                    path,
+                    ChaosActivation.always(),
+                    42,
+                    "synthetic");
+    }
+
+    private static ChaosRunPlan plan(int stageSeconds,
+                                     int maximumSeconds,
+                                     long maximumActivations,
+                                     int maximumConcurrent,
+                                     String path,
+                                     ChaosActivation activation,
+                                     long seed,
+                                     String disruptionName) {
+        ChaosSyntheticResponse response = new ChaosSyntheticResponse(503,
+                                                                      Map.of("Retry-After", "1"),
+                                                                      Optional.of(MediaTypes.TEXT_PLAIN),
+                                                                      "failure".getBytes(StandardCharsets.UTF_8));
+        return plan(stageSeconds,
+                    maximumSeconds,
+                    maximumActivations,
+                    maximumConcurrent,
+                    path,
+                    activation,
+                    seed,
+                    disruptionName,
+                    response);
+    }
+
+    private static ChaosRunPlan plan(int stageSeconds,
+                                     int maximumSeconds,
+                                     long maximumActivations,
+                                     int maximumConcurrent,
+                                     String path,
+                                     ChaosActivation activation,
+                                     long seed,
+                                     String disruptionName,
+                                     ChaosEffect effect) {
+        ChaosHttpScope scope = new ChaosHttpScope(Set.of("GET"), PREFIX, path);
+        ChaosBudget budget = new ChaosBudget(maximumActivations, maximumConcurrent);
+        ChaosRunPlan.ChaosDisruption disruption =
+                new ChaosRunPlan.ChaosDisruption(disruptionName, scope, activation, effect, budget);
+        ChaosRunPlan.ChaosStage stage =
+                new ChaosRunPlan.ChaosStage("stage", Duration.ofSeconds(stageSeconds), disruption);
+        return new ChaosRunPlan("run", Duration.ofSeconds(maximumSeconds), seed, stage);
+    }
+
+    private static List<Boolean> reserveSequence(ChaosRunEngine runEngine, int count) {
+        List<Boolean> decisions = new ArrayList<>(count);
+        for (int i = 0; i < count; i++) {
+            Optional<ChaosRunEngine.Reservation> reservation = runEngine.reserve("GET", "/orders/42");
+            decisions.add(reservation.isPresent());
+            reservation.ifPresent(ChaosRunEngine.Reservation::close);
+        }
+        return decisions;
+    }
+
+}

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunEngineTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunEngineTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.helidon.common.media.type.MediaTypes;
+import io.helidon.extensions.chaos.ChaosActivation.ProbabilityActivation;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunEngineTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunEngineTest.java
@@ -237,11 +237,11 @@ class ChaosRunEngineTest {
                         if (candidate.isPresent()) {
                             reserved.incrementAndGet();
                         }
-                    } catch (InterruptedException e) {
+                    } catch (InterruptedException exception) {
                         Thread.currentThread().interrupt();
-                        failures.add(e);
-                    } catch (RuntimeException | AssertionError e) {
-                        failures.add(e);
+                        failures.add(exception);
+                    } catch (RuntimeException | AssertionError exception) {
+                        failures.add(exception);
                     } finally {
                         attempted.countDown();
                     }
@@ -250,11 +250,11 @@ class ChaosRunEngineTest {
                             if (!release.await(5, TimeUnit.SECONDS)) {
                                 throw new AssertionError("Timed out waiting to release reservation");
                             }
-                        } catch (InterruptedException e) {
+                        } catch (InterruptedException exception) {
                             Thread.currentThread().interrupt();
-                            failures.add(e);
-                        } catch (AssertionError e) {
-                            failures.add(e);
+                            failures.add(exception);
+                        } catch (AssertionError exception) {
+                            failures.add(exception);
                         } finally {
                             candidate.orElseThrow().close();
                         }

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunEngineTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunEngineTest.java
@@ -108,7 +108,7 @@ class ChaosRunEngineTest {
                                  20,
                                  2,
                                  "/orders",
-                                 new ChaosActivation.Probability(0.5),
+                                 new ProbabilityActivation(0.5),
                                  42,
                                  "synthetic");
         ChaosRunView created = engine.create(plan, "alice");
@@ -129,13 +129,13 @@ class ChaosRunEngineTest {
     void probabilityStreamIncludesSeedAndStableDisruptionIdentity() {
         ChaosRunEngine seedEngine = engine(limits(1, 8, Duration.ofMinutes(5)));
         seedEngine.create(plan(10, 30, 20, 2, "/orders",
-                               new ChaosActivation.Probability(0.5), 44, "synthetic"), "alice");
+                               new ProbabilityActivation(0.5), 44, "synthetic"), "alice");
         assertThat(reserveSequence(seedEngine, 8),
                    is(List.of(false, true, false, true, true, false, false, false)));
 
         ChaosRunEngine identityEngine = engine(limits(1, 8, Duration.ofMinutes(5)));
         identityEngine.create(plan(10, 30, 20, 2, "/orders",
-                                   new ChaosActivation.Probability(0.5), 42, "alternate"), "alice");
+                                   new ProbabilityActivation(0.5), 42, "alternate"), "alice");
         assertThat(reserveSequence(identityEngine, 8),
                    is(List.of(false, true, true, true, true, false, false, true)));
     }

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunEngineTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunEngineTest.java
@@ -276,13 +276,6 @@ class ChaosRunEngineTest {
         assertThat(engine.list().getFirst().inFlight(), is(0L));
     }
 
-    private ChaosRunEngine engine(ChaosLimitsConfig limits) {
-        return ChaosRunEngine.create(limits,
-                                     scheduler.clock(),
-                                     scheduler,
-                                     () -> new UUID(0, ids.incrementAndGet()));
-    }
-
     private static ChaosLimitsConfig limits(int activeRuns, int retainedRuns, Duration retention) {
         return ChaosLimitsConfig.builder()
                 .maximumActiveRuns(activeRuns)
@@ -355,6 +348,13 @@ class ChaosRunEngineTest {
             reservation.ifPresent(ChaosRunEngine.Reservation::close);
         }
         return decisions;
+    }
+
+    private ChaosRunEngine engine(ChaosLimitsConfig limits) {
+        return ChaosRunEngine.create(limits,
+                                     scheduler.clock(),
+                                     scheduler,
+                                     () -> new UUID(0, ids.incrementAndGet()));
     }
 
 }

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunJsonTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunJsonTest.java
@@ -100,7 +100,7 @@ class ChaosRunJsonTest {
                                                          Optional.of(CREATED.plusSeconds(4)),
                                                          Optional.of("operator-stopped"))));
         assertThat(list.size(), is(1));
-        assertThat(list.get(0).orElseThrow().asObject(), is(terminal));
+        assertThat(list.get(0).orElseThrow().asObject().toString(), is(terminal.toString()));
     }
 
     @Test
@@ -112,7 +112,7 @@ class ChaosRunJsonTest {
         ChaosProblemJson.Problem problem = ChaosProblemJson.from(error, "/chaos/v1/runs");
 
         assertThat(problem.status(), is(422));
-        assertThat(problem.body(), is(json("""
+        assertThat(problem.body().toString(), is(json("""
                 {
                   "type": "/chaos/v1/problems/invalid-plan",
                   "title": "Invalid chaos run plan",
@@ -127,7 +127,7 @@ class ChaosRunJsonTest {
                     }
                   ]
                 }
-                """)));
+                """).toString()));
     }
 
     @Test

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunJsonTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunJsonTest.java
@@ -26,6 +26,7 @@ import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.helidon.common.media.type.MediaTypes;
+import io.helidon.extensions.chaos.ChaosActivation.ProbabilityActivation;
 import io.helidon.json.JsonArray;
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonParser;

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunJsonTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunJsonTest.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import static io.helidon.extensions.chaos.ChaosHttpScope.PathMatch.PREFIX;
+import static io.helidon.extensions.chaos.ChaosRunState.RUNNING;
+import static io.helidon.extensions.chaos.ChaosRunState.STOPPED;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ChaosRunJsonTest {
+    private static final UUID ID = UUID.fromString("00000000-0000-0000-0000-000000000042");
+    private static final Instant CREATED = Instant.parse("2026-08-24T12:00:00Z");
+
+    @Test
+    void writesNormalizedRunningRepresentation() {
+        JsonObject json = ChaosRunJson.toJson(view(RUNNING, Optional.empty(), Optional.empty()));
+
+        assertThat(json.stringValue("id").orElseThrow(), is(ID.toString()));
+        assertThat(json.stringValue("name").orElseThrow(), is("orders-unavailable"));
+        assertThat(json.stringValue("state").orElseThrow(), is("RUNNING"));
+        assertThat(json.longValue("seed").orElseThrow(), is(148_894L));
+        assertThat(json.stringValue("actor").orElseThrow(), is("alice"));
+        assertThat(json.stringValue("createdAt").orElseThrow(), is("2026-08-24T12:00:00Z"));
+        assertThat(json.stringValue("startedAt").orElseThrow(), is("2026-08-24T12:00:00Z"));
+        assertThat(json.stringValue("expiresAt").orElseThrow(), is("2026-08-24T12:00:30Z"));
+        assertThat(json.containsKey("terminalAt"), is(false));
+        assertThat(json.containsKey("terminalReason"), is(false));
+
+        JsonObject counters = json.objectValue("counters").orElseThrow();
+        assertThat(counters.longValue("matched").orElseThrow(), is(7L));
+        assertThat(counters.longValue("activated").orElseThrow(), is(5L));
+        assertThat(counters.longValue("skippedActivation").orElseThrow(), is(2L));
+        assertThat(counters.longValue("skippedConcurrent").orElseThrow(), is(1L));
+        assertThat(counters.longValue("skippedBudget").orElseThrow(), is(1L));
+        assertThat(counters.longValue("inFlight").orElseThrow(), is(2L));
+        assertThat(counters.longValue("completed").orElseThrow(), is(3L));
+        assertThat(json.objectValue("links").orElseThrow().stringValue("self").orElseThrow(),
+                   is("/chaos/v1/runs/" + ID));
+
+        assertNormalizedPlan(json.objectValue("plan").orElseThrow());
+    }
+
+    @Test
+    void writesNormalizedProbabilityActivation() {
+        ChaosRunPlan probabilityPlan = plan(new ChaosActivation.Probability(0.25));
+
+        JsonObject json = ChaosRunJson.toJson(view(RUNNING,
+                                                   Optional.empty(),
+                                                   Optional.empty(),
+                                                   probabilityPlan));
+
+        JsonObject activation = json.objectValue("plan").orElseThrow()
+                .arrayValue("stages").orElseThrow().get(0).orElseThrow().asObject()
+                .arrayValue("disruptions").orElseThrow().get(0).orElseThrow().asObject()
+                .objectValue("activation").orElseThrow();
+        assertThat(activation.stringValue("type").orElseThrow(), is("probability"));
+        assertThat(activation.doubleValue("probability").orElseThrow(), is(0.25));
+    }
+
+    @Test
+    void writesTerminalFieldsAndRunList() {
+        JsonObject terminal = ChaosRunJson.toJson(view(STOPPED,
+                                                       Optional.of(CREATED.plusSeconds(4)),
+                                                       Optional.of("operator-stopped")));
+
+        assertThat(terminal.stringValue("terminalAt").orElseThrow(), is("2026-08-24T12:00:04Z"));
+        assertThat(terminal.stringValue("terminalReason").orElseThrow(), is("operator-stopped"));
+        JsonArray list = ChaosRunJson.toJson(List.of(view(STOPPED,
+                                                         Optional.of(CREATED.plusSeconds(4)),
+                                                         Optional.of("operator-stopped"))));
+        assertThat(list.size(), is(1));
+        assertThat(list.get(0).orElseThrow().asObject(), is(terminal));
+    }
+
+    @Test
+    void writesExactValidationProblem() {
+        ChaosRequestException error = ChaosRequestException.invalidPlan("/stages/0/duration",
+                                                                         "duration-limit",
+                                                                         "Stage duration exceeds maximumDuration.");
+
+        ChaosProblemJson.Problem problem = ChaosProblemJson.from(error, "/chaos/v1/runs");
+
+        assertThat(problem.status(), is(422));
+        assertThat(problem.body(), is(json("""
+                {
+                  "type": "/chaos/v1/problems/invalid-plan",
+                  "title": "Invalid chaos run plan",
+                  "status": 422,
+                  "detail": "The run plan violates one or more constraints.",
+                  "instance": "/chaos/v1/runs",
+                  "violations": [
+                    {
+                      "path": "/stages/0/duration",
+                      "code": "duration-limit",
+                      "message": "Stage duration exceeds maximumDuration."
+                    }
+                  ]
+                }
+                """)));
+    }
+
+    @Test
+    void mapsEngineAndBoundaryProblemsWithoutLeakingUnexpectedDetails() {
+        TestChaosScheduler scheduler = new TestChaosScheduler();
+        AtomicInteger ids = new AtomicInteger();
+        ChaosRunEngine engine = ChaosRunEngine.create(ChaosLimitsConfig.builder().build(),
+                                                      scheduler.clock(),
+                                                      scheduler,
+                                                      () -> new UUID(0, ids.incrementAndGet()));
+        engine.create(plan(), "alice");
+        ChaosRunEngine.ConflictException conflict =
+                assertThrows(ChaosRunEngine.ConflictException.class, () -> engine.create(plan(), "bob"));
+        ChaosRunEngine.NotFoundException notFound =
+                assertThrows(ChaosRunEngine.NotFoundException.class, () -> engine.stop(UUID.randomUUID()));
+
+        assertProblem(ChaosProblemJson.from(conflict, "/chaos/v1/runs"),
+                      409,
+                      "run-conflict");
+        assertProblem(ChaosProblemJson.from(notFound, "/chaos/v1/runs/" + ID),
+                      404,
+                      "run-not-found");
+        assertProblem(ChaosProblemJson.unsupportedMediaType("/chaos/v1/runs"),
+                      415,
+                      "unsupported-media-type");
+        assertProblem(ChaosProblemJson.controlCapacity("/chaos/v1/runs"),
+                      429,
+                      "control-capacity");
+
+        ChaosProblemJson.Problem unexpected =
+                ChaosProblemJson.from(new IllegalStateException("/secret/path classpath token"), "/chaos/v1/runs");
+        assertProblem(unexpected, 500, "internal-error");
+        assertThat(unexpected.body().toString().contains("secret"), is(false));
+        assertThat(unexpected.body().toString().contains("classpath"), is(false));
+        assertThat(unexpected.body().toString().contains("IllegalStateException"), is(false));
+    }
+
+    private static void assertNormalizedPlan(JsonObject plan) {
+        assertThat(plan.stringValue("name").orElseThrow(), is("orders-unavailable"));
+        assertThat(plan.stringValue("maximumDuration").orElseThrow(), is("PT30S"));
+        assertThat(plan.longValue("seed").orElseThrow(), is(148_894L));
+        JsonObject stage = plan.arrayValue("stages").orElseThrow().get(0).orElseThrow().asObject();
+        assertThat(stage.stringValue("name").orElseThrow(), is("reject-orders"));
+        assertThat(stage.stringValue("duration").orElseThrow(), is("PT10S"));
+        JsonObject disruption = stage.arrayValue("disruptions").orElseThrow().get(0).orElseThrow().asObject();
+        assertThat(disruption.stringValue("name").orElseThrow(), is("orders-503"));
+        JsonObject scope = disruption.objectValue("scope").orElseThrow();
+        assertThat(scope.stringValue("type").orElseThrow(), is("inbound-http"));
+        assertThat(scope.arrayValue("methods").orElseThrow().get(0).orElseThrow().asString().value(), is("GET"));
+        assertThat(scope.objectValue("path").orElseThrow().stringValue("match").orElseThrow(), is("prefix"));
+        assertThat(disruption.objectValue("activation").orElseThrow().stringValue("type").orElseThrow(), is("always"));
+        JsonObject effect = disruption.objectValue("effect").orElseThrow();
+        assertThat(effect.stringValue("type").orElseThrow(), is("synthetic-http-response"));
+        assertThat(effect.intValue("status").orElseThrow(), is(503));
+        assertThat(effect.objectValue("headers").orElseThrow().stringValue("Retry-After").orElseThrow(), is("1"));
+        assertThat(effect.stringValue("mediaType").orElseThrow(), is("text/plain"));
+        assertThat(effect.stringValue("body").orElseThrow(), is("failure"));
+        JsonObject budget = disruption.objectValue("budget").orElseThrow();
+        assertThat(budget.longValue("maximumActivations").orElseThrow(), is(20L));
+        assertThat(budget.intValue("maximumConcurrent").orElseThrow(), is(2));
+    }
+
+    private static void assertProblem(ChaosProblemJson.Problem problem,
+                                      int status,
+                                      String type) {
+        assertThat(problem.status(), is(status));
+        assertThat(problem.body().intValue("status").orElseThrow(), is(status));
+        assertThat(problem.body().stringValue("type").orElseThrow(), is("/chaos/v1/problems/" + type));
+    }
+
+    private static ChaosRunView view(ChaosRunState state,
+                                     Optional<Instant> terminalAt,
+                                     Optional<String> terminalReason) {
+        return view(state, terminalAt, terminalReason, plan());
+    }
+
+    private static ChaosRunView view(ChaosRunState state,
+                                     Optional<Instant> terminalAt,
+                                     Optional<String> terminalReason,
+                                     ChaosRunPlan plan) {
+        return new ChaosRunView(ID,
+                                plan.name(),
+                                state,
+                                plan,
+                                plan.seed(),
+                                "alice",
+                                CREATED,
+                                CREATED,
+                                CREATED.plusSeconds(30),
+                                terminalAt,
+                                terminalReason,
+                                7,
+                                5,
+                                2,
+                                1,
+                                1,
+                                2,
+                                3);
+    }
+
+    private static ChaosRunPlan plan() {
+        return plan(ChaosActivation.always());
+    }
+
+    private static ChaosRunPlan plan(ChaosActivation activation) {
+        ChaosHttpScope scope = new ChaosHttpScope(Set.of("GET"), PREFIX, "/orders");
+        ChaosSyntheticResponse response = new ChaosSyntheticResponse(503,
+                                                                      Map.of("Retry-After", "1"),
+                                                                      Optional.of(MediaTypes.TEXT_PLAIN),
+                                                                      "failure".getBytes(StandardCharsets.UTF_8));
+        ChaosBudget budget = new ChaosBudget(20, 2);
+        ChaosRunPlan.ChaosDisruption disruption =
+                new ChaosRunPlan.ChaosDisruption("orders-503", scope, activation, response, budget);
+        ChaosRunPlan.ChaosStage stage =
+                new ChaosRunPlan.ChaosStage("reject-orders", Duration.ofSeconds(10), disruption);
+        return new ChaosRunPlan("orders-unavailable", Duration.ofSeconds(30), 148_894, stage);
+    }
+
+    private static JsonObject json(String text) {
+        return JsonParser.create(text).readJsonObject();
+    }
+}

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunJsonTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunJsonTest.java
@@ -73,7 +73,7 @@ class ChaosRunJsonTest {
 
     @Test
     void writesNormalizedProbabilityActivation() {
-        ChaosRunPlan probabilityPlan = plan(new ChaosActivation.Probability(0.25));
+        ChaosRunPlan probabilityPlan = plan(new ProbabilityActivation(0.25));
 
         JsonObject json = ChaosRunJson.toJson(view(RUNNING,
                                                    Optional.empty(),

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunPlanJsonTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunPlanJsonTest.java
@@ -15,13 +15,13 @@
  */
 package io.helidon.extensions.chaos;
 
-import java.lang.reflect.Modifier;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
 import java.util.Map;
 import java.util.Optional;
 
+import io.helidon.extensions.chaos.ChaosActivation.ProbabilityActivation;
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonParser;
 import org.junit.jupiter.api.Test;
@@ -75,12 +75,6 @@ class ChaosRunPlanJsonTest {
                 json(withActivation("{\"type\": \"probability\", \"probability\": 1}")),
                 LIMITS);
         assertThat(certain.stage().disruption().activation(), is(new ProbabilityActivation(1)));
-    }
-
-    @Test
-    void activationImplementationsAreNotPublicApiTypes() {
-        assertThat(Modifier.isPublic(AlwaysActivation.class.getModifiers()), is(false));
-        assertThat(Modifier.isPublic(ProbabilityActivation.class.getModifiers()), is(false));
     }
 
     @Test

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunPlanJsonTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunPlanJsonTest.java
@@ -18,6 +18,7 @@ package io.helidon.extensions.chaos;
 import java.lang.reflect.Modifier;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
+import java.time.format.DateTimeParseException;
 
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonParser;
@@ -25,8 +26,11 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ChaosRunPlanJsonTest {
@@ -151,6 +155,18 @@ class ChaosRunPlanJsonTest {
                 .maximumRunDuration(Duration.ofSeconds(20))
                 .build();
         assertInvalidPlan(validJson(), limits, "/maximumDuration");
+    }
+
+    @Test
+    void retainsParsingCauseWithoutExposingItInProblemResponse() {
+        ChaosRequestException exception = assertThrows(ChaosRequestException.class,
+                                                        () -> ChaosRunPlanJson.parse(
+                                                                json(validJson().replace("PT30S", "not-a-duration")),
+                                                                LIMITS));
+
+        assertThat(exception.getCause(), instanceOf(DateTimeParseException.class));
+        assertThat(ChaosProblemJson.from(exception, "/chaos/v1/runs").body().toString(),
+                   not(containsString("not-a-duration")));
     }
 
     @Test

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunPlanJsonTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunPlanJsonTest.java
@@ -15,6 +15,7 @@
  */
 package io.helidon.extensions.chaos;
 
+import java.lang.reflect.Modifier;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 
@@ -56,18 +57,24 @@ class ChaosRunPlanJsonTest {
 
         ChaosRunPlan plan = ChaosRunPlanJson.parse(json(input), LIMITS);
 
-        assertThat(plan.stage().disruption().activation(), is(new ChaosActivation.Probability(0.25)));
+        assertThat(plan.stage().disruption().activation(), is(new ProbabilityActivation(0.25)));
 
         ChaosRunPlan minimum = ChaosRunPlanJson.parse(
                 json(withActivation("{\"type\": \"probability\", "
                                             + "\"probability\": 1.1102230246251565e-16}")),
                 LIMITS);
         assertThat(minimum.stage().disruption().activation(),
-                   is(new ChaosActivation.Probability(0x1.0p-53)));
+                   is(new ProbabilityActivation(0x1.0p-53)));
         ChaosRunPlan certain = ChaosRunPlanJson.parse(
                 json(withActivation("{\"type\": \"probability\", \"probability\": 1}")),
                 LIMITS);
-        assertThat(certain.stage().disruption().activation(), is(new ChaosActivation.Probability(1)));
+        assertThat(certain.stage().disruption().activation(), is(new ProbabilityActivation(1)));
+    }
+
+    @Test
+    void activationImplementationsAreNotPublicApiTypes() {
+        assertThat(Modifier.isPublic(AlwaysActivation.class.getModifiers()), is(false));
+        assertThat(Modifier.isPublic(ProbabilityActivation.class.getModifiers()), is(false));
     }
 
     @Test

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunPlanJsonTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunPlanJsonTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ChaosRunPlanJsonTest {
+
+    private static final ChaosLimitsConfig LIMITS = ChaosLimitsConfig.create();
+
+    @Test
+    void parsesAndNormalizesOneStagePlan() {
+        ChaosRunPlan plan = ChaosRunPlanJson.parse(json(validJson()), LIMITS);
+
+        assertThat(plan.name(), is("orders-unavailable"));
+        assertThat(plan.maximumDuration(), is(Duration.ofSeconds(30)));
+        assertThat(plan.seed(), is(148_894L));
+        assertThat(plan.stage().duration(), is(Duration.ofSeconds(10)));
+        assertThat(plan.stage().disruption().scope().methods(), contains("GET"));
+        assertThat(plan.stage().disruption().activation(), is(ChaosActivation.always()));
+        ChaosSyntheticResponse effect = (ChaosSyntheticResponse) plan.stage().disruption().effect();
+        assertThat(effect.status(), is(503));
+        assertThat(effect.headers(), hasEntry("Retry-After", "1"));
+        assertThat(new String(effect.body(), StandardCharsets.UTF_8),
+                   is("Synthetic service failure"));
+    }
+
+    @Test
+    void parsesProbabilityActivation() {
+        String input = validJson().replace("{\"type\": \"always\"}",
+                                           "{\"type\": \"probability\", \"probability\": 0.25}");
+
+        ChaosRunPlan plan = ChaosRunPlanJson.parse(json(input), LIMITS);
+
+        assertThat(plan.stage().disruption().activation(), is(new ChaosActivation.Probability(0.25)));
+
+        ChaosRunPlan minimum = ChaosRunPlanJson.parse(
+                json(withActivation("{\"type\": \"probability\", "
+                                            + "\"probability\": 1.1102230246251565e-16}")),
+                LIMITS);
+        assertThat(minimum.stage().disruption().activation(),
+                   is(new ChaosActivation.Probability(0x1.0p-53)));
+        ChaosRunPlan certain = ChaosRunPlanJson.parse(
+                json(withActivation("{\"type\": \"probability\", \"probability\": 1}")),
+                LIMITS);
+        assertThat(certain.stage().disruption().activation(), is(new ChaosActivation.Probability(1)));
+    }
+
+    @Test
+    void rejectsMissingNonNumericAndOutOfRangeProbability() {
+        assertBadRequest(withActivation("{\"type\": \"probability\"}"),
+                         "/stages/0/disruptions/0/activation/probability");
+        assertBadRequest(withActivation("{\"type\": \"probability\", \"probability\": \"often\"}"),
+                         "/stages/0/disruptions/0/activation/probability");
+        assertInvalidPlan(withActivation("{\"type\": \"probability\", \"probability\": 0}"),
+                          "/stages/0/disruptions/0/activation/probability");
+        assertInvalidPlan(withActivation("{\"type\": \"probability\", \"probability\": -0.1}"),
+                          "/stages/0/disruptions/0/activation/probability");
+        assertInvalidPlan(withActivation("{\"type\": \"probability\", \"probability\": 1.01}"),
+                          "/stages/0/disruptions/0/activation/probability");
+        assertInvalidPlan(withActivation("{\"type\": \"probability\", \"probability\": 1e-10000}"),
+                          "/stages/0/disruptions/0/activation/probability");
+        assertInvalidPlan(withActivation("{\"type\": \"probability\", \"probability\": 1e-100}"),
+                          "/stages/0/disruptions/0/activation/probability");
+        assertInvalidPlan(withActivation("{\"type\": \"probability\", "
+                                                 + "\"probability\": 0.99999999999999999}"),
+                          "/stages/0/disruptions/0/activation/probability");
+    }
+
+    @Test
+    void rejectsUnknownRootPropertyAsBadRequest() {
+        String input = validJson().replace("\"name\":", "\"enabled\":true,\"name\":");
+
+        ChaosRequestException exception = assertThrows(ChaosRequestException.class,
+                                                        () -> ChaosRunPlanJson.parse(json(input), LIMITS));
+
+        assertThat(exception.status(), is(400));
+        assertThat(exception.violations().getFirst().path(), is("/enabled"));
+        assertThat(exception.violations().getFirst().code(), is("unknown-property"));
+    }
+
+    @Test
+    void rejectsUnsupportedScopeActivationAndEffectTypes() {
+        assertInvalidPlan(validJson().replace("inbound-http", "outbound-http"), "/stages/0/disruptions/0/scope/type");
+        assertInvalidPlan(validJson().replace("\"always\"", "\"invocation-cycle\""),
+                          "/stages/0/disruptions/0/activation/type");
+        assertInvalidPlan(validJson().replace("synthetic-http-response", "future-effect"),
+                          "/stages/0/disruptions/0/effect/type");
+    }
+
+    @Test
+    void rejectsUnknownActivationPropertyBeforeUnsupportedType() {
+        String input = withActivation("{\"type\": \"future\", \"unexpected\": true}");
+
+        assertBadRequest(input, "/stages/0/disruptions/0/activation/unexpected");
+    }
+
+    @Test
+    void rejectsUnsafeOrNonNormalizedPaths() {
+        assertInvalidPlan(validJson().replace("/orders", "/chaos/v1"),
+                          "/stages/0/disruptions/0/scope/path/value");
+        assertInvalidPlan(validJson().replace("/orders", "orders"),
+                          "/stages/0/disruptions/0/scope/path/value");
+        assertInvalidPlan(validJson().replace("/orders", "/orders/../admin"),
+                          "/stages/0/disruptions/0/scope/path/value");
+    }
+
+    @Test
+    void rejectsEmptyMethods() {
+        assertInvalidPlan(validJson().replace("[\"get\"]", "[]"),
+                          "/stages/0/disruptions/0/scope/methods");
+    }
+
+    @Test
+    void rejectsInvalidDurationsAndServerLimitExcess() {
+        assertInvalidPlan(validJson().replace("PT30S", "not-a-duration"), "/maximumDuration");
+        assertInvalidPlan(validJson().replace("PT10S", "PT31S"), "/stages/0/duration");
+
+        ChaosLimitsConfig limits = ChaosLimitsConfig.builder()
+                .maximumRunDuration(Duration.ofSeconds(20))
+                .build();
+        assertInvalidPlan(validJson(), limits, "/maximumDuration");
+    }
+
+    @Test
+    void rejectsInvalidOrExcessiveBudgets() {
+        assertInvalidPlan(validJson().replace("\"maximumActivations\": 20", "\"maximumActivations\": 0"),
+                          "/stages/0/disruptions/0/budget/maximumActivations");
+        assertInvalidPlan(validJson().replace("\"maximumConcurrent\": 2", "\"maximumConcurrent\": 0"),
+                          "/stages/0/disruptions/0/budget/maximumConcurrent");
+
+        ChaosLimitsConfig limits = ChaosLimitsConfig.builder()
+                .maximumActivationsPerDisruption(19)
+                .build();
+        assertInvalidPlan(validJson(), limits,
+                          "/stages/0/disruptions/0/budget/maximumActivations");
+    }
+
+    @Test
+    void restrictsSyntheticStatusHeadersAndBody() {
+        assertInvalidPlan(validJson().replace("\"status\": 503", "\"status\": 399"),
+                          "/stages/0/disruptions/0/effect/status");
+        assertInvalidPlan(validJson().replace("\"Retry-After\": \"1\"", "\"Content-Length\": \"2\""),
+                          "/stages/0/disruptions/0/effect/headers/Content-Length");
+        assertInvalidPlan(validJson().replace("\"Retry-After\": \"1\"", "\"X-Test\": \"bad\\nvalue\""),
+                          "/stages/0/disruptions/0/effect/headers/X-Test");
+        assertInvalidPlan(validJson().replace("\"Retry-After\": \"1\"", "\"X-Test\": \"bad\\u0001value\""),
+                          "/stages/0/disruptions/0/effect/headers/X-Test");
+        assertInvalidPlan(validJson().replace("\"Retry-After\": \"1\"", "\"X-Test\": \"bad\\u007fvalue\""),
+                          "/stages/0/disruptions/0/effect/headers/X-Test");
+
+        ChaosLimitsConfig limits = ChaosLimitsConfig.builder().maximumSyntheticBodyBytes(4).build();
+        assertInvalidPlan(validJson().replace("Synthetic service failure", "ééé"), limits,
+                          "/stages/0/disruptions/0/effect/body");
+    }
+
+    @Test
+    void rejectsUnpairedUnicodeSurrogates() {
+        assertBadRequest(validJson().replace("orders-unavailable", "bad\\ud800name"), "/name");
+    }
+
+    @Test
+    void rejectsWrongStageAndDisruptionCounts() {
+        assertInvalidPlan("""
+                {"name":"empty","maximumDuration":"PT30S","stages":[]}
+                """, "/stages");
+        assertInvalidPlan("""
+                {
+                  "name":"empty",
+                  "maximumDuration":"PT30S",
+                  "stages":[{"name":"stage","duration":"PT10S","disruptions":[]}]
+                }
+                """, "/stages/0/disruptions");
+    }
+
+    private static void assertInvalidPlan(String input, String path) {
+        assertInvalidPlan(input, LIMITS, path);
+    }
+
+    private static void assertBadRequest(String input, String path) {
+        ChaosRequestException exception = assertThrows(ChaosRequestException.class,
+                                                        () -> ChaosRunPlanJson.parse(json(input), LIMITS));
+        assertThat(exception.status(), is(400));
+        assertThat(exception.violations().getFirst().path(), is(path));
+    }
+
+    private static void assertInvalidPlan(String input, ChaosLimitsConfig limits, String path) {
+        ChaosRequestException exception = assertThrows(ChaosRequestException.class,
+                                                        () -> ChaosRunPlanJson.parse(json(input), limits));
+        assertThat(exception.status(), is(422));
+        assertThat(exception.violations().getFirst().path(), is(path));
+    }
+
+    private static JsonObject json(String text) {
+        return JsonParser.create(text).readJsonObject();
+    }
+
+    private static String withActivation(String activation) {
+        return validJson().replace("{\"type\": \"always\"}", activation);
+    }
+
+    private static String withEffect(String effect) {
+        return planJson(effect.strip());
+    }
+
+    private static String validJson() {
+        return planJson("""
+                {
+                  "type": "synthetic-http-response",
+                  "status": 503,
+                  "headers": {"Retry-After": "1"},
+                  "mediaType": "text/plain",
+                  "body": "Synthetic service failure"
+                }
+                """);
+    }
+
+    private static String planJson(String effect) {
+        return """
+                {
+                  "name": "orders-unavailable",
+                  "maximumDuration": "PT30S",
+                  "seed": 148894,
+                  "stages": [{
+                    "name": "reject-orders",
+                    "duration": "PT10S",
+                    "disruptions": [{
+                      "name": "orders-503",
+                      "scope": {
+                        "type": "inbound-http",
+                        "methods": ["get"],
+                        "path": {"match": "prefix", "value": "/orders"}
+                      },
+                      "activation": {"type": "always"},
+                      "effect": %s,
+                      "budget": {"maximumActivations": 20, "maximumConcurrent": 2}
+                    }]
+                  }]
+                }
+                """.formatted(effect);
+    }
+}

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunPlanJsonTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosRunPlanJsonTest.java
@@ -19,6 +19,8 @@ import java.lang.reflect.Modifier;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.format.DateTimeParseException;
+import java.util.Map;
+import java.util.Optional;
 
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonParser;
@@ -189,6 +191,9 @@ class ChaosRunPlanJsonTest {
                           "/stages/0/disruptions/0/effect/status");
         assertInvalidPlan(validJson().replace("\"Retry-After\": \"1\"", "\"Content-Length\": \"2\""),
                           "/stages/0/disruptions/0/effect/headers/Content-Length");
+        assertInvalidPlan(validJson().replace("\"Retry-After\": \"1\"",
+                                              "\"Retry-After\": \"1\", \"retry-after\": \"60\""),
+                          "/stages/0/disruptions/0/effect/headers/retry-after");
         assertInvalidPlan(validJson().replace("\"Retry-After\": \"1\"", "\"X-Test\": \"bad\\nvalue\""),
                           "/stages/0/disruptions/0/effect/headers/X-Test");
         assertInvalidPlan(validJson().replace("\"Retry-After\": \"1\"", "\"X-Test\": \"bad\\u0001value\""),
@@ -199,6 +204,19 @@ class ChaosRunPlanJsonTest {
         ChaosLimitsConfig limits = ChaosLimitsConfig.builder().maximumSyntheticBodyBytes(4).build();
         assertInvalidPlan(validJson().replace("Synthetic service failure", "ééé"), limits,
                           "/stages/0/disruptions/0/effect/body");
+    }
+
+    @Test
+    void reportsNullSyntheticResponseComponents() {
+        assertThat(assertThrows(NullPointerException.class,
+                                () -> new ChaosSyntheticResponse(503, null, Optional.empty(), new byte[0])).getMessage(),
+                   is("headers is null"));
+        assertThat(assertThrows(NullPointerException.class,
+                                () -> new ChaosSyntheticResponse(503, Map.of(), null, new byte[0])).getMessage(),
+                   is("mediaType is null"));
+        assertThat(assertThrows(NullPointerException.class,
+                                () -> new ChaosSyntheticResponse(503, Map.of(), Optional.empty(), null)).getMessage(),
+                   is("body is null"));
     }
 
     @Test

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosServerFeatureTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosServerFeatureTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import io.helidon.config.Config;
+import io.helidon.security.AuthenticationResponse;
+import io.helidon.security.Security;
+import io.helidon.webserver.ListenerConfig;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.security.SecurityFeature;
+import io.helidon.webserver.spi.ServerFeature;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ChaosServerFeatureTest {
+
+    @Test
+    void disabledFeatureDoesNotInspectOrMutateSockets() {
+        TestFeatureContext context = context("127.0.0.1", false, true);
+
+        ChaosServerFeature.create(ChaosConfig.builder().buildPrototype()).setup(context);
+
+        assertThat(context.requestedSockets(), is(empty()));
+    }
+
+    @Test
+    void rejectsUnknownControlAndApplicationSockets() {
+        ChaosConfig unknownControl = enabledConfig("unknown", Set.of(WebServer.DEFAULT_SOCKET_NAME), true);
+        ChaosConfig unknownApplication = enabledConfig("chaos-control", Set.of("unknown"), true);
+
+        assertThrows(IllegalStateException.class,
+                     () -> ChaosSocketPolicy.validate(unknownControl, context("127.0.0.1", false, true)));
+        assertThrows(IllegalStateException.class,
+                     () -> ChaosSocketPolicy.validate(unknownApplication, context("127.0.0.1", false, true)));
+    }
+
+    @Test
+    void anonymousModeRequiresActualLoopbackBinding() {
+        ChaosConfig config = enabledConfig("chaos-control", Set.of(WebServer.DEFAULT_SOCKET_NAME), true);
+
+        assertDoesNotThrow(() -> ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true)));
+        assertThrows(IllegalStateException.class,
+                     () -> ChaosSocketPolicy.validate(config, context("0.0.0.0", false, true)));
+    }
+
+    @Test
+    void controlSocketRequiresFinitePayloadCeilingWithinChaosLimit() {
+        ChaosConfig config = enabledConfig("chaos-control", Set.of(WebServer.DEFAULT_SOCKET_NAME), true);
+
+        assertThrows(IllegalStateException.class,
+                     () -> ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true, -1)));
+        assertThrows(IllegalStateException.class,
+                     () -> ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true, 65_537)));
+        assertDoesNotThrow(() -> ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true, 65_536)));
+    }
+
+    @Test
+    void securedModeRequiresEnabledHelidonSecurityFeature() {
+        ChaosConfig config = enabledConfig("chaos-control", Set.of(WebServer.DEFAULT_SOCKET_NAME), false);
+
+        assertThrows(IllegalStateException.class,
+                     () -> ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true)));
+        assertThrows(IllegalStateException.class,
+                     () -> ChaosSocketPolicy.validate(config, context("127.0.0.1", true, false)));
+        assertDoesNotThrow(() -> ChaosSocketPolicy.validate(config, context("0.0.0.0", true, true)));
+    }
+
+    @Test
+    void setupTargetsOnlyControlAndApplicationSockets() {
+        TestFeatureContext context = context("127.0.0.1", false, true);
+        ChaosServerFeature feature = ChaosServerFeature.create(
+                enabledConfig("chaos-control", Set.of(WebServer.DEFAULT_SOCKET_NAME), true));
+
+        feature.setup(context);
+
+        assertThat(new LinkedHashSet<>(context.requestedSockets()),
+                   containsInAnyOrder("chaos-control", WebServer.DEFAULT_SOCKET_NAME));
+        assertThat(feature.name(), is("chaos"));
+        assertThat(feature.type(), is("chaos"));
+        assertThat(feature.weight(), is(700.0));
+    }
+
+    @Test
+    void providerUsesHelidonConfiguredProviderContract() {
+        ChaosServerFeatureProvider provider = new ChaosServerFeatureProvider();
+
+        ChaosServerFeature feature = provider.create(Config.empty(), "custom-chaos");
+
+        assertThat(provider.configKey(), is("chaos"));
+        assertThat(feature.name(), is("custom-chaos"));
+        assertThat(feature.prototype().enabled(), is(false));
+    }
+
+    private static ChaosConfig enabledConfig(String controlSocket,
+                                             Set<String> applicationSockets,
+                                             boolean anonymousLoopback) {
+        return ChaosConfig.builder()
+                .enabled(true)
+                .controlSocket(controlSocket)
+                .applicationSockets(applicationSockets)
+                .security(ChaosSecurityConfig.builder()
+                                  .allowUnauthenticatedLoopback(anonymousLoopback)
+                                  .build())
+                .buildPrototype();
+    }
+
+    private static TestFeatureContext context(String controlHost,
+                                              boolean securityFeature,
+                                              boolean securityEnabled) {
+        return context(controlHost, securityFeature, securityEnabled, 65_536);
+    }
+
+    private static TestFeatureContext context(String controlHost,
+                                              boolean securityFeature,
+                                              boolean securityEnabled,
+                                              long maximumPayloadSize) {
+        WebServerConfig.Builder builder = WebServerConfig.builder()
+                .featuresDiscoverServices(false)
+                .host("127.0.0.1")
+                .port(0)
+                .putSocket("chaos-control", socket -> socket.host(controlHost)
+                        .port(0)
+                        .maxPayloadSize(maximumPayloadSize));
+        if (securityFeature) {
+            Security security = Security.builder()
+                    .enabled(securityEnabled)
+                    .addAuthenticationProvider(request -> AuthenticationResponse.abstain())
+                    .build();
+            builder.addFeature(SecurityFeature.builder().security(security).build());
+        }
+        return new TestFeatureContext(builder.buildPrototype());
+    }
+
+    private static final class TestFeatureContext implements ServerFeature.ServerFeatureContext {
+        private final WebServerConfig config;
+        private final Map<String, ServerFeature.SocketBuilders> socketBuilders = new LinkedHashMap<>();
+        private final List<String> requestedSockets = new ArrayList<>();
+
+        private TestFeatureContext(WebServerConfig config) {
+            this.config = config;
+            socketBuilders.put(WebServer.DEFAULT_SOCKET_NAME, socketBuilders(config));
+            config.sockets().forEach((name, listener) -> socketBuilders.put(name, socketBuilders(listener)));
+        }
+
+        @Override
+        public WebServerConfig serverConfig() {
+            return config;
+        }
+
+        @Override
+        public Set<String> sockets() {
+            return Set.copyOf(socketBuilders.keySet());
+        }
+
+        @Override
+        public boolean socketExists(String socketName) {
+            return socketBuilders.containsKey(socketName);
+        }
+
+        @Override
+        public ServerFeature.SocketBuilders socket(String socketName) {
+            requestedSockets.add(socketName);
+            ServerFeature.SocketBuilders builders = socketBuilders.get(socketName);
+            if (builders == null) {
+                throw new IllegalArgumentException("Unknown test socket: " + socketName);
+            }
+            return builders;
+        }
+
+        private List<String> requestedSockets() {
+            return List.copyOf(requestedSockets);
+        }
+
+        private static ServerFeature.SocketBuilders socketBuilders(ListenerConfig listener) {
+            HttpRouting.Builder routing = HttpRouting.builder();
+            return new ServerFeature.SocketBuilders() {
+                @Override
+                public ListenerConfig listener() {
+                    return listener;
+                }
+
+                @Override
+                public HttpRouting.Builder httpRouting() {
+                    return routing;
+                }
+
+                @Override
+                public ServerFeature.RoutingBuilders routingBuilders() {
+                    return null;
+                }
+            };
+        }
+    }
+}

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosServerFeatureTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosServerFeatureTest.java
@@ -119,6 +119,30 @@ class ChaosServerFeatureTest {
         assertThat(feature.prototype().enabled(), is(false));
     }
 
+    @Test
+    void unsafeSocketConfigurationsFailDuringServerConstruction() {
+        var wildcard = WebServer.builder()
+                .featuresDiscoverServices(false)
+                .host("127.0.0.1")
+                .port(0)
+                .putSocket("chaos-control", socket -> socket.host("0.0.0.0").port(0))
+                .addFeature(ChaosServerFeature.create(enabledConfig("chaos-control",
+                                                                      Set.of(WebServer.DEFAULT_SOCKET_NAME),
+                                                                      true)));
+        assertThat(wildcard.sockets().get("chaos-control").host(), is("0.0.0.0"));
+        assertThat(wildcard.sockets().get("chaos-control").address().isAnyLocalAddress(), is(true));
+        assertThrows(IllegalStateException.class, wildcard::build);
+
+        var missingControl = WebServer.builder()
+                .featuresDiscoverServices(false)
+                .host("127.0.0.1")
+                .port(0)
+                .addFeature(ChaosServerFeature.create(enabledConfig("missing-control",
+                                                                      Set.of(WebServer.DEFAULT_SOCKET_NAME),
+                                                                      true)));
+        assertThrows(IllegalStateException.class, missingControl::build);
+    }
+
     private static ChaosConfig enabledConfig(String controlSocket,
                                              Set<String> applicationSockets,
                                              boolean anonymousLoopback) {

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosServerFeatureTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosServerFeatureTest.java
@@ -37,7 +37,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class ChaosServerFeatureTest {
@@ -73,7 +72,7 @@ class ChaosServerFeatureTest {
     void anonymousModeRequiresActualLoopbackBinding() {
         ChaosConfig config = enabledConfig("chaos-control", Set.of(WebServer.DEFAULT_SOCKET_NAME), true);
 
-        assertDoesNotThrow(() -> ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true)));
+        assertThat(ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true)).anonymousLoopback(), is(true));
         assertThrows(IllegalStateException.class,
                      () -> ChaosSocketPolicy.validate(config, context("0.0.0.0", false, true)));
     }
@@ -86,7 +85,8 @@ class ChaosServerFeatureTest {
                      () -> ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true, -1)));
         assertThrows(IllegalStateException.class,
                      () -> ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true, 65_537)));
-        assertDoesNotThrow(() -> ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true, 65_536)));
+        assertThat(ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true, 65_536)).anonymousLoopback(),
+                   is(true));
     }
 
     @Test
@@ -97,7 +97,7 @@ class ChaosServerFeatureTest {
                      () -> ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true)));
         assertThrows(IllegalStateException.class,
                      () -> ChaosSocketPolicy.validate(config, context("127.0.0.1", true, false)));
-        assertDoesNotThrow(() -> ChaosSocketPolicy.validate(config, context("0.0.0.0", true, true)));
+        assertThat(ChaosSocketPolicy.validate(config, context("0.0.0.0", true, true)).anonymousLoopback(), is(false));
     }
 
     @Test
@@ -226,10 +226,6 @@ class ChaosServerFeatureTest {
             return builders;
         }
 
-        private List<String> requestedSockets() {
-            return List.copyOf(requestedSockets);
-        }
-
         private static ServerFeature.SocketBuilders socketBuilders(ListenerConfig listener) {
             HttpRouting.Builder routing = HttpRouting.builder();
             return new ServerFeature.SocketBuilders() {
@@ -248,6 +244,10 @@ class ChaosServerFeatureTest {
                     return null;
                 }
             };
+        }
+
+        private List<String> requestedSockets() {
+            return List.copyOf(requestedSockets);
         }
     }
 }

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosServerFeatureTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosServerFeatureTest.java
@@ -52,6 +52,13 @@ class ChaosServerFeatureTest {
     }
 
     @Test
+    void rejectsNullFeatureContextWhenDisabled() {
+        ChaosServerFeature feature = ChaosServerFeature.create(ChaosConfig.builder().buildPrototype());
+
+        assertThrows(NullPointerException.class, () -> feature.setup(null));
+    }
+
+    @Test
     void rejectsUnknownControlAndApplicationSockets() {
         ChaosConfig unknownControl = enabledConfig("unknown", Set.of(WebServer.DEFAULT_SOCKET_NAME), true);
         ChaosConfig unknownApplication = enabledConfig("chaos-control", Set.of("unknown"), true);

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosServerFeatureTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosServerFeatureTest.java
@@ -15,6 +15,10 @@
  */
 package io.helidon.extensions.chaos;
 
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.net.UnixDomainSocketAddress;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -70,12 +74,31 @@ class ChaosServerFeatureTest {
     }
 
     @Test
-    void anonymousModeRequiresActualLoopbackBinding() {
+    void anonymousModeRequiresActualLocalBinding() {
         ChaosConfig config = enabledConfig("chaos-control", Set.of(WebServer.DEFAULT_SOCKET_NAME), true);
 
-        assertThat(ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true)).anonymousLoopback(), is(true));
+        assertThat(ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true)).anonymousLocal(), is(true));
         assertThrows(IllegalStateException.class,
                      () -> ChaosSocketPolicy.validate(config, context("0.0.0.0", false, true)));
+        assertThat(ChaosSocketPolicy.validate(config,
+                                              context(new InetSocketAddress("127.0.0.1", 0), false, true))
+                           .anonymousLocal(),
+                   is(true));
+        assertThrows(IllegalStateException.class,
+                     () -> ChaosSocketPolicy.validate(config,
+                                                       context(new InetSocketAddress("0.0.0.0", 0), false, true)));
+        assertThrows(IllegalStateException.class,
+                     () -> ChaosSocketPolicy.validate(config,
+                                                       context(new InetSocketAddress("192.0.2.1", 0), false, true)));
+        assertThrows(IllegalStateException.class,
+                     () -> ChaosSocketPolicy.validate(config,
+                                                       context(InetSocketAddress.createUnresolved("localhost", 0),
+                                                               false,
+                                                               true)));
+        SocketAddress unixDomainSocket = UnixDomainSocketAddress.of(Path.of("target", "chaos-control.sock"));
+        assertThat(ChaosSocketPolicy.validate(config, context(unixDomainSocket, false, true))
+                           .anonymousLocal(),
+                   is(true));
     }
 
     @Test
@@ -86,7 +109,7 @@ class ChaosServerFeatureTest {
                      () -> ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true, -1)));
         assertThrows(IllegalStateException.class,
                      () -> ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true, 65_537)));
-        assertThat(ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true, 65_536)).anonymousLoopback(),
+        assertThat(ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true, 65_536)).anonymousLocal(),
                    is(true));
     }
 
@@ -98,7 +121,7 @@ class ChaosServerFeatureTest {
                      () -> ChaosSocketPolicy.validate(config, context("127.0.0.1", false, true)));
         assertThrows(IllegalStateException.class,
                      () -> ChaosSocketPolicy.validate(config, context("127.0.0.1", true, false)));
-        assertThat(ChaosSocketPolicy.validate(config, context("0.0.0.0", true, true)).anonymousLoopback(), is(false));
+        assertThat(ChaosSocketPolicy.validate(config, context("0.0.0.0", true, true)).anonymousLocal(), is(false));
     }
 
     @Test
@@ -153,13 +176,13 @@ class ChaosServerFeatureTest {
 
     private static ChaosConfig enabledConfig(String controlSocket,
                                              Set<String> applicationSockets,
-                                             boolean anonymousLoopback) {
+                                             boolean anonymousLocal) {
         return ChaosConfig.builder()
                 .enabled(true)
                 .controlSocket(controlSocket)
                 .applicationSockets(applicationSockets)
                 .security(ChaosSecurityConfig.builder()
-                                  .allowUnauthenticatedLoopback(anonymousLoopback)
+                                  .allowUnauthenticatedLocal(anonymousLocal)
                                   .build())
                 .buildPrototype();
     }
@@ -181,6 +204,25 @@ class ChaosServerFeatureTest {
                 .putSocket("chaos-control", socket -> socket.host(controlHost)
                         .port(0)
                         .maxPayloadSize(maximumPayloadSize));
+        if (securityFeature) {
+            Security security = Security.builder()
+                    .enabled(securityEnabled)
+                    .addAuthenticationProvider(request -> AuthenticationResponse.abstain())
+                    .build();
+            builder.addFeature(SecurityFeature.builder().security(security).build());
+        }
+        return new TestFeatureContext(builder.buildPrototype());
+    }
+
+    private static TestFeatureContext context(SocketAddress controlBindAddress,
+                                              boolean securityFeature,
+                                              boolean securityEnabled) {
+        WebServerConfig.Builder builder = WebServerConfig.builder()
+                .featuresDiscoverServices(false)
+                .host("127.0.0.1")
+                .port(0)
+                .putSocket("chaos-control", socket -> socket.bindAddress(controlBindAddress)
+                        .maxPayloadSize(65_536));
         if (securityFeature) {
             Security security = Security.builder()
                     .enabled(securityEnabled)

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosServerFeatureTest.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/ChaosServerFeatureTest.java
@@ -20,6 +20,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 import java.util.Set;
 
 import io.helidon.config.Config;
@@ -62,9 +63,9 @@ class ChaosServerFeatureTest {
         ChaosConfig unknownControl = enabledConfig("unknown", Set.of(WebServer.DEFAULT_SOCKET_NAME), true);
         ChaosConfig unknownApplication = enabledConfig("chaos-control", Set.of("unknown"), true);
 
-        assertThrows(IllegalStateException.class,
+        assertThrows(NoSuchElementException.class,
                      () -> ChaosSocketPolicy.validate(unknownControl, context("127.0.0.1", false, true)));
-        assertThrows(IllegalStateException.class,
+        assertThrows(NoSuchElementException.class,
                      () -> ChaosSocketPolicy.validate(unknownApplication, context("127.0.0.1", false, true)));
     }
 
@@ -147,7 +148,7 @@ class ChaosServerFeatureTest {
                 .addFeature(ChaosServerFeature.create(enabledConfig("missing-control",
                                                                       Set.of(WebServer.DEFAULT_SOCKET_NAME),
                                                                       true)));
-        assertThrows(IllegalStateException.class, missingControl::build);
+        assertThrows(NoSuchElementException.class, missingControl::build);
     }
 
     private static ChaosConfig enabledConfig(String controlSocket,
@@ -221,7 +222,7 @@ class ChaosServerFeatureTest {
             requestedSockets.add(socketName);
             ServerFeature.SocketBuilders builders = socketBuilders.get(socketName);
             if (builders == null) {
-                throw new IllegalArgumentException("Unknown test socket: " + socketName);
+                throw new NoSuchElementException("Unknown test socket: " + socketName);
             }
             return builders;
         }

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/TestChaosScheduler.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/TestChaosScheduler.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+final class TestChaosScheduler implements ChaosScheduler {
+
+    private final MutableClock clock = new MutableClock(Instant.parse("2026-08-24T12:00:00Z"));
+    private final List<Task> tasks = new ArrayList<>();
+
+    Clock clock() {
+        return clock;
+    }
+
+    @Override
+    public Cancellable schedule(Duration delay, Runnable action) {
+        Task task = new Task(clock.instant().plus(delay), action);
+        tasks.add(task);
+        return task;
+    }
+
+    void advance(Duration duration) {
+        clock.advance(duration);
+        runDueTasks();
+    }
+
+    void fireLast() {
+        Task task = tasks.stream()
+                .filter(candidate -> !candidate.cancelled && !candidate.executed)
+                .max(Comparator.comparing(candidate -> candidate.due))
+                .orElseThrow();
+        clock.set(task.due);
+        task.run();
+    }
+
+    private void runDueTasks() {
+        tasks.stream()
+                .filter(task -> !task.cancelled && !task.executed && !task.due.isAfter(clock.instant()))
+                .sorted(Comparator.comparing(task -> task.due))
+                .toList()
+                .forEach(Task::run);
+    }
+
+    @Override
+    public void close() {
+        tasks.forEach(Task::cancel);
+    }
+
+    private static final class Task implements Cancellable {
+        private final Instant due;
+        private final Runnable action;
+        private boolean cancelled;
+        private boolean executed;
+
+        private Task(Instant due, Runnable action) {
+            this.due = due;
+            this.action = action;
+        }
+
+        @Override
+        public boolean cancel() {
+            if (cancelled || executed) {
+                return false;
+            }
+            cancelled = true;
+            return true;
+        }
+
+        private void run() {
+            if (!cancelled && !executed) {
+                executed = true;
+                action.run();
+            }
+        }
+    }
+
+    private static final class MutableClock extends Clock {
+        private Instant instant;
+
+        private MutableClock(Instant instant) {
+            this.instant = instant;
+        }
+
+        @Override
+        public ZoneId getZone() {
+            return ZoneOffset.UTC;
+        }
+
+        @Override
+        public Clock withZone(ZoneId zone) {
+            if (!ZoneOffset.UTC.equals(zone)) {
+                throw new IllegalArgumentException("Test clock supports UTC only");
+            }
+            return this;
+        }
+
+        @Override
+        public Instant instant() {
+            return instant;
+        }
+
+        private void advance(Duration duration) {
+            instant = instant.plus(duration);
+        }
+
+        private void set(Instant value) {
+            instant = value;
+        }
+    }
+}

--- a/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/TestChaosScheduler.java
+++ b/extensions/chaos/modules/chaos/src/test/java/io/helidon/extensions/chaos/TestChaosScheduler.java
@@ -54,17 +54,17 @@ final class TestChaosScheduler implements ChaosScheduler {
         task.run();
     }
 
+    @Override
+    public void close() {
+        tasks.forEach(Task::cancel);
+    }
+
     private void runDueTasks() {
         tasks.stream()
                 .filter(task -> !task.cancelled && !task.executed && !task.due.isAfter(clock.instant()))
                 .sorted(Comparator.comparing(task -> task.due))
                 .toList()
                 .forEach(Task::run);
-    }
-
-    @Override
-    public void close() {
-        tasks.forEach(Task::cancel);
     }
 
     private static final class Task implements Cancellable {

--- a/extensions/chaos/modules/pom.xml
+++ b/extensions/chaos/modules/pom.xml
@@ -18,33 +18,23 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.extensions</groupId>
-        <artifactId>helidon-extensions-project</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <groupId>io.helidon.extensions.chaos</groupId>
+        <artifactId>helidon-extensions-chaos-project</artifactId>
+        <version>27.0.0-SNAPSHOT</version>
     </parent>
-
-    <artifactId>helidon-extensions-modules-project</artifactId>
-
     <packaging>pom</packaging>
 
-    <name>Helidon Extensions Modules Project</name>
+    <artifactId>helidon-extensions-chaos-modules-project</artifactId>
+    <name>Helidon Extensions Chaos Modules Project</name>
+
+    <properties>
+        <javadoc.fail-on-warnings>true</javadoc.fail-on-warnings>
+    </properties>
 
     <modules>
         <module>chaos</module>
-        <module>hashicorp-vault</module>
-        <module>neo4j</module>
-        <module>oci-v3</module>
-        <module>langchain4j</module>
-        <module>eureka</module>
-        <module>crac</module>
-        <module>openapi-ui</module>
-        <module>openapi-generator</module>
-        <module>gson</module>
-        <module>toml</module>
     </modules>
 </project>

--- a/extensions/chaos/modules/pom.xml
+++ b/extensions/chaos/modules/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.extensions.chaos</groupId>
         <artifactId>helidon-extensions-chaos-project</artifactId>
-        <version>27.0.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/extensions/chaos/pom.xml
+++ b/extensions/chaos/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.extensions</groupId>
+        <artifactId>helidon-extensions-project</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <groupId>io.helidon.extensions.chaos</groupId>
+    <artifactId>helidon-extensions-chaos-project</artifactId>
+    <version>27.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+
+    <name>Helidon Extensions Chaos Project</name>
+
+    <modules>
+        <module>bom</module>
+        <module>modules</module>
+    </modules>
+
+    <properties>
+        <helidon.version>27.0.0-SNAPSHOT</helidon.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.helidon.extensions.chaos</groupId>
+                <artifactId>helidon-extensions-chaos-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.helidon</groupId>
+                <artifactId>helidon-dependencies</artifactId>
+                <version>${helidon.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <profiles>
+        <profile>
+            <id>tests</id>
+            <modules>
+                <module>tests</module>
+            </modules>
+        </profile>
+    </profiles>
+</project>

--- a/extensions/chaos/pom.xml
+++ b/extensions/chaos/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>io.helidon.extensions.chaos</groupId>
     <artifactId>helidon-extensions-chaos-project</artifactId>
-    <version>27.0.0-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Helidon Extensions Chaos Project</name>
@@ -40,7 +40,8 @@
     </modules>
 
     <properties>
-        <helidon.version>27.0.0-SNAPSHOT</helidon.version>
+        <helidon.version>4.5.3</helidon.version>
+        <version.java>21</version.java>
     </properties>
 
     <dependencyManagement>

--- a/extensions/chaos/tests/extension/pom.xml
+++ b/extensions/chaos/tests/extension/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.extensions.chaos.tests</groupId>
+        <artifactId>helidon-extensions-chaos-tests-project</artifactId>
+        <version>27.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-extensions-chaos-tests-extension</artifactId>
+    <name>Helidon Extensions Chaos Tests Extension</name>
+
+    <properties>
+        <enforcer.skip>true</enforcer.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.extensions.chaos</groupId>
+            <artifactId>helidon-extensions-chaos</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.security.providers</groupId>
+            <artifactId>helidon-security-providers-http-auth</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webclient</groupId>
+            <artifactId>helidon-webclient-http1</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <classesDirectory>${project.build.outputDirectory}</classesDirectory>
+                    <includes>
+                        <include>**/*IT.java</include>
+                    </includes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>Run Chaos extension integration tests</id>
+                        <phase>integration-test</phase>
+                        <goals>
+                            <goal>integration-test</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>Verify Chaos extension integration tests</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/chaos/tests/extension/pom.xml
+++ b/extensions/chaos/tests/extension/pom.xml
@@ -60,6 +60,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
             <scope>test</scope>

--- a/extensions/chaos/tests/extension/pom.xml
+++ b/extensions/chaos/tests/extension/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.extensions.chaos.tests</groupId>
         <artifactId>helidon-extensions-chaos-tests-project</artifactId>
-        <version>27.0.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>helidon-extensions-chaos-tests-extension</artifactId>

--- a/extensions/chaos/tests/extension/src/test/java/io/helidon/extensions/chaos/tests/extension/ChaosDisabledFeatureIT.java
+++ b/extensions/chaos/tests/extension/src/test/java/io/helidon/extensions/chaos/tests/extension/ChaosDisabledFeatureIT.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos.tests.extension;
+
+import java.util.Map;
+
+import io.helidon.config.Config;
+import io.helidon.extensions.chaos.ChaosConfig;
+import io.helidon.extensions.chaos.ChaosServerFeature;
+import io.helidon.http.Status;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+@ServerTest
+class ChaosDisabledFeatureIT {
+    private static final String RUNS = "/chaos/v1/runs";
+
+    private final Http1Client client;
+    private final WebServer server;
+
+    ChaosDisabledFeatureIT(Http1Client client, WebServer server) {
+        this.client = client;
+        this.server = server;
+    }
+
+    @SetUpServer
+    static void setUpServer(WebServerConfig.Builder server) {
+        server.config(Config.empty())
+                .sockets(Map.of())
+                .featuresDiscoverServices(false)
+                .addFeature(ChaosServerFeature.create(ChaosConfig.builder().buildPrototype()));
+    }
+
+    @SetUpRoute
+    static void setUpRoute(HttpRouting.Builder routing) {
+        routing.get("/ready", (request, response) -> response.send("ready"));
+    }
+
+    @Test
+    void disabledFeatureDoesNotRequireChaosSockets() {
+        assertThat(client.get("/ready").request().status(), is(Status.OK_200));
+        assertThat(client.get(RUNS).request().status(), is(Status.NOT_FOUND_404));
+        assertThat(server.prototype().sockets().containsKey("chaos-control"), is(false));
+    }
+}

--- a/extensions/chaos/tests/extension/src/test/java/io/helidon/extensions/chaos/tests/extension/ChaosExtensionIT.java
+++ b/extensions/chaos/tests/extension/src/test/java/io/helidon/extensions/chaos/tests/extension/ChaosExtensionIT.java
@@ -20,213 +20,123 @@ import java.util.concurrent.atomic.AtomicInteger;
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigSources;
-import io.helidon.extensions.chaos.ChaosConfig;
-import io.helidon.extensions.chaos.ChaosSecurityConfig;
-import io.helidon.extensions.chaos.ChaosServerFeature;
 import io.helidon.http.Status;
 import io.helidon.json.JsonArray;
 import io.helidon.json.JsonObject;
 import io.helidon.json.JsonParser;
 import io.helidon.webclient.http1.Http1Client;
-import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.http.HttpRouting;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+import io.helidon.webserver.testing.junit5.Socket;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
+@ServerTest
 class ChaosExtensionIT {
 
     private static final String CONTROL_SOCKET = "chaos-control";
     private static final String RUNS = "/chaos/v1/runs";
+    private static final AtomicInteger APPLICATION_INVOCATIONS = new AtomicInteger();
 
-    @Test
-    void isolatesSocketsAndExecutesRunLifecycle() {
-        AtomicInteger applicationInvocations = new AtomicInteger();
-        WebServer server = startServer(applicationInvocations);
-        Http1Client application = client(server.port());
-        Http1Client control = client(server.port(CONTROL_SOCKET));
-        try {
-            assertThat(application.get(RUNS).request().status(), is(Status.NOT_FOUND_404));
-            assertThat(control.get("/orders/42").request().status(), is(Status.NOT_FOUND_404));
+    private final Http1Client application;
+    private final Http1Client control;
 
-            JsonObject created = postRun(control);
-            String id = created.stringValue("id").orElseThrow();
-            assertThat(created.stringValue("state").orElseThrow(), is("RUNNING"));
-            assertThat(created.stringValue("actor").orElseThrow(), is("anonymous-local"));
+    ChaosExtensionIT(Http1Client application, @Socket(CONTROL_SOCKET) Http1Client control) {
+        this.application = application;
+        this.control = control;
+    }
 
-            assertThat(application.get("/orders/42").request(String.class).status(),
-                       is(Status.SERVICE_UNAVAILABLE_503));
-            assertThat(applicationInvocations.get(), is(0));
-            assertThat(application.get("/orders-old").request(String.class).status(), is(Status.OK_200));
-            assertThat(applicationInvocations.get(), is(1));
+    @SetUpServer
+    static void setUpServer(WebServerConfig.Builder server) {
+        Config config = Config.just(ConfigSources.classpath("application.yaml"));
+        server.config(config.get("server"));
+    }
 
-            JsonObject fetched = control.get(RUNS + "/" + id).request(JsonObject.class).entity();
-            assertThat(fetched.objectValue("counters").orElseThrow().longValue("activated").orElseThrow(), is(1L));
+    @SetUpRoute
+    static void setUpRoute(HttpRouting.Builder routing) {
+        routing.get("/orders/{id}", (request, response) -> {
+            APPLICATION_INVOCATIONS.incrementAndGet();
+            response.send("order");
+        }).get("/orders-old", (request, response) -> {
+            APPLICATION_INVOCATIONS.incrementAndGet();
+            response.send("legacy-order");
+        });
+    }
 
-            assertThat(control.delete(RUNS + "/" + id).request(JsonObject.class).status(), is(Status.OK_200));
-            assertThat(application.get("/orders/42").request(String.class).status(), is(Status.OK_200));
-            assertThat(applicationInvocations.get(), is(2));
-        } finally {
-            application.closeResource();
-            control.closeResource();
-            server.stop();
+    @BeforeEach
+    void resetApplicationInvocations() {
+        APPLICATION_INVOCATIONS.set(0);
+    }
+
+    @AfterEach
+    void stopActiveRuns() {
+        JsonArray runs = control.get(RUNS).request(JsonArray.class).entity();
+        for (int index = 0; index < runs.size(); index++) {
+            String id = runs.get(index).orElseThrow().asObject().stringValue("id").orElseThrow();
+            control.delete(RUNS + "/" + id).request();
         }
     }
 
     @Test
-    void restartDoesNotReconstructRuns() {
-        WebServer first = startServer(new AtomicInteger());
-        Http1Client firstControl = client(first.port(CONTROL_SOCKET));
-        try {
-            postRun(firstControl);
-            assertThat(firstControl.get(RUNS).request(JsonArray.class).entity().size(), is(1));
-        } finally {
-            firstControl.closeResource();
-            first.stop();
-        }
+    void isolatesSocketsAndExecutesRunLifecycle() {
+        assertThat(application.get(RUNS).request().status(), is(Status.NOT_FOUND_404));
+        assertThat(control.get("/orders/42").request().status(), is(Status.NOT_FOUND_404));
 
-        WebServer second = startServer(new AtomicInteger());
-        Http1Client secondControl = client(second.port(CONTROL_SOCKET));
-        try {
-            assertThat(secondControl.get(RUNS).request(JsonArray.class).entity().size(), is(0));
-        } finally {
-            secondControl.closeResource();
-            second.stop();
-        }
+        JsonObject created = postRun(control);
+        String id = created.stringValue("id").orElseThrow();
+        assertThat(created.stringValue("state").orElseThrow(), is("RUNNING"));
+        assertThat(created.stringValue("actor").orElseThrow(), is("anonymous-local"));
+
+        assertThat(application.get("/orders/42").request(String.class).status(),
+                   is(Status.SERVICE_UNAVAILABLE_503));
+        assertThat(APPLICATION_INVOCATIONS.get(), is(0));
+        assertThat(application.get("/orders-old").request(String.class).status(), is(Status.OK_200));
+        assertThat(APPLICATION_INVOCATIONS.get(), is(1));
+
+        JsonObject fetched = control.get(RUNS + "/" + id).request(JsonObject.class).entity();
+        assertThat(fetched.objectValue("counters").orElseThrow().longValue("activated").orElseThrow(), is(1L));
+
+        assertThat(control.delete(RUNS + "/" + id).request(JsonObject.class).status(), is(Status.OK_200));
+        assertThat(application.get("/orders/42").request(String.class).status(), is(Status.OK_200));
+        assertThat(APPLICATION_INVOCATIONS.get(), is(2));
     }
 
     @Test
     void executesDeterministicProbabilityActivation() {
-        AtomicInteger applicationInvocations = new AtomicInteger();
-        WebServer server = startServer(applicationInvocations);
-        Http1Client application = client(server.port());
-        Http1Client control = client(server.port(CONTROL_SOCKET));
-        try {
-            JsonObject created = postRun(control,
-                                         runPlan(42,
-                                                 "stage",
-                                                 "synthetic",
-                                                 "{\"type\":\"probability\",\"probability\":0.5}"));
-            String id = created.stringValue("id").orElseThrow();
+        JsonObject created = postRun(control,
+                                     runPlan(42,
+                                             "stage",
+                                             "synthetic",
+                                             "{\"type\":\"probability\",\"probability\":0.5}"));
+        String id = created.stringValue("id").orElseThrow();
 
-            Status[] expected = {
-                    Status.OK_200,
-                    Status.OK_200,
-                    Status.OK_200,
-                    Status.OK_200,
-                    Status.SERVICE_UNAVAILABLE_503,
-                    Status.OK_200,
-                    Status.OK_200,
-                    Status.SERVICE_UNAVAILABLE_503
-            };
-            for (Status status : expected) {
-                assertThat(application.get("/orders/42").request(String.class).status(), is(status));
-            }
-
-            JsonObject fetched = control.get(RUNS + "/" + id).request(JsonObject.class).entity();
-            JsonObject counters = fetched.objectValue("counters").orElseThrow();
-            assertThat(counters.longValue("matched").orElseThrow(), is(8L));
-            assertThat(counters.longValue("activated").orElseThrow(), is(2L));
-            assertThat(counters.longValue("skippedActivation").orElseThrow(), is(6L));
-            assertThat(applicationInvocations.get(), is(6));
-        } finally {
-            application.closeResource();
-            control.closeResource();
-            server.stop();
+        Status[] expected = {
+                Status.OK_200,
+                Status.OK_200,
+                Status.OK_200,
+                Status.OK_200,
+                Status.SERVICE_UNAVAILABLE_503,
+                Status.OK_200,
+                Status.OK_200,
+                Status.SERVICE_UNAVAILABLE_503
+        };
+        for (Status status : expected) {
+            assertThat(application.get("/orders/42").request(String.class).status(), is(status));
         }
-    }
 
-    @Test
-    void disabledFeatureDoesNotRequireChaosSockets() {
-        WebServer server = WebServer.builder()
-                .featuresDiscoverServices(false)
-                .host("127.0.0.1")
-                .port(0)
-                .addFeature(ChaosServerFeature.create(ChaosConfig.builder().buildPrototype()))
-                .routing(rules -> rules.get("/ready", (request, response) -> response.send("ready")))
-                .build()
-                .start();
-        Http1Client client = client(server.port());
-        try {
-            assertThat(client.get("/ready").request().status(), is(Status.OK_200));
-            assertThat(client.get(RUNS).request().status(), is(Status.NOT_FOUND_404));
-        } finally {
-            client.closeResource();
-            server.stop();
-        }
-    }
-
-    @Test
-    void unsafeSocketConfigurationsFailBeforeStartup() {
-        var wildcard = WebServer.builder()
-                .featuresDiscoverServices(false)
-                .host("127.0.0.1")
-                .port(0)
-                .putSocket(CONTROL_SOCKET, socket -> socket.host("0.0.0.0").port(0))
-                .addFeature(ChaosServerFeature.create(enabledConfig(CONTROL_SOCKET)));
-        assertThat(wildcard.sockets().get(CONTROL_SOCKET).host(), is("0.0.0.0"));
-        assertThat(wildcard.sockets().get(CONTROL_SOCKET).address().isAnyLocalAddress(), is(true));
-        assertFailsStartup(wildcard);
-
-        assertFailsStartup(WebServer.builder()
-                                   .featuresDiscoverServices(false)
-                                   .host("127.0.0.1")
-                                   .port(0)
-                                   .addFeature(ChaosServerFeature.create(enabledConfig("missing-control"))));
-
-        assertThrows(IllegalArgumentException.class,
-                     () -> ChaosConfig.builder()
-                             .enabled(true)
-                             .controlSocket(WebServer.DEFAULT_SOCKET_NAME)
-                             .addApplicationSocket(WebServer.DEFAULT_SOCKET_NAME)
-                             .security(ChaosSecurityConfig.builder()
-                                               .allowUnauthenticatedLoopback(true)
-                                               .build())
-                             .buildPrototype());
-    }
-
-    private static WebServer startServer(AtomicInteger applicationInvocations) {
-        Config config = Config.just(ConfigSources.classpath("application.yaml"));
-        return WebServer.builder()
-                .config(config.get("server"))
-                .routing(rules -> rules
-                        .get("/orders/{id}", (request, response) -> {
-                            applicationInvocations.incrementAndGet();
-                            response.send("order");
-                        })
-                        .get("/orders-old", (request, response) -> {
-                            applicationInvocations.incrementAndGet();
-                            response.send("legacy-order");
-                        }))
-                .build()
-                .start();
-    }
-
-    private static ChaosConfig enabledConfig(String controlSocket) {
-        return ChaosConfig.builder()
-                .enabled(true)
-                .controlSocket(controlSocket)
-                .addApplicationSocket(WebServer.DEFAULT_SOCKET_NAME)
-                .security(ChaosSecurityConfig.builder()
-                                  .allowUnauthenticatedLoopback(true)
-                                  .build())
-                .buildPrototype();
-    }
-
-    private static void assertFailsStartup(io.helidon.webserver.WebServerConfig.Builder serverBuilder) {
-        assertThat(serverBuilder.features().stream()
-                           .filter(ChaosServerFeature.class::isInstance)
-                           .map(ChaosServerFeature.class::cast)
-                           .anyMatch(feature -> feature.prototype().enabled()),
-                   is(true));
-        assertThrows(IllegalStateException.class, serverBuilder::build);
-    }
-
-    private static Http1Client client(int port) {
-        return Http1Client.builder()
-                .baseUri("http://127.0.0.1:" + port)
-                .build();
+        JsonObject fetched = control.get(RUNS + "/" + id).request(JsonObject.class).entity();
+        JsonObject counters = fetched.objectValue("counters").orElseThrow();
+        assertThat(counters.longValue("matched").orElseThrow(), is(8L));
+        assertThat(counters.longValue("activated").orElseThrow(), is(2L));
+        assertThat(counters.longValue("skippedActivation").orElseThrow(), is(6L));
+        assertThat(APPLICATION_INVOCATIONS.get(), is(6));
     }
 
     private static JsonObject postRun(Http1Client control) {

--- a/extensions/chaos/tests/extension/src/test/java/io/helidon/extensions/chaos/tests/extension/ChaosExtensionIT.java
+++ b/extensions/chaos/tests/extension/src/test/java/io/helidon/extensions/chaos/tests/extension/ChaosExtensionIT.java
@@ -1,0 +1,272 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos.tests.extension;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.extensions.chaos.ChaosConfig;
+import io.helidon.extensions.chaos.ChaosSecurityConfig;
+import io.helidon.extensions.chaos.ChaosServerFeature;
+import io.helidon.http.Status;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonParser;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webserver.WebServer;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ChaosExtensionIT {
+
+    private static final String CONTROL_SOCKET = "chaos-control";
+    private static final String RUNS = "/chaos/v1/runs";
+
+    @Test
+    void isolatesSocketsAndExecutesRunLifecycle() {
+        AtomicInteger applicationInvocations = new AtomicInteger();
+        WebServer server = startServer(applicationInvocations);
+        Http1Client application = client(server.port());
+        Http1Client control = client(server.port(CONTROL_SOCKET));
+        try {
+            assertThat(application.get(RUNS).request().status(), is(Status.NOT_FOUND_404));
+            assertThat(control.get("/orders/42").request().status(), is(Status.NOT_FOUND_404));
+
+            JsonObject created = postRun(control);
+            String id = created.stringValue("id").orElseThrow();
+            assertThat(created.stringValue("state").orElseThrow(), is("RUNNING"));
+            assertThat(created.stringValue("actor").orElseThrow(), is("anonymous-local"));
+
+            assertThat(application.get("/orders/42").request(String.class).status(),
+                       is(Status.SERVICE_UNAVAILABLE_503));
+            assertThat(applicationInvocations.get(), is(0));
+            assertThat(application.get("/orders-old").request(String.class).status(), is(Status.OK_200));
+            assertThat(applicationInvocations.get(), is(1));
+
+            JsonObject fetched = control.get(RUNS + "/" + id).request(JsonObject.class).entity();
+            assertThat(fetched.objectValue("counters").orElseThrow().longValue("activated").orElseThrow(), is(1L));
+
+            assertThat(control.delete(RUNS + "/" + id).request(JsonObject.class).status(), is(Status.OK_200));
+            assertThat(application.get("/orders/42").request(String.class).status(), is(Status.OK_200));
+            assertThat(applicationInvocations.get(), is(2));
+        } finally {
+            application.closeResource();
+            control.closeResource();
+            server.stop();
+        }
+    }
+
+    @Test
+    void restartDoesNotReconstructRuns() {
+        WebServer first = startServer(new AtomicInteger());
+        Http1Client firstControl = client(first.port(CONTROL_SOCKET));
+        try {
+            postRun(firstControl);
+            assertThat(firstControl.get(RUNS).request(JsonArray.class).entity().size(), is(1));
+        } finally {
+            firstControl.closeResource();
+            first.stop();
+        }
+
+        WebServer second = startServer(new AtomicInteger());
+        Http1Client secondControl = client(second.port(CONTROL_SOCKET));
+        try {
+            assertThat(secondControl.get(RUNS).request(JsonArray.class).entity().size(), is(0));
+        } finally {
+            secondControl.closeResource();
+            second.stop();
+        }
+    }
+
+    @Test
+    void executesDeterministicProbabilityActivation() {
+        AtomicInteger applicationInvocations = new AtomicInteger();
+        WebServer server = startServer(applicationInvocations);
+        Http1Client application = client(server.port());
+        Http1Client control = client(server.port(CONTROL_SOCKET));
+        try {
+            JsonObject created = postRun(control,
+                                         runPlan(42,
+                                                 "stage",
+                                                 "synthetic",
+                                                 "{\"type\":\"probability\",\"probability\":0.5}"));
+            String id = created.stringValue("id").orElseThrow();
+
+            Status[] expected = {
+                    Status.OK_200,
+                    Status.OK_200,
+                    Status.OK_200,
+                    Status.OK_200,
+                    Status.SERVICE_UNAVAILABLE_503,
+                    Status.OK_200,
+                    Status.OK_200,
+                    Status.SERVICE_UNAVAILABLE_503
+            };
+            for (Status status : expected) {
+                assertThat(application.get("/orders/42").request(String.class).status(), is(status));
+            }
+
+            JsonObject fetched = control.get(RUNS + "/" + id).request(JsonObject.class).entity();
+            JsonObject counters = fetched.objectValue("counters").orElseThrow();
+            assertThat(counters.longValue("matched").orElseThrow(), is(8L));
+            assertThat(counters.longValue("activated").orElseThrow(), is(2L));
+            assertThat(counters.longValue("skippedActivation").orElseThrow(), is(6L));
+            assertThat(applicationInvocations.get(), is(6));
+        } finally {
+            application.closeResource();
+            control.closeResource();
+            server.stop();
+        }
+    }
+
+    @Test
+    void disabledFeatureDoesNotRequireChaosSockets() {
+        WebServer server = WebServer.builder()
+                .featuresDiscoverServices(false)
+                .host("127.0.0.1")
+                .port(0)
+                .addFeature(ChaosServerFeature.create(ChaosConfig.builder().buildPrototype()))
+                .routing(rules -> rules.get("/ready", (request, response) -> response.send("ready")))
+                .build()
+                .start();
+        Http1Client client = client(server.port());
+        try {
+            assertThat(client.get("/ready").request().status(), is(Status.OK_200));
+            assertThat(client.get(RUNS).request().status(), is(Status.NOT_FOUND_404));
+        } finally {
+            client.closeResource();
+            server.stop();
+        }
+    }
+
+    @Test
+    void unsafeSocketConfigurationsFailBeforeStartup() {
+        var wildcard = WebServer.builder()
+                .featuresDiscoverServices(false)
+                .host("127.0.0.1")
+                .port(0)
+                .putSocket(CONTROL_SOCKET, socket -> socket.host("0.0.0.0").port(0))
+                .addFeature(ChaosServerFeature.create(enabledConfig(CONTROL_SOCKET)));
+        assertThat(wildcard.sockets().get(CONTROL_SOCKET).host(), is("0.0.0.0"));
+        assertThat(wildcard.sockets().get(CONTROL_SOCKET).address().isAnyLocalAddress(), is(true));
+        assertFailsStartup(wildcard);
+
+        assertFailsStartup(WebServer.builder()
+                                   .featuresDiscoverServices(false)
+                                   .host("127.0.0.1")
+                                   .port(0)
+                                   .addFeature(ChaosServerFeature.create(enabledConfig("missing-control"))));
+
+        assertThrows(IllegalArgumentException.class,
+                     () -> ChaosConfig.builder()
+                             .enabled(true)
+                             .controlSocket(WebServer.DEFAULT_SOCKET_NAME)
+                             .addApplicationSocket(WebServer.DEFAULT_SOCKET_NAME)
+                             .security(ChaosSecurityConfig.builder()
+                                               .allowUnauthenticatedLoopback(true)
+                                               .build())
+                             .buildPrototype());
+    }
+
+    private static WebServer startServer(AtomicInteger applicationInvocations) {
+        Config config = Config.just(ConfigSources.classpath("application.yaml"));
+        return WebServer.builder()
+                .config(config.get("server"))
+                .routing(rules -> rules
+                        .get("/orders/{id}", (request, response) -> {
+                            applicationInvocations.incrementAndGet();
+                            response.send("order");
+                        })
+                        .get("/orders-old", (request, response) -> {
+                            applicationInvocations.incrementAndGet();
+                            response.send("legacy-order");
+                        }))
+                .build()
+                .start();
+    }
+
+    private static ChaosConfig enabledConfig(String controlSocket) {
+        return ChaosConfig.builder()
+                .enabled(true)
+                .controlSocket(controlSocket)
+                .addApplicationSocket(WebServer.DEFAULT_SOCKET_NAME)
+                .security(ChaosSecurityConfig.builder()
+                                  .allowUnauthenticatedLoopback(true)
+                                  .build())
+                .buildPrototype();
+    }
+
+    private static void assertFailsStartup(io.helidon.webserver.WebServerConfig.Builder serverBuilder) {
+        assertThat(serverBuilder.features().stream()
+                           .filter(ChaosServerFeature.class::isInstance)
+                           .map(ChaosServerFeature.class::cast)
+                           .anyMatch(feature -> feature.prototype().enabled()),
+                   is(true));
+        assertThrows(IllegalStateException.class, serverBuilder::build);
+    }
+
+    private static Http1Client client(int port) {
+        return Http1Client.builder()
+                .baseUri("http://127.0.0.1:" + port)
+                .build();
+    }
+
+    private static JsonObject postRun(Http1Client control) {
+        return postRun(control, runPlan(148_894, "reject-orders", "orders-503", "{\"type\":\"always\"}"));
+    }
+
+    private static JsonObject runPlan(long seed, String stageName, String disruptionName, String activation) {
+        return JsonParser.create("""
+                {
+                  "name": "orders-unavailable",
+                  "maximumDuration": "PT30S",
+                  "seed": %d,
+                  "stages": [{
+                    "name": "%s",
+                    "duration": "PT10S",
+                    "disruptions": [{
+                      "name": "%s",
+                      "scope": {
+                        "type": "inbound-http",
+                        "methods": ["GET"],
+                        "path": {"match": "prefix", "value": "/orders"}
+                      },
+                      "activation": %s,
+                      "effect": {
+                        "type": "synthetic-http-response",
+                        "status": 503,
+                        "body": "failure"
+                      },
+                      "budget": {"maximumActivations": 20, "maximumConcurrent": 2}
+                    }]
+                  }]
+                }
+                """.formatted(seed, stageName, disruptionName, activation)).readJsonObject();
+    }
+
+    private static JsonObject postRun(Http1Client control, JsonObject plan) {
+        var response = control.post(RUNS)
+                .contentType(MediaTypes.APPLICATION_JSON)
+                .submit(plan, JsonObject.class);
+        assertThat(response.status(), is(Status.CREATED_201));
+        return response.entity();
+    }
+}

--- a/extensions/chaos/tests/extension/src/test/java/io/helidon/extensions/chaos/tests/extension/ChaosSecurityIT.java
+++ b/extensions/chaos/tests/extension/src/test/java/io/helidon/extensions/chaos/tests/extension/ChaosSecurityIT.java
@@ -28,38 +28,42 @@ import io.helidon.json.JsonObject;
 import io.helidon.json.JsonParser;
 import io.helidon.webclient.http1.Http1Client;
 import io.helidon.webclient.http1.Http1ClientRequest;
-import io.helidon.webserver.WebServer;
+import io.helidon.webserver.WebServerConfig;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpServer;
+import io.helidon.webserver.testing.junit5.Socket;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+@ServerTest
 class ChaosSecurityIT {
 
+    private static final String CONTROL_SOCKET = "chaos-control";
     private static final String RUNS = "/chaos/v1/runs";
+
+    private final Http1Client control;
+
+    ChaosSecurityIT(@Socket(CONTROL_SOCKET) Http1Client control) {
+        this.control = control;
+    }
+
+    @SetUpServer
+    static void setUpServer(WebServerConfig.Builder server) {
+        Config config = Config.just(ConfigSources.classpath("security-application.yaml"));
+        server.config(config.get("server"));
+    }
 
     @Test
     void protectsEveryControlRouteWithAuthenticationAndOperatorRole() {
-        Config config = Config.just(ConfigSources.classpath("security-application.yaml"));
-        WebServer server = WebServer.builder()
-                .config(config.get("server"))
-                .build()
-                .start();
-        Http1Client control = Http1Client.builder()
-                .baseUri("http://127.0.0.1:" + server.port("chaos-control"))
-                .build();
-        try {
-            assertAccess(() -> control.get(RUNS), Status.OK_200);
-            JsonObject created = assertCreateAccess(control);
-            assertThat(created.stringValue("actor").orElseThrow(), is("operator"));
-            String run = RUNS + "/" + created.stringValue("id").orElseThrow();
+        assertAccess(() -> control.get(RUNS), Status.OK_200);
+        JsonObject created = assertCreateAccess(control);
+        assertThat(created.stringValue("actor").orElseThrow(), is("operator"));
+        String run = RUNS + "/" + created.stringValue("id").orElseThrow();
 
-            assertAccess(() -> control.get(run), Status.OK_200);
-            assertAccess(() -> control.delete(run), Status.OK_200);
-        } finally {
-            control.closeResource();
-            server.stop();
-        }
+        assertAccess(() -> control.get(run), Status.OK_200);
+        assertAccess(() -> control.delete(run), Status.OK_200);
     }
 
     private static void assertAccess(Supplier<Http1ClientRequest> request, Status operatorStatus) {

--- a/extensions/chaos/tests/extension/src/test/java/io/helidon/extensions/chaos/tests/extension/ChaosSecurityIT.java
+++ b/extensions/chaos/tests/extension/src/test/java/io/helidon/extensions/chaos/tests/extension/ChaosSecurityIT.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos.tests.extension;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.function.Supplier;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.http.HeaderNames;
+import io.helidon.http.Status;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonParser;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webclient.http1.Http1ClientRequest;
+import io.helidon.webserver.WebServer;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class ChaosSecurityIT {
+
+    private static final String RUNS = "/chaos/v1/runs";
+
+    @Test
+    void protectsEveryControlRouteWithAuthenticationAndOperatorRole() {
+        Config config = Config.just(ConfigSources.classpath("security-application.yaml"));
+        WebServer server = WebServer.builder()
+                .config(config.get("server"))
+                .build()
+                .start();
+        Http1Client control = Http1Client.builder()
+                .baseUri("http://127.0.0.1:" + server.port("chaos-control"))
+                .build();
+        try {
+            assertAccess(() -> control.get(RUNS), Status.OK_200);
+            JsonObject created = assertCreateAccess(control);
+            assertThat(created.stringValue("actor").orElseThrow(), is("operator"));
+            String run = RUNS + "/" + created.stringValue("id").orElseThrow();
+
+            assertAccess(() -> control.get(run), Status.OK_200);
+            assertAccess(() -> control.delete(run), Status.OK_200);
+        } finally {
+            control.closeResource();
+            server.stop();
+        }
+    }
+
+    private static void assertAccess(Supplier<Http1ClientRequest> request, Status operatorStatus) {
+        assertThat(request.get().request().status(), is(Status.UNAUTHORIZED_401));
+        assertThat(observer(request.get()).request().status(), is(Status.FORBIDDEN_403));
+        assertThat(operator(request.get()).request().status(), is(operatorStatus));
+    }
+
+    private static JsonObject assertCreateAccess(Http1Client control) {
+        assertThat(control.post(RUNS)
+                           .contentType(MediaTypes.APPLICATION_JSON)
+                           .submit(plan())
+                           .status(),
+                   is(Status.UNAUTHORIZED_401));
+        assertThat(observer(control.post(RUNS).contentType(MediaTypes.APPLICATION_JSON))
+                           .submit(plan())
+                           .status(),
+                   is(Status.FORBIDDEN_403));
+        var response = operator(control.post(RUNS).contentType(MediaTypes.APPLICATION_JSON))
+                .submit(plan(), String.class);
+        assertThat(response.status(), is(Status.CREATED_201));
+        return JsonParser.create(response.entity()).readJsonObject();
+    }
+
+    private static Http1ClientRequest observer(Http1ClientRequest request) {
+        return basic(request, "observer", "observer-password");
+    }
+
+    private static Http1ClientRequest operator(Http1ClientRequest request) {
+        return basic(request, "operator", "operator-password");
+    }
+
+    private static Http1ClientRequest basic(Http1ClientRequest request, String login, String password) {
+        String value = Base64.getEncoder()
+                .encodeToString((login + ":" + password).getBytes(StandardCharsets.UTF_8));
+        return request.header(HeaderNames.AUTHORIZATION, "Basic " + value);
+    }
+
+    private static JsonObject plan() {
+        return JsonParser.create("""
+                {
+                  "name": "security-contract",
+                  "maximumDuration": "PT30S",
+                  "stages": [{
+                    "name": "reject-orders",
+                    "duration": "PT10S",
+                    "disruptions": [{
+                      "name": "orders-503",
+                      "scope": {
+                        "type": "inbound-http",
+                        "methods": ["GET"],
+                        "path": {"match": "prefix", "value": "/orders"}
+                      },
+                      "activation": {"type": "always"},
+                      "effect": {"type": "synthetic-http-response", "status": 503},
+                      "budget": {"maximumActivations": 1, "maximumConcurrent": 1}
+                    }]
+                  }]
+                }
+                """).readJsonObject();
+    }
+}

--- a/extensions/chaos/tests/extension/src/test/java/io/helidon/extensions/chaos/tests/extension/ChaosServerLifecycleIT.java
+++ b/extensions/chaos/tests/extension/src/test/java/io/helidon/extensions/chaos/tests/extension/ChaosServerLifecycleIT.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.helidon.extensions.chaos.tests.extension;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.http.Status;
+import io.helidon.json.JsonArray;
+import io.helidon.json.JsonObject;
+import io.helidon.json.JsonParser;
+import io.helidon.webclient.http1.Http1Client;
+import io.helidon.webserver.WebServer;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+class ChaosServerLifecycleIT {
+    private static final String CONTROL_SOCKET = "chaos-control";
+    private static final String RUNS = "/chaos/v1/runs";
+
+    @Test
+    void restartDoesNotReconstructRuns() {
+        // This contract requires two distinct server lifecycles; @ServerTest owns one per test class.
+        WebServer first = startServer();
+        Http1Client firstControl = client(first.port(CONTROL_SOCKET));
+        try {
+            postRun(firstControl);
+            assertThat(firstControl.get(RUNS).request(JsonArray.class).entity().size(), is(1));
+        } finally {
+            firstControl.closeResource();
+            first.stop();
+        }
+
+        WebServer second = startServer();
+        Http1Client secondControl = client(second.port(CONTROL_SOCKET));
+        try {
+            assertThat(secondControl.get(RUNS).request(JsonArray.class).entity().size(), is(0));
+        } finally {
+            secondControl.closeResource();
+            second.stop();
+        }
+    }
+
+    private static WebServer startServer() {
+        Config config = Config.just(ConfigSources.classpath("application.yaml"));
+        return WebServer.builder()
+                .config(config.get("server"))
+                .build()
+                .start();
+    }
+
+    private static Http1Client client(int port) {
+        return Http1Client.builder()
+                .baseUri("http://127.0.0.1:" + port)
+                .build();
+    }
+
+    private static void postRun(Http1Client control) {
+        var response = control.post(RUNS)
+                .contentType(MediaTypes.APPLICATION_JSON)
+                .submit(plan(), JsonObject.class);
+        assertThat(response.status(), is(Status.CREATED_201));
+    }
+
+    private static JsonObject plan() {
+        return JsonParser.create("""
+                {
+                  "name": "restart-contract",
+                  "maximumDuration": "PT30S",
+                  "stages": [{
+                    "name": "reject-orders",
+                    "duration": "PT10S",
+                    "disruptions": [{
+                      "name": "orders-503",
+                      "scope": {
+                        "type": "inbound-http",
+                        "methods": ["GET"],
+                        "path": {"match": "prefix", "value": "/orders"}
+                      },
+                      "activation": {"type": "always"},
+                      "effect": {"type": "synthetic-http-response", "status": 503},
+                      "budget": {"maximumActivations": 1, "maximumConcurrent": 1}
+                    }]
+                  }]
+                }
+                """).readJsonObject();
+    }
+}

--- a/extensions/chaos/tests/extension/src/test/resources/application.yaml
+++ b/extensions/chaos/tests/extension/src/test/resources/application.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+server:
+  host: 127.0.0.1
+  port: 0
+  sockets:
+    chaos-control:
+      host: 127.0.0.1
+      port: 0
+      max-payload-size: 65536
+  features:
+    chaos:
+      enabled: true
+      control-socket: chaos-control
+      application-sockets:
+        - "@default"
+      security:
+        allow-unauthenticated-loopback: true
+      limits:
+        maximum-run-duration: PT30S
+        maximum-activations-per-disruption: 20
+        maximum-concurrent-activations-per-disruption: 2

--- a/extensions/chaos/tests/extension/src/test/resources/application.yaml
+++ b/extensions/chaos/tests/extension/src/test/resources/application.yaml
@@ -28,7 +28,7 @@ server:
       application-sockets:
         - "@default"
       security:
-        allow-unauthenticated-loopback: true
+        allow-unauthenticated-local: true
       limits:
         maximum-run-duration: PT30S
         maximum-activations-per-disruption: 20

--- a/extensions/chaos/tests/extension/src/test/resources/security-application.yaml
+++ b/extensions/chaos/tests/extension/src/test/resources/security-application.yaml
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+server:
+  host: 127.0.0.1
+  port: 0
+  sockets:
+    chaos-control:
+      host: 127.0.0.1
+      port: 0
+      max-payload-size: 65536
+  features:
+    security:
+      security:
+        providers:
+          - http-basic-auth:
+              realm: chaos-test
+              users:
+                - login: operator
+                  password: operator-password
+                  roles:
+                    - chaos-operator
+                - login: observer
+                  password: observer-password
+                  roles:
+                    - observer
+    chaos:
+      enabled: true
+      control-socket: chaos-control
+      application-sockets:
+        - "@default"
+      security:
+        required-role: chaos-operator

--- a/extensions/chaos/tests/pom.xml
+++ b/extensions/chaos/tests/pom.xml
@@ -18,33 +18,28 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
-                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>io.helidon.extensions</groupId>
-        <artifactId>helidon-extensions-project</artifactId>
-        <version>1.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <groupId>io.helidon.extensions.chaos</groupId>
+        <artifactId>helidon-extensions-chaos-project</artifactId>
+        <version>27.0.0-SNAPSHOT</version>
     </parent>
-
-    <artifactId>helidon-extensions-modules-project</artifactId>
-
     <packaging>pom</packaging>
 
-    <name>Helidon Extensions Modules Project</name>
+    <groupId>io.helidon.extensions.chaos.tests</groupId>
+    <artifactId>helidon-extensions-chaos-tests-project</artifactId>
+    <name>Helidon Extensions Chaos Tests Project</name>
+
+    <properties>
+        <spotbugs.skip>true</spotbugs.skip>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.sources.skip>true</maven.sources.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+        <dependency-check.skip>true</dependency-check.skip>
+    </properties>
 
     <modules>
-        <module>chaos</module>
-        <module>hashicorp-vault</module>
-        <module>neo4j</module>
-        <module>oci-v3</module>
-        <module>langchain4j</module>
-        <module>eureka</module>
-        <module>crac</module>
-        <module>openapi-ui</module>
-        <module>openapi-generator</module>
-        <module>gson</module>
-        <module>toml</module>
+        <module>extension</module>
     </modules>
 </project>

--- a/extensions/chaos/tests/pom.xml
+++ b/extensions/chaos/tests/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>io.helidon.extensions.chaos</groupId>
         <artifactId>helidon-extensions-chaos-project</artifactId>
-        <version>27.0.0-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
Resolves #130

### Description

Adds the Helidon Chaos extension for Helidon 27. The extension is disabled by
default and provides a dedicated `/chaos/v1` control API for starting, listing,
inspecting, and stopping bounded, in-process chaos runs.

The initial slice supports selected inbound HTTP requests receiving a
`synthetic-http-response` (4xx/5xx), with deterministic `always` or
`probability` activation, request budgets, and server-enforced limits.

### Documentation

Documentation tracking: #NNN

Initial extension documentation is included in this PR:
`extensions/chaos/docs/README.md`
