### PR TITLE
Upgrade OpenAPI generator to Helidon 4.5.4

### DIFF
--- a/extensions/openapi-generator/docs/README.md
+++ b/extensions/openapi-generator/docs/README.md
@@ -58,7 +58,7 @@ The module is packaged as a thin jar. Runtime dependencies are copied to
 
 In the examples below, `4.0.0-SNAPSHOT` is the version of this extension artifact.
 The separate `helidonVersion` option controls which Helidon version is written
-into generated Maven and Gradle projects, and its current default is `4.5.2`.
+into generated Maven and Gradle projects, and its current default is `4.5.4`.
 The `javaVersion` option controls the generated Maven compiler source and target
 values and the generated Gradle Java toolchain version, and its current default is
 `21`.
@@ -93,7 +93,7 @@ Add the generator as a dependency of `openapi-generator-maven-plugin`:
                 <inputSpec>${project.basedir}/src/main/resources/openapi.yaml</inputSpec>
                 <output>${project.build.directory}/generated-sources/openapi</output>
                 <configOptions>
-                    <helidonVersion>4.5.2</helidonVersion>
+                    <helidonVersion>4.5.4</helidonVersion>
                     <javaVersion>21</javaVersion>
                     <apiPackage>com.example.api</apiPackage>
                     <modelPackage>com.example.model</modelPackage>
@@ -121,7 +121,7 @@ mvn generate-sources
 In that example:
 
 - `4.0.0-SNAPSHOT` is the version of `helidon-extensions-openapi-generator`
-- `4.5.2` is the Helidon version used in the generated project
+- `4.5.4` is the Helidon version used in the generated project
 
 ## CLI Usage
 
@@ -133,11 +133,11 @@ java -jar openapi-generator/modules/openapi-generator/target/helidon-extensions-
   -g helidon-declarative \
   -i /path/to/openapi.yaml \
   -o /path/to/output \
-  --additional-properties helidonVersion=4.5.2,javaVersion=21,apiPackage=com.example.api,modelPackage=com.example.model,invokerPackage=com.example
+  --additional-properties helidonVersion=4.5.4,javaVersion=21,apiPackage=com.example.api,modelPackage=com.example.model,invokerPackage=com.example
 ```
 
 Here again, the jar version (`4.0.0-SNAPSHOT`) is the generator version, while
-`helidonVersion=4.5.2` controls the generated Helidon dependencies and
+`helidonVersion=4.5.4` controls the generated Helidon dependencies and
 `javaVersion=21` controls the generated project Java compilation level.
 
 Example with the optional-list flag enabled:
@@ -148,7 +148,7 @@ java -jar openapi-generator/modules/openapi-generator/target/helidon-extensions-
   -g helidon-declarative \
   -i /path/to/openapi.yaml \
   -o /tmp/generated-openapi \
-  --additional-properties helidonVersion=4.5.2,avoidOptionalListParams=true
+  --additional-properties helidonVersion=4.5.4,avoidOptionalListParams=true
 ```
 
 ## Generator Options
@@ -157,7 +157,7 @@ Set these under Maven `<configOptions>` or CLI `--additional-properties`.
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `helidonVersion` | `4.5.2` | Helidon version written into generated Maven and Gradle builds |
+| `helidonVersion` | `4.5.4` | Helidon version written into generated Maven and Gradle builds |
 | `javaVersion` | `21` | Java version written into generated Maven compiler source/target and Gradle toolchain builds |
 | `apiPackage` | `io.helidon.example.api` | Package for generated API, endpoint, client, and error classes |
 | `modelPackage` | `io.helidon.example.model` | Package for generated model classes |

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/cascading-validation-mapped-containers/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/cascading-validation-mapped-containers/pom.xml
@@ -30,7 +30,7 @@
     <name>OpenAPI Generator IT Cascading Validation Mapped Containers</name>
 
     <properties>
-        <helidon.version>4.5.3</helidon.version>
+        <helidon.version>4.5.4</helidon.version>
         <inputSpec>${project.basedir}/../../specs/cascading-validation-mapped-containers.yaml</inputSpec>
         <skipGeneratedTests>false</skipGeneratedTests>
     </properties>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/cascading-validation/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/cascading-validation/pom.xml
@@ -30,7 +30,7 @@
     <name>OpenAPI Generator IT Cascading Validation</name>
 
     <properties>
-        <helidon.version>4.5.3</helidon.version>
+        <helidon.version>4.5.4</helidon.version>
         <inputSpec>${project.basedir}/../../specs/cascading-validation.yaml</inputSpec>
         <skipGeneratedTests>false</skipGeneratedTests>
     </properties>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/json-string-enums/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/json-string-enums/pom.xml
@@ -30,7 +30,7 @@
     <name>OpenAPI Generator IT JSON String Enums</name>
 
     <properties>
-        <helidon.version>4.5.3</helidon.version>
+        <helidon.version>4.5.4</helidon.version>
         <inputSpec>${project.basedir}/../../specs/json-string-enums.yaml</inputSpec>
         <skipGeneratedTests>false</skipGeneratedTests>
     </properties>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <!-- Compatibility baseline; feature-specific modules override this when they require Helidon 4.5. -->
-        <helidon.version>4.5.3</helidon.version>
+        <helidon.version>4.5.4</helidon.version>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mainClass>io.helidon.example.Main</mainClass>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/swagger2-contracts/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/swagger2-contracts/pom.xml
@@ -30,7 +30,7 @@
     <name>OpenAPI Generator IT Swagger 2 Contracts</name>
 
     <properties>
-        <helidon.version>4.5.3</helidon.version>
+        <helidon.version>4.5.4</helidon.version>
         <inputSpec>${project.basedir}/../../specs/swagger2-contracts.yaml</inputSpec>
         <skipGeneratedTests>false</skipGeneratedTests>
     </properties>

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -111,7 +111,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
     static final String OPT_DISCRIMINATOR_REPRESENTATION = "discriminatorRepresentation";
     private static final String EXT_DISCRIMINATOR_REPRESENTATION =
             "x-helidon-discriminator-representation";
-    private String helidonVersion = "4.5.2";
+    private String helidonVersion = "4.5.4";
     private String javaVersion = "21";
     private boolean generateClient = true;
     private boolean generateErrorHandler = true;

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/CascadingValidationGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/CascadingValidationGenerationIT.java
@@ -515,7 +515,7 @@ class CascadingValidationGenerationIT {
                 .setGeneratorName("helidon-declarative")
                 .setInputSpec(inputSpec)
                 .setOutputDir(target.toString())
-                .addAdditionalProperty("helidonVersion", "4.5.2")
+                .addAdditionalProperty("helidonVersion", "4.5.4")
                 .addAdditionalProperty("apiPackage", "io.helidon.example.api")
                 .addAdditionalProperty("modelPackage", "io.helidon.example.model")
                 .addAdditionalProperty("invokerPackage", "io.helidon.example");

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/JsonStringEnumGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/JsonStringEnumGenerationIT.java
@@ -185,8 +185,8 @@ class JsonStringEnumGenerationIT {
 
     @Test
     void generatedProjectUsesLatestHelidonReleaseByDefault() throws IOException {
-        assertThat(read(outputDir.resolve("pom.xml")), containsString("<helidon.version>4.5.2</helidon.version>"));
-        assertThat(read(outputDir.resolve("build.gradle")), containsString("def helidonVersion = '4.5.2'"));
+        assertThat(read(outputDir.resolve("pom.xml")), containsString("<helidon.version>4.5.4</helidon.version>"));
+        assertThat(read(outputDir.resolve("build.gradle")), containsString("def helidonVersion = '4.5.4'"));
     }
 
     @Test

--- a/extensions/openapi-generator/pom.xml
+++ b/extensions/openapi-generator/pom.xml
@@ -42,8 +42,8 @@
     </modules>
 
     <properties>
-        <!-- Compatibility baseline for building the generator; generated projects default to 4.5.3. -->
-        <helidon.version>4.5.3</helidon.version>
+        <!-- Compatibility baseline for building the generator; generated projects default to 4.5.4. -->
+        <helidon.version>4.5.4</helidon.version>
         <version.java>21</version.java>
 
         <version.lib.openapi-generator>7.11.0</version.lib.openapi-generator>


### PR DESCRIPTION
## Summary

- Upgrade the OpenAPI Generator extension’s Helidon baseline from 4.5.3 to 4.5.4.
- Align its generated-project integration-test POM overrides with 4.5.4.

## Testing

- `mvn -pl extensions/openapi-generator/modules/openapi-generator -am verify -DskipTests`