### PR TITLE
Support configurable LangChain4j A2A agents

### DIFF
--- a/extensions/langchain4j/bom/pom.xml
+++ b/extensions/langchain4j/bom/pom.xml
@@ -37,6 +37,7 @@
 
     <properties>
         <langchain4j.extension.version>27.0.0-SNAPSHOT</langchain4j.extension.version>
+        <version.lib.langchain4j-agentic-a2a>1.18.1-beta28</version.lib.langchain4j-agentic-a2a>
     </properties>
 
     <dependencyManagement>
@@ -50,6 +51,11 @@
                 <groupId>io.helidon.extensions.langchain4j</groupId>
                 <artifactId>helidon-extensions-langchain4j-codegen</artifactId>
                 <version>${langchain4j.extension.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>dev.langchain4j</groupId>
+                <artifactId>langchain4j-agentic-a2a</artifactId>
+                <version>${version.lib.langchain4j-agentic-a2a}</version>
             </dependency>
             <dependency>
                 <groupId>io.helidon.extensions.langchain4j.providers</groupId>

--- a/extensions/langchain4j/docs/config/io.helidon.extensions.langchain4j.AgentsConfig.md
+++ b/extensions/langchain4j/docs/config/io.helidon.extensions.langchain4j.AgentsConfig.md
@@ -19,6 +19,17 @@ Configuration for a single LangChain4j agent
 <tbody>
 <tr>
 <td>
+<code>a2a-<wbr>server-<wbr>url</code>
+</td>
+<td>
+<code>String</code>
+</td>
+<td>
+</td>
+<td>URL of the remote A2A agent server</td>
+</tr>
+<tr>
+<td>
 <code>chat-<wbr>model</code>
 </td>
 <td>

--- a/extensions/langchain4j/docs/config/io.helidon.extensions.langchain4j.AgentsConfig.md
+++ b/extensions/langchain4j/docs/config/io.helidon.extensions.langchain4j.AgentsConfig.md
@@ -26,7 +26,7 @@ Configuration for a single LangChain4j agent
 </td>
 <td>
 </td>
-<td>URL of the remote A2A agent server</td>
+<td>URL of the remote A2A agent server; when configured, it must be a non-blank absolute HTTP or HTTPS URI with a host, no user info or fragment, and a numeric port from 0 through 65535 when present</td>
 </tr>
 <tr>
 <td>

--- a/extensions/langchain4j/docs/langchain4j.md
+++ b/extensions/langchain4j/docs/langchain4j.md
@@ -453,6 +453,65 @@ entries, for example to replace a chat model or adjust an output key.
 
 ![LangChain4j agents in Helidon](images/agents.svg)
 
+#### Remote A2A Agents
+
+The optional LangChain4j A2A module allows a Helidon agent to delegate to a
+remote agent using the Agent2Agent protocol. Add the following dependency; its
+version is managed by the Helidon LangChain4j extension BOM:
+
+```xml
+<dependency>
+    <groupId>dev.langchain4j</groupId>
+    <artifactId>langchain4j-agentic-a2a</artifactId>
+</dependency>
+```
+
+Define the remote agent as a normal named Helidon agent and annotate its method
+with LangChain4j `@A2AClientAgent`:
+
+```java
+@Ai.Agent("remote-writer")
+public interface RemoteWriter {
+
+    @A2AClientAgent(a2aServerUrl = "https://writer.example.com",
+                    outputKey = "draft",
+                    async = true)
+    String write(@V("topic") String topic);
+}
+```
+
+The A2A URL, output key, and asynchronous execution setting can be overridden
+without recompiling the application:
+
+```yaml
+langchain4j:
+  agents:
+    remote-writer:
+      a2a-server-url: http://writer.internal:8080
+      output-key: story
+      async: false
+```
+
+Configuration takes precedence over `@A2AClientAgent` values. If
+`a2a-server-url` is not configured, Helidon retains LangChain4j's normal URL
+resolution through the annotation or an `@A2AServerUrlSupplier` method. Remote
+agents are available as top-level Helidon services and can also participate as
+subagents in declarative sequence, loop, conditional, and other composed
+workflows. A remote A2A agent does not require a local chat model.
+Configuration overrides do not mask invalid annotation declarations that set
+mutually exclusive URL or output-key sources.
+
+> [!NOTE]
+> LangChain4j applies `@A2AClientCustomizer` after it discovers the remote
+> Agent Card. The customizer therefore cannot add authentication or TLS
+> customization to that initial discovery request.
+
+> [!WARNING]
+> The A2A Java SDK used by this version contains a split package across its
+> `common` and `spec` artifacts. Use the A2A integration on the class path;
+> named JPMS applications are not supported until the upstream SDK resolves
+> that module-path conflict.
+
 #### Agentic Workflow
 
 Helidon supports LangChain4j declarative agentic workflows such as sequence and

--- a/extensions/langchain4j/docs/langchain4j.md
+++ b/extensions/langchain4j/docs/langchain4j.md
@@ -487,24 +487,29 @@ without recompiling the application:
 langchain4j:
   agents:
     remote-writer:
-      a2a-server-url: http://writer.internal:8080
+      a2a-server-url: https://writer.internal:8443
       output-key: story
       async: false
 ```
 
 Configuration takes precedence over `@A2AClientAgent` values. If
-`a2a-server-url` is not configured, Helidon retains LangChain4j's normal URL
-resolution through the annotation or an `@A2AServerUrlSupplier` method. Remote
-agents are available as top-level Helidon services and can also participate as
-subagents in declarative sequence, loop, conditional, and other composed
-workflows. A remote A2A agent does not require a local chat model.
-Configuration overrides do not mask invalid annotation declarations that set
-mutually exclusive URL or output-key sources.
+`a2a-server-url` is configured, it must be a non-blank absolute `http` or
+`https` URI with a host. It must not contain user information or a fragment,
+and any explicit port must be numeric and in the range `0` through `65535`.
+Paths and query strings are allowed. These restrictions apply only to the
+Helidon configuration override. Without an override, Helidon passes the URL
+declared by `@A2AClientAgent` or returned by `@A2AServerUrlSupplier` unchanged
+to LangChain4j's selected A2A service. Remote agents are available as top-level
+Helidon services and can also participate as subagents in declarative sequence,
+loop, conditional, and other composed workflows. A remote A2A agent does not
+require a local chat model. Configuration overrides do not mask invalid
+annotation declarations that set mutually exclusive URL or output-key sources.
 
 > [!NOTE]
-> LangChain4j applies `@A2AClientCustomizer` after it discovers the remote
-> Agent Card. The customizer therefore cannot add authentication or TLS
-> customization to that initial discovery request.
+> For HTTPS endpoints, the discovery connection must already trust the remote
+> server certificate. LangChain4j applies `@A2AClientCustomizer` after it
+> discovers the remote Agent Card, so the customizer cannot add authentication
+> or TLS customization to that initial discovery request.
 
 > [!WARNING]
 > The A2A Java SDK used by this version contains a split package across its

--- a/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/AgentCodegen.java
+++ b/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/AgentCodegen.java
@@ -17,6 +17,7 @@
 package io.helidon.extensions.langchain4j.codegen;
 
 import java.util.Collection;
+import java.util.Set;
 
 import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.CodegenUtil;
@@ -39,11 +40,13 @@ import static io.helidon.common.types.AccessModifier.PACKAGE_PRIVATE;
 import static io.helidon.common.types.AccessModifier.PRIVATE;
 import static io.helidon.common.types.TypeNames.CLASS_WILDCARD;
 import static io.helidon.common.types.TypeNames.STRING;
+import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.A2A_AGENT_CONFIG_SUPPORT;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AGENTS_CONFIG;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AGENT_METADATA;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AI_AGENT;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AI_CHAT_MODEL;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.CONFIG;
+import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_A2A_CLIENT_AGENT;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_AGENTIC_SERVICES;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_CHAT_MODEL;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.LC_DECLARATIVE_AGENT_CREATION_CONTEXT;
@@ -54,6 +57,14 @@ import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_REGISTRY;
 
 class AgentCodegen implements CodegenExtension {
     private static final TypeName GENERATOR = TypeName.create(AgentCodegen.class);
+    private static final Set<TypeName> COMPOSED_AGENT_ANNOTATIONS = Set.of(
+            TypeName.create("dev.langchain4j.agentic.declarative.SequenceAgent"),
+            TypeName.create("dev.langchain4j.agentic.declarative.LoopAgent"),
+            TypeName.create("dev.langchain4j.agentic.declarative.ConditionalAgent"),
+            TypeName.create("dev.langchain4j.agentic.declarative.ParallelAgent"),
+            TypeName.create("dev.langchain4j.agentic.declarative.ParallelMapperAgent"),
+            TypeName.create("dev.langchain4j.agentic.declarative.SupervisorAgent"),
+            TypeName.create("dev.langchain4j.agentic.declarative.PlannerAgent"));
     static final String AGENTS_CONFIG_KEY = "langchain4j.agents";
 
     @Override
@@ -79,6 +90,7 @@ class AgentCodegen implements CodegenExtension {
     private void process(RoundContext roundCtx, TypeInfo agentInterface) {
         TypeName agentInterfaceType = agentInterface.typeName();
         TypeName generatedType = generatedTypeName(agentInterfaceType, "AiAgent");
+        boolean a2aAgent = isA2AAgent(agentInterface);
         AgentMetadataSupplierBuilder.build(agentInterface, roundCtx);
 
         var classModel = ClassModel.builder()
@@ -109,58 +121,71 @@ class AgentCodegen implements CodegenExtension {
                 .accessModifier(PRIVATE)
         );
 
-        classModel.addField(aiServices -> aiServices
-                .name("chatModel")
-                .type(LC_CHAT_MODEL)
-                .isFinal(true)
-                .accessModifier(PRIVATE)
-        );
+        if (!a2aAgent) {
+            classModel.addField(aiServices -> aiServices
+                    .name("chatModel")
+                    .type(LC_CHAT_MODEL)
+                    .isFinal(true)
+                    .accessModifier(PRIVATE)
+            );
+        }
 
         // constructor (parameters depend on annotations on interface)
         classModel.addConstructor(ctr -> ctr
                 .accessModifier(AccessModifier.PACKAGE_PRIVATE)
                 .addAnnotation(Annotation.create(ServiceCodegenTypes.SERVICE_ANNOTATION_INJECT))
                 .update(it -> {
-                    aiAgentsParameter(it,
-                                      true,
-                                      agentInterface,
-                                      AI_CHAT_MODEL,
-                                      LC_CHAT_MODEL,
-                                      "chatModel");
+                    if (a2aAgent) {
+                        agentBaseParameters(it);
+                    } else {
+                        aiAgentsParameter(it,
+                                          true,
+                                          agentInterface,
+                                          AI_CHAT_MODEL,
+                                          LC_CHAT_MODEL,
+                                          "chatModel");
+                    }
                 })
         );
 
         // and the get method (implementation of supplier)
-        classModel.addMethod(get -> get
-                .accessModifier(AccessModifier.PUBLIC)
-                .addAnnotation(Annotations.OVERRIDE)
-                .returnType(agentInterfaceType)
-                .name("get")
-                .addContent("var topAgentConfig = this.agenticConfig.get(")
-                .addContentLiteral(agentInterface.annotation(AI_AGENT).stringValue().orElseThrow())
-                .addContentLine(");")
-                .addContent("var configuredModel = topAgentConfig")
-                .addContent(".get(")
-                .addContentLiteral("chat-model")
-                .addContentLine(")")
-                .increaseContentPadding()
-                .addContentLine(".asString()")
-                .addContent(".map(n -> registry.getNamed(ChatModel.class, n))")
-                .addContentLine(".orElse(chatModel);")
-                .decreaseContentPadding()
-                .addContent("return ")
-                .addContent(LC_AGENTIC_SERVICES)
-                .addContent(".createAgenticSystem(")
-                .addContent(agentInterfaceType)
-                .addContent(".class, ")
-                .addContent("configuredModel, new ")
-                .addContent(LC_AGENTIC_SERVICES)
-                .addContent(".AgentConfigurator(this")
-                .addContentLine("::configureSubAgents, null, null));")
-                .addContentLine("")
-        );
+        classModel.addMethod(get -> {
+            get.accessModifier(AccessModifier.PUBLIC)
+                    .addAnnotation(Annotations.OVERRIDE)
+                    .returnType(agentInterfaceType)
+                    .name("get")
+                    .addContent("var agentsConfig = agentsConfig(")
+                    .addContent(agentInterfaceType)
+                    .addContentLine(".class);");
+            if (a2aAgent) {
+                get.addContent("return ")
+                        .addContent(A2A_AGENT_CONFIG_SUPPORT)
+                        .addContent(".create(")
+                        .addContent(agentInterfaceType)
+                        .addContentLine(".class, agentsConfig);");
+            } else {
+                get.addContent("var configuredModel = agentsConfig.chatModel()")
+                        .increaseContentPadding()
+                        .addContentLine()
+                        .addContentLine(".map(n -> registry.getNamed(ChatModel.class, n))")
+                        .addContentLine(".orElse(chatModel);")
+                        .decreaseContentPadding()
+                        .addContent("return ")
+                        .addContent(LC_AGENTIC_SERVICES)
+                        .addContent(".createAgenticSystem(")
+                        .addContent(agentInterfaceType)
+                        .addContent(".class, ")
+                        .addContent("configuredModel, new ")
+                        .addContent(LC_AGENTIC_SERVICES)
+                        .addContent(".AgentConfigurator(this")
+                        .addContentLine("::configureSubAgents, this::resolveSubAgent, null));")
+                        .addContentLine("");
+            }
+        });
 
+        classModel.addMethod(this::addAgentsConfigMethod);
         classModel.addMethod(this::addConfigureSubAgentsMethod);
+        classModel.addMethod(this::addResolveSubAgentMethod);
 
         roundCtx.addGeneratedType(generatedType, classModel, agentInterfaceType, agentInterface.originatingElementValue());
     }
@@ -171,21 +196,7 @@ class AgentCodegen implements CodegenExtension {
                                    TypeName aiModelAnnotation,
                                    TypeName lcModelType,
                                    String aiServicesMethodName) {
-
-        ctr.addParameter(Parameter.builder()
-                                 .type(CONFIG)
-                                 .name("config")
-                                 .build());
-
-        ctr.addParameter(Parameter.builder()
-                                 .type(SERVICE_REGISTRY)
-                                 .name("registry")
-                                 .build());
-
-        ctr.addContent("this.agenticConfig = config.get(")
-                .addContentLiteral(AGENTS_CONFIG_KEY)
-                .addContentLine(");");
-        ctr.addContentLine("this.registry = registry;");
+        agentBaseParameters(ctr);
 
         // if annotated, we have a named value (and that is mandatory)
         String modelName = aiInterface.findAnnotation(aiModelAnnotation)
@@ -218,18 +229,32 @@ class AgentCodegen implements CodegenExtension {
         }
     }
 
-    private void addConfigureSubAgentsMethod(Method.Builder mb) {
-        mb
-                .accessModifier(PACKAGE_PRIVATE)
+    private void agentBaseParameters(Constructor.Builder ctr) {
+        ctr.addParameter(Parameter.builder()
+                                 .type(CONFIG)
+                                 .name("config")
+                                 .build());
+
+        ctr.addParameter(Parameter.builder()
+                                 .type(SERVICE_REGISTRY)
+                                 .name("registry")
+                                 .build());
+
+        ctr.addContent("this.agenticConfig = config.get(")
+                .addContentLiteral(AGENTS_CONFIG_KEY)
+                .addContentLine(");");
+        ctr.addContentLine("this.registry = registry;");
+    }
+
+    private void addAgentsConfigMethod(Method.Builder mb) {
+        mb.accessModifier(PRIVATE)
+                .returnType(AGENTS_CONFIG)
                 .addParameter(Parameter.builder()
-                                      .name("ctx")
-                                      .type(LC_DECLARATIVE_AGENT_CREATION_CONTEXT)
+                                      .name("cls")
+                                      .type(CLASS_WILDCARD)
                                       .build())
-                .name("configureSubAgents")
-                .addContent(CLASS_WILDCARD)
-                .addContentLine(" cls = ctx.agentServiceClass();")
-                .addContentLine()
-                .addContentLine("// Get Agent metadata created from it's annotations in build-time")
+                .name("agentsConfig")
+                .addContentLine("// Get Agent metadata created from its annotations at build time")
                 .addContent("var metadata = registry.first(")
                 .addContent(AGENT_METADATA)
                 .addContent(".class, ")
@@ -243,20 +268,73 @@ class AgentCodegen implements CodegenExtension {
                 .addContent("+ cls +")
                 .addContentLiteral(" has no build time metadata available!")
                 .addContentLine("));")
-
                 .decreaseContentPadding()
                 .addContent(STRING)
                 .addContentLine(" agentName = metadata.agentName();")
                 .addContent("var agentsConfigBuilder = ")
                 .addContent(AGENTS_CONFIG)
-                .addContent(".builder(metadata.buildTimeConfig());")
-                .decreaseContentPadding()
-                .addContentLine()
-                .addContentLine()
-                .addContentLine("// Override annotation setup with config")
+                .addContentLine(".builder(metadata.buildTimeConfig());")
                 .addContentLine("agentsConfigBuilder.config(agenticConfig.get(agentName));")
-                .addContentLine("var agentsConfig = agentsConfigBuilder.build();")
-                .addContentLine("agentsConfig.configure(ctx, registry);");
+                .addContentLine("return agentsConfigBuilder.build();");
+    }
+
+    private void addConfigureSubAgentsMethod(Method.Builder mb) {
+        mb
+                .accessModifier(PACKAGE_PRIVATE)
+                .addParameter(Parameter.builder()
+                                      .name("ctx")
+                                      .type(LC_DECLARATIVE_AGENT_CREATION_CONTEXT)
+                                      .build())
+                .name("configureSubAgents")
+                .addContent(CLASS_WILDCARD)
+                .addContentLine(" cls = ctx.agentServiceClass();")
+                .addContentLine("agentsConfig(cls).configure(ctx, registry);");
+    }
+
+    private void addResolveSubAgentMethod(Method.Builder mb) {
+        mb.accessModifier(PRIVATE)
+                .returnType(TypeNames.OBJECT)
+                .addParameter(Parameter.builder()
+                                      .name("cls")
+                                      .type(CLASS_WILDCARD)
+                                      .build())
+                .name("resolveSubAgent")
+                .addContent("if (!")
+                .addContent(A2A_AGENT_CONFIG_SUPPORT)
+                .addContentLine(".isA2A(cls)) {")
+                .increaseContentPadding()
+                .addContentLine("return null;")
+                .decreaseContentPadding()
+                .addContentLine("}")
+                .addContent("if (registry.first(")
+                .addContent(AGENT_METADATA)
+                .addContent(".class, ")
+                .addContent(SERVICE_QUALIFIER)
+                .addContentLine(".createNamed(cls)).isEmpty()) {")
+                .increaseContentPadding()
+                .addContentLine("return null;")
+                .decreaseContentPadding()
+                .addContentLine("}")
+                .addContentLine("// Each workflow needs a fresh A2A proxy because it carries mutable parent state")
+                .addContent("return ")
+                .addContent(A2A_AGENT_CONFIG_SUPPORT)
+                .addContentLine(".create(cls, agentsConfig(cls));");
+    }
+
+    private boolean isA2AAgent(TypeInfo typeInfo) {
+        return hasAnnotation(typeInfo, LC_A2A_CLIENT_AGENT)
+                && COMPOSED_AGENT_ANNOTATIONS.stream().noneMatch(annotation -> hasAnnotation(typeInfo, annotation));
+    }
+
+    private boolean hasAnnotation(TypeInfo typeInfo, TypeName annotation) {
+        if (typeInfo.elementInfo()
+                .stream()
+                .anyMatch(element -> element.hasAnnotation(annotation))) {
+            return true;
+        }
+        return typeInfo.interfaceTypeInfo()
+                .stream()
+                .anyMatch(interfaceType -> hasAnnotation(interfaceType, annotation));
     }
 
     private TypeName generatedTypeName(TypeName aiInterfaceType, String suffix) {

--- a/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/AgentCodegen.java
+++ b/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/AgentCodegen.java
@@ -178,8 +178,8 @@ class AgentCodegen implements CodegenExtension {
                     .addContentLine("");
         });
 
-        classModel.addMethod(this::addAgentsConfigMethod);
         classModel.addMethod(this::addConfigureSubAgentsMethod);
+        classModel.addMethod(this::addAgentsConfigMethod);
         classModel.addMethod(this::addIsA2AAgentMethod);
         classModel.addMethod(this::addResolveSubAgentMethod);
 

--- a/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/AgentCodegen.java
+++ b/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/AgentCodegen.java
@@ -40,7 +40,6 @@ import static io.helidon.common.types.AccessModifier.PACKAGE_PRIVATE;
 import static io.helidon.common.types.AccessModifier.PRIVATE;
 import static io.helidon.common.types.TypeNames.CLASS_WILDCARD;
 import static io.helidon.common.types.TypeNames.STRING;
-import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.A2A_AGENT_CONFIG_SUPPORT;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AGENTS_CONFIG;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AGENT_METADATA;
 import static io.helidon.extensions.langchain4j.codegen.LangchainTypes.AI_AGENT;
@@ -56,6 +55,7 @@ import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_QUALIFIER;
 import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_REGISTRY;
 
 class AgentCodegen implements CodegenExtension {
+    static final String AGENTS_CONFIG_KEY = "langchain4j.agents";
     private static final TypeName GENERATOR = TypeName.create(AgentCodegen.class);
     private static final Set<TypeName> COMPOSED_AGENT_ANNOTATIONS = Set.of(
             TypeName.create("dev.langchain4j.agentic.declarative.SequenceAgent"),
@@ -65,7 +65,6 @@ class AgentCodegen implements CodegenExtension {
             TypeName.create("dev.langchain4j.agentic.declarative.ParallelMapperAgent"),
             TypeName.create("dev.langchain4j.agentic.declarative.SupervisorAgent"),
             TypeName.create("dev.langchain4j.agentic.declarative.PlannerAgent"));
-    static final String AGENTS_CONFIG_KEY = "langchain4j.agents";
 
     @Override
     public void process(RoundContext roundCtx) {
@@ -158,11 +157,9 @@ class AgentCodegen implements CodegenExtension {
                     .addContent(agentInterfaceType)
                     .addContentLine(".class);");
             if (a2aAgent) {
-                get.addContent("return ")
-                        .addContent(A2A_AGENT_CONFIG_SUPPORT)
-                        .addContent(".create(")
+                get.addContent("return agentsConfig.createA2AAgent(")
                         .addContent(agentInterfaceType)
-                        .addContentLine(".class, agentsConfig);");
+                        .addContentLine(".class);");
             } else {
                 get.addContent("var configuredModel = agentsConfig.chatModel()")
                         .increaseContentPadding()
@@ -300,8 +297,8 @@ class AgentCodegen implements CodegenExtension {
                                       .build())
                 .name("resolveSubAgent")
                 .addContent("if (!")
-                .addContent(A2A_AGENT_CONFIG_SUPPORT)
-                .addContentLine(".isA2A(cls)) {")
+                .addContent(AGENTS_CONFIG)
+                .addContentLine(".isA2ASubAgent(cls)) {")
                 .increaseContentPadding()
                 .addContentLine("return null;")
                 .decreaseContentPadding()
@@ -316,9 +313,7 @@ class AgentCodegen implements CodegenExtension {
                 .decreaseContentPadding()
                 .addContentLine("}")
                 .addContentLine("// Each workflow needs a fresh A2A proxy because it carries mutable parent state")
-                .addContent("return ")
-                .addContent(A2A_AGENT_CONFIG_SUPPORT)
-                .addContentLine(".create(cls, agentsConfig(cls));");
+                .addContentLine("return agentsConfig(cls).createA2AAgent(cls);");
     }
 
     private boolean isA2AAgent(TypeInfo typeInfo) {

--- a/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/AgentCodegen.java
+++ b/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/AgentCodegen.java
@@ -17,7 +17,7 @@
 package io.helidon.extensions.langchain4j.codegen;
 
 import java.util.Collection;
-import java.util.Set;
+import java.util.List;
 
 import io.helidon.codegen.CodegenException;
 import io.helidon.codegen.CodegenUtil;
@@ -57,7 +57,9 @@ import static io.helidon.service.codegen.ServiceCodegenTypes.SERVICE_REGISTRY;
 class AgentCodegen implements CodegenExtension {
     static final String AGENTS_CONFIG_KEY = "langchain4j.agents";
     private static final TypeName GENERATOR = TypeName.create(AgentCodegen.class);
-    private static final Set<TypeName> COMPOSED_AGENT_ANNOTATIONS = Set.of(
+    private static final TypeName LC_HUMAN_IN_THE_LOOP =
+            TypeName.create("dev.langchain4j.agentic.declarative.HumanInTheLoop");
+    private static final List<TypeName> COMPOSED_AGENT_ANNOTATIONS = List.of(
             TypeName.create("dev.langchain4j.agentic.declarative.SequenceAgent"),
             TypeName.create("dev.langchain4j.agentic.declarative.LoopAgent"),
             TypeName.create("dev.langchain4j.agentic.declarative.ConditionalAgent"),
@@ -182,6 +184,7 @@ class AgentCodegen implements CodegenExtension {
 
         classModel.addMethod(this::addAgentsConfigMethod);
         classModel.addMethod(this::addConfigureSubAgentsMethod);
+        classModel.addMethod(this::addIsA2ASubAgentMethod);
         classModel.addMethod(this::addResolveSubAgentMethod);
 
         roundCtx.addGeneratedType(generatedType, classModel, agentInterfaceType, agentInterface.originatingElementValue());
@@ -288,6 +291,43 @@ class AgentCodegen implements CodegenExtension {
                 .addContentLine("agentsConfig(cls).configure(ctx, registry);");
     }
 
+    private void addIsA2ASubAgentMethod(Method.Builder mb) {
+        mb.accessModifier(PRIVATE)
+                .returnType(TypeNames.PRIMITIVE_BOOLEAN)
+                .addParameter(Parameter.builder()
+                                      .name("agentType")
+                                      .type(CLASS_WILDCARD)
+                                      .build())
+                .name("isA2ASubAgent")
+                .addContentLine("boolean a2a = false;")
+                .addContentLine("for (var method : agentType.getMethods()) {")
+                .increaseContentPadding();
+        for (TypeName annotation : COMPOSED_AGENT_ANNOTATIONS) {
+            addHigherPrecedenceAnnotationCheck(mb, annotation);
+        }
+        addHigherPrecedenceAnnotationCheck(mb, LC_HUMAN_IN_THE_LOOP);
+        mb.addContent("if (method.isAnnotationPresent(")
+                .addContent(LC_A2A_CLIENT_AGENT)
+                .addContentLine(".class)) {")
+                .increaseContentPadding()
+                .addContentLine("a2a = true;")
+                .decreaseContentPadding()
+                .addContentLine("}")
+                .decreaseContentPadding()
+                .addContentLine("}")
+                .addContentLine("return a2a;");
+    }
+
+    private void addHigherPrecedenceAnnotationCheck(Method.Builder mb, TypeName annotation) {
+        mb.addContent("if (method.isAnnotationPresent(")
+                .addContent(annotation)
+                .addContentLine(".class)) {")
+                .increaseContentPadding()
+                .addContentLine("return false;")
+                .decreaseContentPadding()
+                .addContentLine("}");
+    }
+
     private void addResolveSubAgentMethod(Method.Builder mb) {
         mb.accessModifier(PRIVATE)
                 .returnType(TypeNames.OBJECT)
@@ -296,9 +336,7 @@ class AgentCodegen implements CodegenExtension {
                                       .type(CLASS_WILDCARD)
                                       .build())
                 .name("resolveSubAgent")
-                .addContent("if (!")
-                .addContent(AGENTS_CONFIG)
-                .addContentLine(".isA2ASubAgent(cls)) {")
+                .addContentLine("if (!isA2ASubAgent(cls)) {")
                 .increaseContentPadding()
                 .addContentLine("return null;")
                 .decreaseContentPadding()

--- a/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/AgentCodegen.java
+++ b/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/AgentCodegen.java
@@ -91,7 +91,6 @@ class AgentCodegen implements CodegenExtension {
     private void process(RoundContext roundCtx, TypeInfo agentInterface) {
         TypeName agentInterfaceType = agentInterface.typeName();
         TypeName generatedType = generatedTypeName(agentInterfaceType, "AiAgent");
-        boolean a2aAgent = isA2AAgent(agentInterface);
         AgentMetadataSupplierBuilder.build(agentInterface, roundCtx);
 
         var classModel = ClassModel.builder()
@@ -122,31 +121,23 @@ class AgentCodegen implements CodegenExtension {
                 .accessModifier(PRIVATE)
         );
 
-        if (!a2aAgent) {
-            classModel.addField(aiServices -> aiServices
-                    .name("chatModel")
-                    .type(LC_CHAT_MODEL)
-                    .isFinal(true)
-                    .accessModifier(PRIVATE)
-            );
-        }
+        classModel.addField(aiServices -> aiServices
+                .name("chatModel")
+                .type(supplierType(optionalType(LC_CHAT_MODEL)))
+                .isFinal(true)
+                .accessModifier(PRIVATE)
+        );
 
         // constructor (parameters depend on annotations on interface)
         classModel.addConstructor(ctr -> ctr
                 .accessModifier(AccessModifier.PACKAGE_PRIVATE)
                 .addAnnotation(Annotation.create(ServiceCodegenTypes.SERVICE_ANNOTATION_INJECT))
-                .update(it -> {
-                    if (a2aAgent) {
-                        agentBaseParameters(it);
-                    } else {
-                        aiAgentsParameter(it,
-                                          true,
-                                          agentInterface,
-                                          AI_CHAT_MODEL,
-                                          LC_CHAT_MODEL,
-                                          "chatModel");
-                    }
-                })
+                .update(it -> aiAgentsParameter(it,
+                                                true,
+                                                agentInterface,
+                                                AI_CHAT_MODEL,
+                                                LC_CHAT_MODEL,
+                                                "chatModel"))
         );
 
         // and the get method (implementation of supplier)
@@ -158,33 +149,38 @@ class AgentCodegen implements CodegenExtension {
                     .addContent("var agentsConfig = agentsConfig(")
                     .addContent(agentInterfaceType)
                     .addContentLine(".class);");
-            if (a2aAgent) {
-                get.addContent("return agentsConfig.createA2AAgent(")
-                        .addContent(agentInterfaceType)
-                        .addContentLine(".class);");
-            } else {
-                get.addContent("var configuredModel = agentsConfig.chatModel()")
-                        .increaseContentPadding()
-                        .addContentLine()
-                        .addContentLine(".map(n -> registry.getNamed(ChatModel.class, n))")
-                        .addContentLine(".orElse(chatModel);")
-                        .decreaseContentPadding()
-                        .addContent("return ")
-                        .addContent(LC_AGENTIC_SERVICES)
-                        .addContent(".createAgenticSystem(")
-                        .addContent(agentInterfaceType)
-                        .addContent(".class, ")
-                        .addContent("configuredModel, new ")
-                        .addContent(LC_AGENTIC_SERVICES)
-                        .addContent(".AgentConfigurator(this")
-                        .addContentLine("::configureSubAgents, this::resolveSubAgent, null));")
-                        .addContentLine("");
-            }
+            get.addContent("if (isA2AAgent(")
+                    .addContent(agentInterfaceType)
+                    .addContentLine(".class, false)) {")
+                    .increaseContentPadding()
+                    .addContent("return agentsConfig.createA2AAgent(")
+                    .addContent(agentInterfaceType)
+                    .addContentLine(".class);")
+                    .decreaseContentPadding()
+                    .addContentLine("}")
+                    .addContent("var configuredModel = agentsConfig.chatModel()")
+                    .increaseContentPadding()
+                    .addContentLine()
+                    .addContent(".map(n -> registry.getNamed(")
+                    .addContent(LC_CHAT_MODEL)
+                    .addContentLine(".class, n))")
+                    .addContentLine(".orElseGet(() -> chatModel.get().orElse(null));")
+                    .decreaseContentPadding()
+                    .addContent("return ")
+                    .addContent(LC_AGENTIC_SERVICES)
+                    .addContent(".createAgenticSystem(")
+                    .addContent(agentInterfaceType)
+                    .addContent(".class, ")
+                    .addContent("configuredModel, new ")
+                    .addContent(LC_AGENTIC_SERVICES)
+                    .addContent(".AgentConfigurator(this")
+                    .addContentLine("::configureSubAgents, this::resolveSubAgent, null));")
+                    .addContentLine("");
         });
 
         classModel.addMethod(this::addAgentsConfigMethod);
         classModel.addMethod(this::addConfigureSubAgentsMethod);
-        classModel.addMethod(this::addIsA2ASubAgentMethod);
+        classModel.addMethod(this::addIsA2AAgentMethod);
         classModel.addMethod(this::addResolveSubAgentMethod);
 
         roundCtx.addGeneratedType(generatedType, classModel, agentInterfaceType, agentInterface.originatingElementValue());
@@ -211,9 +207,8 @@ class AgentCodegen implements CodegenExtension {
             }
             ctr.addParameter(parameter -> parameter
                     .name(aiServicesMethodName)
-                    .type(optionalType(lcModelType)));
-            ctr
-                    .addContent("this.chatModel = chatModel.orElse(null);");
+                    .type(supplierType(optionalType(lcModelType))));
+            ctr.addContent("this.chatModel = chatModel;");
         } else {
             // there is no annotation, use only auto-discovered model (if present)
             if (!autoDiscovery) {
@@ -222,10 +217,9 @@ class AgentCodegen implements CodegenExtension {
             }
             ctr.addParameter(parameter -> parameter
                     .name(aiServicesMethodName)
-                    .type(optionalType(lcModelType))
+                    .type(supplierType(optionalType(lcModelType)))
                     .addAnnotation(namedAnnotation(modelName)));
-            ctr
-                    .addContent("this.chatModel = chatModel.orElse(null);");
+            ctr.addContent("this.chatModel = chatModel;");
         }
     }
 
@@ -291,21 +285,31 @@ class AgentCodegen implements CodegenExtension {
                 .addContentLine("agentsConfig(cls).configure(ctx, registry);");
     }
 
-    private void addIsA2ASubAgentMethod(Method.Builder mb) {
+    private void addIsA2AAgentMethod(Method.Builder mb) {
         mb.accessModifier(PRIVATE)
                 .returnType(TypeNames.PRIMITIVE_BOOLEAN)
                 .addParameter(Parameter.builder()
                                       .name("agentType")
                                       .type(CLASS_WILDCARD)
                                       .build())
-                .name("isA2ASubAgent")
+                .addParameter(Parameter.builder()
+                                      .name("nested")
+                                      .type(TypeNames.PRIMITIVE_BOOLEAN)
+                                      .build())
+                .name("isA2AAgent")
                 .addContentLine("boolean a2a = false;")
                 .addContentLine("for (var method : agentType.getMethods()) {")
                 .increaseContentPadding();
         for (TypeName annotation : COMPOSED_AGENT_ANNOTATIONS) {
             addHigherPrecedenceAnnotationCheck(mb, annotation);
         }
-        addHigherPrecedenceAnnotationCheck(mb, LC_HUMAN_IN_THE_LOOP);
+        mb.addContent("if (nested && method.isAnnotationPresent(")
+                .addContent(LC_HUMAN_IN_THE_LOOP)
+                .addContentLine(".class)) {")
+                .increaseContentPadding()
+                .addContentLine("return false;")
+                .decreaseContentPadding()
+                .addContentLine("}");
         mb.addContent("if (method.isAnnotationPresent(")
                 .addContent(LC_A2A_CLIENT_AGENT)
                 .addContentLine(".class)) {")
@@ -336,7 +340,7 @@ class AgentCodegen implements CodegenExtension {
                                       .type(CLASS_WILDCARD)
                                       .build())
                 .name("resolveSubAgent")
-                .addContentLine("if (!isA2ASubAgent(cls)) {")
+                .addContentLine("if (!isA2AAgent(cls, true)) {")
                 .increaseContentPadding()
                 .addContentLine("return null;")
                 .decreaseContentPadding()
@@ -352,22 +356,6 @@ class AgentCodegen implements CodegenExtension {
                 .addContentLine("}")
                 .addContentLine("// Each workflow needs a fresh A2A proxy because it carries mutable parent state")
                 .addContentLine("return agentsConfig(cls).createA2AAgent(cls);");
-    }
-
-    private boolean isA2AAgent(TypeInfo typeInfo) {
-        return hasAnnotation(typeInfo, LC_A2A_CLIENT_AGENT)
-                && COMPOSED_AGENT_ANNOTATIONS.stream().noneMatch(annotation -> hasAnnotation(typeInfo, annotation));
-    }
-
-    private boolean hasAnnotation(TypeInfo typeInfo, TypeName annotation) {
-        if (typeInfo.elementInfo()
-                .stream()
-                .anyMatch(element -> element.hasAnnotation(annotation))) {
-            return true;
-        }
-        return typeInfo.interfaceTypeInfo()
-                .stream()
-                .anyMatch(interfaceType -> hasAnnotation(interfaceType, annotation));
     }
 
     private TypeName generatedTypeName(TypeName aiInterfaceType, String suffix) {

--- a/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/LangchainTypes.java
+++ b/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/LangchainTypes.java
@@ -46,6 +46,8 @@ final class LangchainTypes {
     static final TypeName MODEL_CUSTOM_BUILDER_MAPPING =
             TypeName.create("io.helidon.extensions.langchain4j.AiProvider.CustomBuilderMapping");
     static final TypeName AGENTS_CONFIG = TypeName.create("io.helidon.extensions.langchain4j.AgentsConfig");
+    static final TypeName A2A_AGENT_CONFIG_SUPPORT =
+            TypeName.create("io.helidon.extensions.langchain4j.A2AAgentConfigSupport");
     static final TypeName AGENT_METADATA = TypeName.create("io.helidon.extensions.langchain4j.AgentMetadata");
 
 
@@ -76,6 +78,8 @@ final class LangchainTypes {
     static final TypeName LC_MCP_TOOL_PROVIDER = TypeName.create("dev.langchain4j.mcp.McpToolProvider");
     static final TypeName LC_MCP_CLIENT = TypeName.create("dev.langchain4j.mcp.client.McpClient");
     static final TypeName LC_AGENTIC_SERVICES = TypeName.create("dev.langchain4j.agentic.AgenticServices");
+    static final TypeName LC_A2A_CLIENT_AGENT =
+            TypeName.create("dev.langchain4j.agentic.declarative.A2AClientAgent");
     static final TypeName LC_DECLARATIVE_AGENT_CREATION_CONTEXT = TypeName.create(
             "dev.langchain4j.agentic.AgenticServices.DeclarativeAgentCreationContext");
 

--- a/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/LangchainTypes.java
+++ b/extensions/langchain4j/modules/codegen/src/main/java/io/helidon/extensions/langchain4j/codegen/LangchainTypes.java
@@ -46,8 +46,6 @@ final class LangchainTypes {
     static final TypeName MODEL_CUSTOM_BUILDER_MAPPING =
             TypeName.create("io.helidon.extensions.langchain4j.AiProvider.CustomBuilderMapping");
     static final TypeName AGENTS_CONFIG = TypeName.create("io.helidon.extensions.langchain4j.AgentsConfig");
-    static final TypeName A2A_AGENT_CONFIG_SUPPORT =
-            TypeName.create("io.helidon.extensions.langchain4j.A2AAgentConfigSupport");
     static final TypeName AGENT_METADATA = TypeName.create("io.helidon.extensions.langchain4j.AgentMetadata");
 
 

--- a/extensions/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupport.java
+++ b/extensions/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupport.java
@@ -136,11 +136,11 @@ public final class A2AAgentConfigSupport {
             return validateServerUrl(agentType, config.a2aServerUrl().get());
         }
         if (!annotationUrl.isBlank()) {
-            return validateServerUrl(agentType, annotationUrl);
+            return annotationUrl;
         }
         if (supplierMethod.isPresent()) {
             checkReturnType(supplierMethod.get(), String.class);
-            return validateServerUrl(agentType, invokeStatic(supplierMethod.get()));
+            return invokeStatic(supplierMethod.get());
         }
 
         throw new IllegalArgumentException("A2A agent " + agentType.getName()

--- a/extensions/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupport.java
+++ b/extensions/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupport.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j;
+
+import java.net.URI;
+import java.util.Locale;
+import java.util.stream.Stream;
+
+import io.helidon.common.Api;
+
+import dev.langchain4j.agentic.AgenticServices;
+import dev.langchain4j.agentic.declarative.A2AClientAgent;
+import dev.langchain4j.agentic.declarative.A2AClientCustomizer;
+import dev.langchain4j.agentic.declarative.A2AServerUrlSupplier;
+import dev.langchain4j.agentic.declarative.AgentListenerSupplier;
+import dev.langchain4j.agentic.declarative.ConditionalAgent;
+import dev.langchain4j.agentic.declarative.HumanInTheLoop;
+import dev.langchain4j.agentic.declarative.LoopAgent;
+import dev.langchain4j.agentic.declarative.ParallelAgent;
+import dev.langchain4j.agentic.declarative.ParallelMapperAgent;
+import dev.langchain4j.agentic.declarative.PlannerAgent;
+import dev.langchain4j.agentic.declarative.SequenceAgent;
+import dev.langchain4j.agentic.declarative.SupervisorAgent;
+import dev.langchain4j.agentic.internal.A2AClientBuilder;
+import dev.langchain4j.agentic.internal.AgentInvoker;
+import dev.langchain4j.agentic.internal.AgentUtil;
+import dev.langchain4j.agentic.observability.AgentListener;
+
+import static dev.langchain4j.agentic.declarative.DeclarativeUtil.checkReturnType;
+import static dev.langchain4j.agentic.declarative.DeclarativeUtil.invokeStatic;
+import static dev.langchain4j.agentic.declarative.DeclarativeUtil.selectMethod;
+import static dev.langchain4j.agentic.internal.AgentUtil.getAnnotatedMethodOnClass;
+
+/**
+ * Runtime support for applying Helidon configuration to LangChain4j A2A client agents.
+ */
+@Api.Internal
+public final class A2AAgentConfigSupport {
+    private static final String A2A_DEPENDENCY = "dev.langchain4j:langchain4j-agentic-a2a";
+
+    private A2AAgentConfigSupport() {
+    }
+
+    /**
+     * Whether the type declares an A2A client agent method.
+     *
+     * @param agentType agent service type
+     * @return whether the type is an A2A client agent
+     */
+    public static boolean isA2A(Class<?> agentType) {
+        return getAnnotatedMethodOnClass(agentType, A2AClientAgent.class).isPresent()
+                && Stream.of(SequenceAgent.class,
+                             LoopAgent.class,
+                             ConditionalAgent.class,
+                             ParallelAgent.class,
+                             ParallelMapperAgent.class,
+                             SupervisorAgent.class,
+                             PlannerAgent.class,
+                             HumanInTheLoop.class)
+                .noneMatch(annotation -> getAnnotatedMethodOnClass(agentType, annotation).isPresent());
+    }
+
+    /**
+     * Creates an A2A client agent, applying Helidon configuration over annotation defaults.
+     *
+     * @param agentType agent service type
+     * @param config agent configuration
+     * @param <T> agent service type
+     * @return configured A2A client agent
+     */
+    public static <T> T create(Class<T> agentType, AgentsConfig config) {
+        var agentMethod = getAnnotatedMethodOnClass(agentType, A2AClientAgent.class)
+                .orElseThrow(() -> new IllegalArgumentException("Type " + agentType.getName()
+                                                                         + " is not an A2A client agent"));
+        var annotation = agentMethod.getAnnotation(A2AClientAgent.class);
+        String serverUrl = serverUrl(agentType, annotation, config);
+
+        A2AClientBuilder<T> builder;
+        try {
+            builder = AgenticServices.a2aBuilder(serverUrl, agentType);
+        } catch (UnsupportedOperationException e) {
+            throw new IllegalStateException("Cannot create A2A agent " + agentType.getName()
+                                                    + ": add " + A2A_DEPENDENCY + " to the runtime dependencies",
+                                            e);
+        }
+        String annotationOutputKey = AgentUtil.outputKey(annotation.outputKey(), annotation.typedOutputKey());
+
+        builder.inputKeys(Stream.of(agentMethod.getParameters())
+                                  .map(AgentInvoker::parameterName)
+                                  .toArray(String[]::new))
+                .outputKey(config.outputKey()
+                                   .map(outputKey -> configuredOutputKey(agentType, outputKey))
+                                   .orElse(annotationOutputKey))
+                .async(config.async().orElse(annotation.async()));
+
+        selectMethod(agentType,
+                     method -> method.isAnnotationPresent(A2AClientCustomizer.class)
+                             && method.getParameterCount() == 1)
+                .ifPresent(method -> builder.clientCustomizer(clientBuilder -> invokeStatic(method, clientBuilder)));
+
+        getAnnotatedMethodOnClass(agentType, AgentListenerSupplier.class)
+                .ifPresent(method -> {
+                    checkReturnType(method, AgentListener.class);
+                    builder.listener(invokeStatic(method));
+                });
+
+        return builder.build();
+    }
+
+    private static String serverUrl(Class<?> agentType, A2AClientAgent annotation, AgentsConfig config) {
+        String annotationUrl = annotation.a2aServerUrl();
+        var supplierMethod = selectMethod(agentType,
+                                          method -> method.isAnnotationPresent(A2AServerUrlSupplier.class)
+                                                  && method.getParameterCount() == 0);
+
+        if (!annotationUrl.isBlank() && supplierMethod.isPresent()) {
+            throw new IllegalArgumentException("Provide either a2aServerUrl in the @A2AClientAgent annotation or an "
+                                                       + "@A2AServerUrlSupplier method, not both.");
+        }
+
+        if (config.a2aServerUrl().isPresent()) {
+            return validateServerUrl(agentType, config.a2aServerUrl().get());
+        }
+        if (!annotationUrl.isBlank()) {
+            return validateServerUrl(agentType, annotationUrl);
+        }
+        if (supplierMethod.isPresent()) {
+            checkReturnType(supplierMethod.get(), String.class);
+            return validateServerUrl(agentType, invokeStatic(supplierMethod.get()));
+        }
+
+        throw new IllegalArgumentException("A2A agent " + agentType.getName()
+                                                   + " requires langchain4j.agents.<agent-name>.a2a-server-url, "
+                                                   + "@A2AClientAgent.a2aServerUrl, or @A2AServerUrlSupplier");
+    }
+
+    private static String configuredOutputKey(Class<?> agentType, String outputKey) {
+        if (outputKey.isBlank()) {
+            throw new IllegalArgumentException("Configured output-key for A2A agent " + agentType.getName()
+                                                       + " must not be blank");
+        }
+        return outputKey;
+    }
+
+    private static String validateServerUrl(Class<?> agentType, String serverUrl) {
+        if (serverUrl == null || serverUrl.isBlank()) {
+            throw invalidServerUrl(agentType);
+        }
+
+        URI uri;
+        try {
+            uri = URI.create(serverUrl);
+        } catch (IllegalArgumentException e) {
+            throw invalidServerUrl(agentType);
+        }
+
+        String scheme = uri.getScheme();
+        if (!uri.isAbsolute()
+                || scheme == null
+                || !(scheme.toLowerCase(Locale.ROOT).equals("http")
+                || scheme.toLowerCase(Locale.ROOT).equals("https"))
+                || uri.getHost() == null
+                || uri.getUserInfo() != null
+                || uri.getFragment() != null
+                || uri.getPort() > 65535) {
+            throw invalidServerUrl(agentType);
+        }
+        return serverUrl;
+    }
+
+    private static IllegalArgumentException invalidServerUrl(Class<?> agentType) {
+        return new IllegalArgumentException("A2A server URL for agent " + agentType.getName()
+                                                    + " must be an absolute HTTP or HTTPS URI without user info or fragment");
+    }
+}

--- a/extensions/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupport.java
+++ b/extensions/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupport.java
@@ -20,8 +20,6 @@ import java.net.URI;
 import java.util.Locale;
 import java.util.stream.Stream;
 
-import io.helidon.common.Api;
-
 import dev.langchain4j.agentic.AgenticServices;
 import dev.langchain4j.agentic.declarative.A2AClientAgent;
 import dev.langchain4j.agentic.declarative.A2AClientCustomizer;
@@ -48,8 +46,7 @@ import static dev.langchain4j.agentic.internal.AgentUtil.getAnnotatedMethodOnCla
 /**
  * Runtime support for applying Helidon configuration to LangChain4j A2A client agents.
  */
-@Api.Internal
-public final class A2AAgentConfigSupport {
+final class A2AAgentConfigSupport {
     private static final String A2A_DEPENDENCY = "dev.langchain4j:langchain4j-agentic-a2a";
 
     private A2AAgentConfigSupport() {
@@ -61,7 +58,7 @@ public final class A2AAgentConfigSupport {
      * @param agentType agent service type
      * @return whether the type is an A2A client agent
      */
-    public static boolean isA2A(Class<?> agentType) {
+    static boolean isA2A(Class<?> agentType) {
         return getAnnotatedMethodOnClass(agentType, A2AClientAgent.class).isPresent()
                 && Stream.of(SequenceAgent.class,
                              LoopAgent.class,
@@ -82,7 +79,11 @@ public final class A2AAgentConfigSupport {
      * @param <T> agent service type
      * @return configured A2A client agent
      */
-    public static <T> T create(Class<T> agentType, AgentsConfig config) {
+    static <T> T create(Class<T> agentType, AgentsConfig config) {
+        if (!config.enabled()) {
+            throw new IllegalStateException("Cannot create A2A agent " + agentType.getName()
+                                                    + " when its configuration is disabled");
+        }
         var agentMethod = getAnnotatedMethodOnClass(agentType, A2AClientAgent.class)
                 .orElseThrow(() -> new IllegalArgumentException("Type " + agentType.getName()
                                                                          + " is not an A2A client agent"));

--- a/extensions/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupport.java
+++ b/extensions/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupport.java
@@ -25,14 +25,6 @@ import dev.langchain4j.agentic.declarative.A2AClientAgent;
 import dev.langchain4j.agentic.declarative.A2AClientCustomizer;
 import dev.langchain4j.agentic.declarative.A2AServerUrlSupplier;
 import dev.langchain4j.agentic.declarative.AgentListenerSupplier;
-import dev.langchain4j.agentic.declarative.ConditionalAgent;
-import dev.langchain4j.agentic.declarative.HumanInTheLoop;
-import dev.langchain4j.agentic.declarative.LoopAgent;
-import dev.langchain4j.agentic.declarative.ParallelAgent;
-import dev.langchain4j.agentic.declarative.ParallelMapperAgent;
-import dev.langchain4j.agentic.declarative.PlannerAgent;
-import dev.langchain4j.agentic.declarative.SequenceAgent;
-import dev.langchain4j.agentic.declarative.SupervisorAgent;
 import dev.langchain4j.agentic.internal.A2AClientBuilder;
 import dev.langchain4j.agentic.internal.AgentInvoker;
 import dev.langchain4j.agentic.internal.AgentUtil;
@@ -50,25 +42,6 @@ final class A2AAgentConfigSupport {
     private static final String A2A_DEPENDENCY = "dev.langchain4j:langchain4j-agentic-a2a";
 
     private A2AAgentConfigSupport() {
-    }
-
-    /**
-     * Whether the type declares an A2A client agent method.
-     *
-     * @param agentType agent service type
-     * @return whether the type is an A2A client agent
-     */
-    static boolean isA2A(Class<?> agentType) {
-        return getAnnotatedMethodOnClass(agentType, A2AClientAgent.class).isPresent()
-                && Stream.of(SequenceAgent.class,
-                             LoopAgent.class,
-                             ConditionalAgent.class,
-                             ParallelAgent.class,
-                             ParallelMapperAgent.class,
-                             SupervisorAgent.class,
-                             PlannerAgent.class,
-                             HumanInTheLoop.class)
-                .noneMatch(annotation -> getAnnotatedMethodOnClass(agentType, annotation).isPresent());
     }
 
     /**

--- a/extensions/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/AgentsConfigBlueprint.java
+++ b/extensions/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/AgentsConfigBlueprint.java
@@ -40,6 +40,7 @@ import dev.langchain4j.guardrail.OutputGuardrail;
 @Prototype.Blueprint
 @Prototype.Configured("langchain4j.agents") // constants in annotations should not reference generated code
 @Prototype.CustomMethods(AgentsConfigSupport.class)
+@Prototype.IncludeDefaultMethods
 interface AgentsConfigBlueprint {
 
     /**
@@ -70,6 +71,19 @@ interface AgentsConfigBlueprint {
      */
     @Option.Configured
     Optional<String> description();
+
+    /**
+     * URL of the remote A2A agent server.
+     * <p>
+     * When configured for an A2A client agent, this value overrides the URL declared by
+     * {@code A2AClientAgent} or supplied by {@code A2AServerUrlSupplier}.
+     *
+    * @return configured A2A server URL, or empty if the annotation configuration should be used
+    */
+    @Option.Configured
+    default Optional<String> a2aServerUrl() {
+        return Optional.empty();
+    }
 
     /**
      * Key of the output variable that will be used to store the result of the agent's invocation.

--- a/extensions/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/AgentsConfigBlueprint.java
+++ b/extensions/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/AgentsConfigBlueprint.java
@@ -73,13 +73,16 @@ interface AgentsConfigBlueprint {
     Optional<String> description();
 
     /**
-     * URL of the remote A2A agent server.
+     * URL of the remote A2A agent server; when configured, it must be a non-blank absolute HTTP or HTTPS URI with a
+     * host, no user info or fragment, and a numeric port from 0 through 65535 when present.
      * <p>
      * When configured for an A2A client agent, this value overrides the URL declared by
      * {@code A2AClientAgent} or supplied by {@code A2AServerUrlSupplier}.
+     * These restrictions apply only to the Helidon configuration override; annotation and supplier URLs are passed
+     * unchanged to the selected A2A service.
      *
-    * @return configured A2A server URL, or empty if the annotation configuration should be used
-    */
+     * @return configured A2A server URL, or empty if the annotation configuration should be used
+     */
     @Option.Configured
     default Optional<String> a2aServerUrl() {
         return Optional.empty();

--- a/extensions/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/AgentsConfigSupport.java
+++ b/extensions/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/AgentsConfigSupport.java
@@ -39,6 +39,37 @@ class AgentsConfigSupport {
     }
 
     /**
+     * Creates a configured A2A client agent.
+     * <p>
+     * Declaring both annotation output-key forms, or using a typed key without an accessible no-argument constructor,
+     * results in {@link dev.langchain4j.agentic.planner.AgenticSystemConfigurationException}. A disabled configuration
+     * or unavailable A2A provider results in {@link IllegalStateException}.
+     *
+     * @param agentsConfig agent configuration
+     * @param agentType agent service type
+     * @param <T> agent service type
+     * @return configured A2A client agent
+     * @throws IllegalArgumentException if {@code agentType} is not an A2A client agent, its server URL sources are
+     *                                  missing or conflicting, its configured URL or output-key override is invalid, or
+     *                                  annotated method metadata is invalid
+     */
+    @Prototype.PrototypeMethod
+    static <T> T createA2AAgent(AgentsConfig agentsConfig, Class<T> agentType) {
+        return A2AAgentConfigSupport.create(agentType, agentsConfig);
+    }
+
+    /**
+     * Whether the type declares an A2A client agent method and no higher-precedence nested-agent method.
+     *
+     * @param agentType agent service type
+     * @return whether the type should use A2A client agent creation as a nested agent
+     */
+    @Prototype.PrototypeFactoryMethod
+    static boolean isA2ASubAgent(Class<?> agentType) {
+        return A2AAgentConfigSupport.isA2A(agentType);
+    }
+
+    /**
      * Configures LangChain4j {@link dev.langchain4j.agentic.agent.AgentBuilder} from {@link AgentsConfig}.
      * <p>
      * This method resolves any configured service references (such as {@link dev.langchain4j.model.chat.ChatModel},

--- a/extensions/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/AgentsConfigSupport.java
+++ b/extensions/langchain4j/modules/langchain4j/src/main/java/io/helidon/extensions/langchain4j/AgentsConfigSupport.java
@@ -43,7 +43,8 @@ class AgentsConfigSupport {
      * <p>
      * Declaring both annotation output-key forms, or using a typed key without an accessible no-argument constructor,
      * results in {@link dev.langchain4j.agentic.planner.AgenticSystemConfigurationException}. A disabled configuration
-     * or unavailable A2A provider results in {@link IllegalStateException}.
+     * or unavailable A2A provider results in {@link IllegalStateException}. Passing a {@code null} agent type results
+     * in {@link NullPointerException}.
      *
      * @param agentsConfig agent configuration
      * @param agentType agent service type
@@ -55,18 +56,8 @@ class AgentsConfigSupport {
      */
     @Prototype.PrototypeMethod
     static <T> T createA2AAgent(AgentsConfig agentsConfig, Class<T> agentType) {
+        Objects.requireNonNull(agentType, "agentType");
         return A2AAgentConfigSupport.create(agentType, agentsConfig);
-    }
-
-    /**
-     * Whether the type declares an A2A client agent method and no higher-precedence nested-agent method.
-     *
-     * @param agentType agent service type
-     * @return whether the type should use A2A client agent creation as a nested agent
-     */
-    @Prototype.PrototypeFactoryMethod
-    static boolean isA2ASubAgent(Class<?> agentType) {
-        return A2AAgentConfigSupport.isA2A(agentType);
     }
 
     /**

--- a/extensions/langchain4j/modules/langchain4j/src/test/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupportTest.java
+++ b/extensions/langchain4j/modules/langchain4j/src/test/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupportTest.java
@@ -1,0 +1,376 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Consumer;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryManager;
+
+import dev.langchain4j.agentic.declarative.A2AClientAgent;
+import dev.langchain4j.agentic.declarative.A2AClientCustomizer;
+import dev.langchain4j.agentic.declarative.A2AServerUrlSupplier;
+import dev.langchain4j.agentic.declarative.AgentListenerSupplier;
+import dev.langchain4j.agentic.declarative.SequenceAgent;
+import dev.langchain4j.agentic.declarative.TypedKey;
+import dev.langchain4j.agentic.internal.A2AClientBuilder;
+import dev.langchain4j.agentic.internal.A2AService;
+import dev.langchain4j.agentic.internal.AgentExecutor;
+import dev.langchain4j.agentic.internal.InternalAgent;
+import dev.langchain4j.agentic.observability.AgentListener;
+import dev.langchain4j.agentic.planner.AgenticSystemConfigurationException;
+import dev.langchain4j.service.V;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContaining;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class A2AAgentConfigSupportTest {
+    private static final AtomicBoolean CUSTOMIZED = new AtomicBoolean();
+    private static final AgentListener LISTENER = new AgentListener() { };
+
+    private A2AService previousService;
+    private RecordingA2AService recordingService;
+
+    @BeforeEach
+    void setUp() {
+        previousService = A2AService.get();
+        recordingService = new RecordingA2AService();
+        A2AService.setA2AService(recordingService);
+        CUSTOMIZED.set(false);
+    }
+
+    @AfterEach
+    void tearDown() {
+        A2AService.setA2AService(previousService);
+    }
+
+    @Test
+    void configurationOverridesAnnotationValues() {
+        var config = AgentsConfig.builder()
+                .a2aServerUrl("https://configured.example.test/a2a")
+                .outputKey("configured-output")
+                .async(false)
+                .build();
+
+        var agent = A2AAgentConfigSupport.create(AnnotatedAgent.class, config);
+
+        assertThat(agent, is(notNullValue()));
+        assertThat(recordingService.serverUrl, is("https://configured.example.test/a2a"));
+        assertThat(recordingService.builder.inputKeys, arrayContaining("question"));
+        assertThat(recordingService.builder.outputKey, is("configured-output"));
+        assertThat(recordingService.builder.async, is(false));
+        assertThat(recordingService.builder.listener, sameInstance(LISTENER));
+        assertThat(CUSTOMIZED.get(), is(true));
+    }
+
+    @Test
+    void annotationValuesAreFallbacks() {
+        A2AAgentConfigSupport.create(AnnotatedAgent.class, AgentsConfig.create());
+
+        assertThat(recordingService.serverUrl, is("https://annotation.example.test/a2a"));
+        assertThat(recordingService.builder.outputKey, is("annotation-output"));
+        assertThat(recordingService.builder.async, is(true));
+    }
+
+    @Test
+    void supplierAndTypedOutputKeyAreFallbacks() {
+        A2AAgentConfigSupport.create(SuppliedAgent.class, AgentsConfig.create());
+
+        assertThat(recordingService.serverUrl, is("https://supplier.example.test/a2a"));
+        assertThat(recordingService.builder.outputKey, is("TypedOutput"));
+        assertThat(recordingService.builder.async, is(false));
+    }
+
+    @Test
+    void readsA2AConfiguration() {
+        // language=YAML
+        String yaml = """
+                a2a-server-url: https://configured.example.test/a2a
+                output-key: configured-output
+                async: true
+                """;
+        var config = AgentsConfig.create(Config.just(ConfigSources.create(yaml, MediaTypes.APPLICATION_X_YAML)));
+
+        assertThat(config.a2aServerUrl().orElseThrow(), is("https://configured.example.test/a2a"));
+        assertThat(config.outputKey().orElseThrow(), is("configured-output"));
+        assertThat(config.async().orElseThrow(), is(true));
+    }
+
+    @Test
+    void rejectsConflictingAnnotationSources() {
+        var error = assertThrows(IllegalArgumentException.class,
+                                 () -> A2AAgentConfigSupport.create(ConflictingAgent.class,
+                                                                   AgentsConfig.builder()
+                                                                           .a2aServerUrl("https://override.example.test")
+                                                                           .build()));
+
+        assertThat(error.getMessage(), containsString("not both"));
+    }
+
+    @Test
+    void rejectsMissingAndInvalidUrls() {
+        var missing = assertThrows(IllegalArgumentException.class,
+                                   () -> A2AAgentConfigSupport.create(MissingUrlAgent.class, AgentsConfig.create()));
+        assertThat(missing.getMessage(), containsString("requires"));
+
+        var invalid = assertThrows(IllegalArgumentException.class,
+                                   () -> A2AAgentConfigSupport.create(MissingUrlAgent.class,
+                                                                     AgentsConfig.builder()
+                                                                             .a2aServerUrl("file:///tmp/agent")
+                                                                             .build()));
+        assertThat(invalid.getMessage(), containsString("absolute HTTP or HTTPS URI"));
+
+        var invalidPort = assertThrows(IllegalArgumentException.class,
+                                       () -> A2AAgentConfigSupport.create(MissingUrlAgent.class,
+                                                                         AgentsConfig.builder()
+                                                                                 .a2aServerUrl("http://example.test:99999")
+                                                                                 .build()));
+        assertThat(invalidPort.getMessage(), containsString("absolute HTTP or HTTPS URI"));
+    }
+
+    @Test
+    void configuredOutputDoesNotMaskInvalidAnnotationOutput() {
+        var error = assertThrows(AgenticSystemConfigurationException.class,
+                                 () -> A2AAgentConfigSupport.create(InvalidOutputAgent.class,
+                                                                   AgentsConfig.builder()
+                                                                           .outputKey("configured-output")
+                                                                           .build()));
+
+        assertThat(error.getMessage(), containsString("Both outputKey and typedOutputKey"));
+    }
+
+    @Test
+    void reportsMissingA2AProvider() {
+        A2AService.setA2AService(new MissingA2AService());
+
+        var error = assertThrows(IllegalStateException.class,
+                                 () -> A2AAgentConfigSupport.create(AnnotatedAgent.class, AgentsConfig.create()));
+
+        assertThat(error.getMessage(), containsString("dev.langchain4j:langchain4j-agentic-a2a"));
+    }
+
+    @Test
+    void generatedTopLevelA2AAgentDoesNotRequireChatModel() throws ReflectiveOperationException {
+        var generatedType = Class.forName(getClass().getPackageName()
+                                                  + ".A2AAgentConfigSupportTest_AnnotatedAgent__AiAgent");
+        var constructor = generatedType.getDeclaredConstructors()[0];
+
+        assertThat(Arrays.asList(constructor.getParameterTypes()), contains(Config.class, ServiceRegistry.class));
+    }
+
+    @Test
+    void composedAgentTakesPrecedenceOverInheritedA2AAgent() throws ReflectiveOperationException {
+        assertThat(A2AAgentConfigSupport.isA2A(ComposedAgent.class), is(false));
+
+        var generatedType = Class.forName(getClass().getPackageName()
+                                                  + ".A2AAgentConfigSupportTest_ComposedAgent__AiAgent");
+        var constructor = generatedType.getDeclaredConstructors()[0];
+
+        assertThat(Arrays.asList(constructor.getParameterTypes()),
+                   contains(Config.class, ServiceRegistry.class, Optional.class));
+    }
+
+    @Test
+    void unannotatedA2ASubAgentFallsThroughToLangChain4j() throws ReflectiveOperationException {
+        var manager = ServiceRegistryManager.create();
+        try {
+            var generatedType = Class.forName(getClass().getPackageName()
+                                                      + ".A2AAgentConfigSupportTest_UnannotatedWorkflow__AiAgent");
+            var constructor = generatedType.getDeclaredConstructor(Config.class, ServiceRegistry.class, Optional.class);
+            constructor.setAccessible(true);
+            var supplier = constructor.newInstance(Config.empty(), manager.registry(), Optional.empty());
+            var resolver = generatedType.getDeclaredMethod("resolveSubAgent", Class.class);
+            resolver.setAccessible(true);
+
+            assertThat(resolver.invoke(supplier, UnannotatedAgent.class), is(nullValue()));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Ai.Agent("annotated-a2a")
+    public interface AnnotatedAgent {
+        @A2AClientAgent(a2aServerUrl = "https://annotation.example.test/a2a",
+                        outputKey = "annotation-output",
+                        async = true)
+        String ask(@V("question") String question);
+
+        @A2AClientCustomizer
+        static void customize(Object ignored) {
+            CUSTOMIZED.set(true);
+        }
+
+        @AgentListenerSupplier
+        static AgentListener listener() {
+            return LISTENER;
+        }
+    }
+
+    public interface SuppliedAgent {
+        @A2AClientAgent(typedOutputKey = TypedOutput.class)
+        String ask(@V("question") String question);
+
+        @A2AServerUrlSupplier
+        static String serverUrl() {
+            return "https://supplier.example.test/a2a";
+        }
+    }
+
+    public interface ConflictingAgent {
+        @A2AClientAgent(a2aServerUrl = "https://annotation.example.test/a2a")
+        String ask(@V("question") String question);
+
+        @A2AServerUrlSupplier
+        static String serverUrl() {
+            return "https://supplier.example.test/a2a";
+        }
+    }
+
+    public interface MissingUrlAgent {
+        @A2AClientAgent
+        String ask(@V("question") String question);
+    }
+
+    public interface InvalidOutputAgent {
+        @A2AClientAgent(a2aServerUrl = "https://annotation.example.test/a2a",
+                outputKey = "annotation-output",
+                typedOutputKey = TypedOutput.class)
+        String ask(@V("question") String question);
+    }
+
+    @Ai.Agent("composed-agent")
+    public interface ComposedAgent extends AnnotatedAgent {
+        @SequenceAgent(subAgents = AnnotatedAgent.class)
+        String compose(@V("question") String question);
+    }
+
+    public interface UnannotatedAgent {
+        @A2AClientAgent(a2aServerUrl = "https://annotation.example.test/a2a")
+        String ask(@V("question") String question);
+    }
+
+    @Ai.Agent("unannotated-workflow")
+    public interface UnannotatedWorkflow {
+        @SequenceAgent(subAgents = UnannotatedAgent.class)
+        String compose(@V("question") String question);
+    }
+
+    public static class TypedOutput implements TypedKey<String> {
+    }
+
+    private static final class RecordingA2AService implements A2AService {
+        private String serverUrl;
+        private RecordingA2AClientBuilder<?> builder;
+
+        @Override
+        public <T> A2AClientBuilder<T> a2aBuilder(String serverUrl, Class<T> agentServiceClass) {
+            this.serverUrl = serverUrl;
+            var builder = new RecordingA2AClientBuilder<>(agentServiceClass);
+            this.builder = builder;
+            return builder;
+        }
+
+        @Override
+        public Optional<AgentExecutor> methodToAgentExecutor(InternalAgent agent, Method method) {
+            return Optional.empty();
+        }
+    }
+
+    private static final class MissingA2AService implements A2AService {
+        @Override
+        public <T> A2AClientBuilder<T> a2aBuilder(String serverUrl, Class<T> agentServiceClass) {
+            throw new UnsupportedOperationException("No A2A service implementation found");
+        }
+
+        @Override
+        public Optional<AgentExecutor> methodToAgentExecutor(InternalAgent agent, Method method) {
+            return Optional.empty();
+        }
+    }
+
+    private static final class RecordingA2AClientBuilder<T> implements A2AClientBuilder<T> {
+        private final Class<T> agentType;
+        private String[] inputKeys;
+        private String outputKey;
+        private boolean async;
+        private AgentListener listener;
+        private Consumer<?> customizer;
+
+        private RecordingA2AClientBuilder(Class<T> agentType) {
+            this.agentType = agentType;
+        }
+
+        @Override
+        public A2AClientBuilder<T> inputKeys(String... inputKeys) {
+            this.inputKeys = inputKeys;
+            return this;
+        }
+
+        @Override
+        public A2AClientBuilder<T> outputKey(String outputKey) {
+            this.outputKey = outputKey;
+            return this;
+        }
+
+        @Override
+        public A2AClientBuilder<T> async(boolean async) {
+            this.async = async;
+            return this;
+        }
+
+        @Override
+        public A2AClientBuilder<T> listener(AgentListener listener) {
+            this.listener = listener;
+            return this;
+        }
+
+        @Override
+        public A2AClientBuilder<T> clientCustomizer(Consumer<?> customizer) {
+            this.customizer = customizer;
+            return this;
+        }
+
+        @Override
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        public T build() {
+            if (customizer != null) {
+                ((Consumer) customizer).accept(new Object());
+            }
+            return agentType.cast(Proxy.newProxyInstance(agentType.getClassLoader(),
+                                                         new Class<?>[] {agentType},
+                                                         (proxy, method, args) -> null));
+        }
+    }
+}

--- a/extensions/langchain4j/modules/langchain4j/src/test/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupportTest.java
+++ b/extensions/langchain4j/modules/langchain4j/src/test/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupportTest.java
@@ -99,7 +99,7 @@ public class A2AAgentConfigSupportTest {
     void annotationValuesAreFallbacks() {
         A2AAgentConfigSupport.create(AnnotatedAgent.class, AgentsConfig.create());
 
-        assertThat(recordingService.serverUrl, is("https://annotation.example.test/a2a"));
+        assertThat(recordingService.serverUrl, is("a2a+test:annotation"));
         assertThat(recordingService.builder.outputKey, is("annotation-output"));
         assertThat(recordingService.builder.async, is(true));
     }
@@ -108,7 +108,7 @@ public class A2AAgentConfigSupportTest {
     void supplierAndTypedOutputKeyAreFallbacks() {
         A2AAgentConfigSupport.create(SuppliedAgent.class, AgentsConfig.create());
 
-        assertThat(recordingService.serverUrl, is("https://supplier.example.test/a2a"));
+        assertThat(recordingService.serverUrl, is("urn:a2a:supplied"));
         assertThat(recordingService.builder.outputKey, is("TypedOutput"));
         assertThat(recordingService.builder.async, is(false));
     }
@@ -148,7 +148,7 @@ public class A2AAgentConfigSupportTest {
         var invalid = assertThrows(IllegalArgumentException.class,
                                    () -> A2AAgentConfigSupport.create(MissingUrlAgent.class,
                                                                      AgentsConfig.builder()
-                                                                             .a2aServerUrl("file:///tmp/agent")
+                                                                             .a2aServerUrl("a2a+test:configured")
                                                                              .build()));
         assertThat(invalid.getMessage(), containsString("absolute HTTP or HTTPS URI"));
 
@@ -222,7 +222,7 @@ public class A2AAgentConfigSupportTest {
 
     @Ai.Agent("annotated-a2a")
     public interface AnnotatedAgent {
-        @A2AClientAgent(a2aServerUrl = "https://annotation.example.test/a2a",
+        @A2AClientAgent(a2aServerUrl = "a2a+test:annotation",
                         outputKey = "annotation-output",
                         async = true)
         String ask(@V("question") String question);
@@ -244,7 +244,7 @@ public class A2AAgentConfigSupportTest {
 
         @A2AServerUrlSupplier
         static String serverUrl() {
-            return "https://supplier.example.test/a2a";
+            return "urn:a2a:supplied";
         }
     }
 

--- a/extensions/langchain4j/modules/langchain4j/src/test/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupportTest.java
+++ b/extensions/langchain4j/modules/langchain4j/src/test/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupportTest.java
@@ -16,6 +16,7 @@
 
 package io.helidon.extensions.langchain4j;
 
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.util.Arrays;
@@ -25,6 +26,7 @@ import java.util.function.Consumer;
 
 import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Config;
+import io.helidon.config.ConfigMappingException;
 import io.helidon.config.ConfigSources;
 import io.helidon.service.registry.ServiceRegistry;
 import io.helidon.service.registry.ServiceRegistryManager;
@@ -33,6 +35,7 @@ import dev.langchain4j.agentic.declarative.A2AClientAgent;
 import dev.langchain4j.agentic.declarative.A2AClientCustomizer;
 import dev.langchain4j.agentic.declarative.A2AServerUrlSupplier;
 import dev.langchain4j.agentic.declarative.AgentListenerSupplier;
+import dev.langchain4j.agentic.declarative.HumanInTheLoop;
 import dev.langchain4j.agentic.declarative.SequenceAgent;
 import dev.langchain4j.agentic.declarative.TypedKey;
 import dev.langchain4j.agentic.internal.A2AClientBuilder;
@@ -50,6 +53,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -84,7 +88,7 @@ public class A2AAgentConfigSupportTest {
                 .async(false)
                 .build();
 
-        var agent = A2AAgentConfigSupport.create(AnnotatedAgent.class, config);
+        var agent = config.createA2AAgent(AnnotatedAgent.class);
 
         assertThat(agent, is(notNullValue()));
         assertThat(recordingService.serverUrl, is("https://configured.example.test/a2a"));
@@ -97,7 +101,7 @@ public class A2AAgentConfigSupportTest {
 
     @Test
     void annotationValuesAreFallbacks() {
-        A2AAgentConfigSupport.create(AnnotatedAgent.class, AgentsConfig.create());
+        AgentsConfig.create().createA2AAgent(AnnotatedAgent.class);
 
         assertThat(recordingService.serverUrl, is("a2a+test:annotation"));
         assertThat(recordingService.builder.outputKey, is("annotation-output"));
@@ -106,7 +110,7 @@ public class A2AAgentConfigSupportTest {
 
     @Test
     void supplierAndTypedOutputKeyAreFallbacks() {
-        A2AAgentConfigSupport.create(SuppliedAgent.class, AgentsConfig.create());
+        AgentsConfig.create().createA2AAgent(SuppliedAgent.class);
 
         assertThat(recordingService.serverUrl, is("urn:a2a:supplied"));
         assertThat(recordingService.builder.outputKey, is("TypedOutput"));
@@ -131,10 +135,10 @@ public class A2AAgentConfigSupportTest {
     @Test
     void rejectsConflictingAnnotationSources() {
         var error = assertThrows(IllegalArgumentException.class,
-                                 () -> A2AAgentConfigSupport.create(ConflictingAgent.class,
-                                                                   AgentsConfig.builder()
-                                                                           .a2aServerUrl("https://override.example.test")
-                                                                           .build()));
+                                 () -> AgentsConfig.builder()
+                                         .a2aServerUrl("https://override.example.test")
+                                         .build()
+                                         .createA2AAgent(ConflictingAgent.class));
 
         assertThat(error.getMessage(), containsString("not both"));
     }
@@ -142,31 +146,31 @@ public class A2AAgentConfigSupportTest {
     @Test
     void rejectsMissingAndInvalidUrls() {
         var missing = assertThrows(IllegalArgumentException.class,
-                                   () -> A2AAgentConfigSupport.create(MissingUrlAgent.class, AgentsConfig.create()));
+                                   () -> AgentsConfig.create().createA2AAgent(MissingUrlAgent.class));
         assertThat(missing.getMessage(), containsString("requires"));
 
         var invalid = assertThrows(IllegalArgumentException.class,
-                                   () -> A2AAgentConfigSupport.create(MissingUrlAgent.class,
-                                                                     AgentsConfig.builder()
-                                                                             .a2aServerUrl("a2a+test:configured")
-                                                                             .build()));
+                                   () -> AgentsConfig.builder()
+                                           .a2aServerUrl("a2a+test:configured")
+                                           .build()
+                                           .createA2AAgent(MissingUrlAgent.class));
         assertThat(invalid.getMessage(), containsString("absolute HTTP or HTTPS URI"));
 
         var invalidPort = assertThrows(IllegalArgumentException.class,
-                                       () -> A2AAgentConfigSupport.create(MissingUrlAgent.class,
-                                                                         AgentsConfig.builder()
-                                                                                 .a2aServerUrl("http://example.test:99999")
-                                                                                 .build()));
+                                       () -> AgentsConfig.builder()
+                                               .a2aServerUrl("http://example.test:99999")
+                                               .build()
+                                               .createA2AAgent(MissingUrlAgent.class));
         assertThat(invalidPort.getMessage(), containsString("absolute HTTP or HTTPS URI"));
     }
 
     @Test
     void configuredOutputDoesNotMaskInvalidAnnotationOutput() {
         var error = assertThrows(AgenticSystemConfigurationException.class,
-                                 () -> A2AAgentConfigSupport.create(InvalidOutputAgent.class,
-                                                                   AgentsConfig.builder()
-                                                                           .outputKey("configured-output")
-                                                                           .build()));
+                                 () -> AgentsConfig.builder()
+                                         .outputKey("configured-output")
+                                         .build()
+                                         .createA2AAgent(InvalidOutputAgent.class));
 
         assertThat(error.getMessage(), containsString("Both outputKey and typedOutputKey"));
     }
@@ -176,7 +180,7 @@ public class A2AAgentConfigSupportTest {
         A2AService.setA2AService(new MissingA2AService());
 
         var error = assertThrows(IllegalStateException.class,
-                                 () -> A2AAgentConfigSupport.create(AnnotatedAgent.class, AgentsConfig.create()));
+                                 () -> AgentsConfig.create().createA2AAgent(AnnotatedAgent.class));
 
         assertThat(error.getMessage(), containsString("dev.langchain4j:langchain4j-agentic-a2a"));
     }
@@ -191,8 +195,30 @@ public class A2AAgentConfigSupportTest {
     }
 
     @Test
+    void disabledTopLevelA2AAgentDoesNotStartDiscovery() throws ReflectiveOperationException {
+        var manager = ServiceRegistryManager.create();
+        try {
+            var generatedType = Class.forName(getClass().getPackageName()
+                                                      + ".A2AAgentConfigSupportTest_AnnotatedAgent__AiAgent");
+            var constructor = generatedType.getDeclaredConstructor(Config.class, ServiceRegistry.class);
+            constructor.setAccessible(true);
+            var supplier = constructor.newInstance(disabledAnnotatedAgentConfig(), manager.registry());
+            var get = generatedType.getDeclaredMethod("get");
+            get.setAccessible(true);
+
+            var error = assertThrows(InvocationTargetException.class, () -> get.invoke(supplier));
+
+            assertThat(error.getCause(), instanceOf(IllegalStateException.class));
+            assertThat(error.getCause().getMessage(), containsString("disabled"));
+            assertThat(recordingService.builder, is(nullValue()));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
     void composedAgentTakesPrecedenceOverInheritedA2AAgent() throws ReflectiveOperationException {
-        assertThat(A2AAgentConfigSupport.isA2A(ComposedAgent.class), is(false));
+        assertThat(AgentsConfig.isA2ASubAgent(ComposedAgent.class), is(false));
 
         var generatedType = Class.forName(getClass().getPackageName()
                                                   + ".A2AAgentConfigSupportTest_ComposedAgent__AiAgent");
@@ -200,6 +226,67 @@ public class A2AAgentConfigSupportTest {
 
         assertThat(Arrays.asList(constructor.getParameterTypes()),
                    contains(Config.class, ServiceRegistry.class, Optional.class));
+    }
+
+    @Test
+    void humanInTheLoopRetainsDistinctTopLevelAndNestedPrecedence() throws ReflectiveOperationException {
+        var invalidConfig = invalidHumanAgentConfig();
+        assertThrows(ConfigMappingException.class,
+                     () -> AgentsConfig.create(invalidConfig.get("langchain4j.agents.human-a2a")));
+
+        var manager = ServiceRegistryManager.create();
+        try {
+            var composedType = Class.forName(getClass().getPackageName()
+                                                     + ".A2AAgentConfigSupportTest_ComposedAgent__AiAgent");
+            var composedConstructor = composedType.getDeclaredConstructor(Config.class,
+                                                                          ServiceRegistry.class,
+                                                                          Optional.class);
+            composedConstructor.setAccessible(true);
+            var composedSupplier = composedConstructor.newInstance(invalidConfig,
+                                                                   manager.registry(),
+                                                                   Optional.empty());
+            var resolver = composedType.getDeclaredMethod("resolveSubAgent", Class.class);
+            resolver.setAccessible(true);
+
+            assertThat(resolver.invoke(composedSupplier, HumanAndA2AAgent.class), is(nullValue()));
+            assertThat(recordingService.builder, is(nullValue()));
+
+            var generatedType = Class.forName(getClass().getPackageName()
+                                                      + ".A2AAgentConfigSupportTest_HumanAndA2AAgent__AiAgent");
+            var constructor = generatedType.getDeclaredConstructor(Config.class, ServiceRegistry.class);
+            constructor.setAccessible(true);
+            var supplier = constructor.newInstance(Config.empty(), manager.registry());
+            var get = generatedType.getDeclaredMethod("get");
+            get.setAccessible(true);
+
+            assertThat(get.invoke(supplier), instanceOf(HumanAndA2AAgent.class));
+            assertThat(recordingService.serverUrl, is("https://human-a2a.example.test"));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
+    void disabledNestedA2AAgentDoesNotStartDiscovery() throws ReflectiveOperationException {
+        var manager = ServiceRegistryManager.create();
+        try {
+            var generatedType = Class.forName(getClass().getPackageName()
+                                                      + ".A2AAgentConfigSupportTest_ComposedAgent__AiAgent");
+            var constructor = generatedType.getDeclaredConstructor(Config.class, ServiceRegistry.class, Optional.class);
+            constructor.setAccessible(true);
+            var supplier = constructor.newInstance(disabledAnnotatedAgentConfig(), manager.registry(), Optional.empty());
+            var resolver = generatedType.getDeclaredMethod("resolveSubAgent", Class.class);
+            resolver.setAccessible(true);
+
+            var error = assertThrows(InvocationTargetException.class,
+                                     () -> resolver.invoke(supplier, AnnotatedAgent.class));
+
+            assertThat(error.getCause(), instanceOf(IllegalStateException.class));
+            assertThat(error.getCause().getMessage(), containsString("disabled"));
+            assertThat(recordingService.builder, is(nullValue()));
+        } finally {
+            manager.shutdown();
+        }
     }
 
     @Test
@@ -218,6 +305,29 @@ public class A2AAgentConfigSupportTest {
         } finally {
             manager.shutdown();
         }
+    }
+
+    private static Config disabledAnnotatedAgentConfig() {
+        // language=YAML
+        String yaml = """
+                langchain4j:
+                  agents:
+                    annotated-a2a:
+                      enabled: false
+                """;
+        return Config.just(ConfigSources.create(yaml, MediaTypes.APPLICATION_X_YAML));
+    }
+
+    private static Config invalidHumanAgentConfig() {
+        // language=YAML
+        String yaml = """
+                langchain4j:
+                  agents:
+                    human-a2a:
+                      tools:
+                        - missing.test.Tool
+                """;
+        return Config.just(ConfigSources.create(yaml, MediaTypes.APPLICATION_X_YAML));
     }
 
     @Ai.Agent("annotated-a2a")
@@ -285,6 +395,17 @@ public class A2AAgentConfigSupportTest {
     public interface UnannotatedWorkflow {
         @SequenceAgent(subAgents = UnannotatedAgent.class)
         String compose(@V("question") String question);
+    }
+
+    @Ai.Agent("human-a2a")
+    public interface HumanAndA2AAgent {
+        @HumanInTheLoop
+        static String review(@V("question") String question) {
+            return question;
+        }
+
+        @A2AClientAgent(a2aServerUrl = "https://human-a2a.example.test")
+        String ask(@V("question") String question);
     }
 
     public static class TypedOutput implements TypedKey<String> {

--- a/extensions/langchain4j/modules/langchain4j/src/test/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupportTest.java
+++ b/extensions/langchain4j/modules/langchain4j/src/test/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupportTest.java
@@ -16,10 +16,8 @@
 
 package io.helidon.extensions.langchain4j;
 
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
-import java.util.Arrays;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
@@ -28,7 +26,7 @@ import io.helidon.common.media.type.MediaTypes;
 import io.helidon.config.Config;
 import io.helidon.config.ConfigMappingException;
 import io.helidon.config.ConfigSources;
-import io.helidon.service.registry.ServiceRegistry;
+import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
 
 import dev.langchain4j.agentic.declarative.A2AClientAgent;
@@ -51,9 +49,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.arrayContaining;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -186,80 +182,22 @@ public class A2AAgentConfigSupportTest {
     }
 
     @Test
-    void generatedTopLevelA2AAgentDoesNotRequireChatModel() throws ReflectiveOperationException {
-        var generatedType = Class.forName(getClass().getPackageName()
-                                                  + ".A2AAgentConfigSupportTest_AnnotatedAgent__AiAgent");
-        var constructor = generatedType.getDeclaredConstructors()[0];
+    void rejectsNullAgentType() {
+        var error = assertThrows(NullPointerException.class,
+                                 () -> AgentsConfig.create().createA2AAgent(null));
 
-        assertThat(Arrays.asList(constructor.getParameterTypes()), contains(Config.class, ServiceRegistry.class));
+        assertThat(error.getMessage(), is("agentType"));
+        assertThat(recordingService.builder, is(nullValue()));
     }
 
     @Test
-    void disabledTopLevelA2AAgentDoesNotStartDiscovery() throws ReflectiveOperationException {
-        var manager = ServiceRegistryManager.create();
+    void createsTopLevelA2AAgentThroughRegistryWithoutChatModel() {
+        var manager = registryManager(Config.empty());
         try {
-            var generatedType = Class.forName(getClass().getPackageName()
-                                                      + ".A2AAgentConfigSupportTest_AnnotatedAgent__AiAgent");
-            var constructor = generatedType.getDeclaredConstructor(Config.class, ServiceRegistry.class);
-            constructor.setAccessible(true);
-            var supplier = constructor.newInstance(disabledAnnotatedAgentConfig(), manager.registry());
-            var get = generatedType.getDeclaredMethod("get");
-            get.setAccessible(true);
+            var agent = manager.registry().get(HumanAndA2AAgent.class);
 
-            var error = assertThrows(InvocationTargetException.class, () -> get.invoke(supplier));
-
-            assertThat(error.getCause(), instanceOf(IllegalStateException.class));
-            assertThat(error.getCause().getMessage(), containsString("disabled"));
-            assertThat(recordingService.builder, is(nullValue()));
-        } finally {
-            manager.shutdown();
-        }
-    }
-
-    @Test
-    void composedAgentTakesPrecedenceOverInheritedA2AAgent() throws ReflectiveOperationException {
-        assertThat(AgentsConfig.isA2ASubAgent(ComposedAgent.class), is(false));
-
-        var generatedType = Class.forName(getClass().getPackageName()
-                                                  + ".A2AAgentConfigSupportTest_ComposedAgent__AiAgent");
-        var constructor = generatedType.getDeclaredConstructors()[0];
-
-        assertThat(Arrays.asList(constructor.getParameterTypes()),
-                   contains(Config.class, ServiceRegistry.class, Optional.class));
-    }
-
-    @Test
-    void humanInTheLoopRetainsDistinctTopLevelAndNestedPrecedence() throws ReflectiveOperationException {
-        var invalidConfig = invalidHumanAgentConfig();
-        assertThrows(ConfigMappingException.class,
-                     () -> AgentsConfig.create(invalidConfig.get("langchain4j.agents.human-a2a")));
-
-        var manager = ServiceRegistryManager.create();
-        try {
-            var composedType = Class.forName(getClass().getPackageName()
-                                                     + ".A2AAgentConfigSupportTest_ComposedAgent__AiAgent");
-            var composedConstructor = composedType.getDeclaredConstructor(Config.class,
-                                                                          ServiceRegistry.class,
-                                                                          Optional.class);
-            composedConstructor.setAccessible(true);
-            var composedSupplier = composedConstructor.newInstance(invalidConfig,
-                                                                   manager.registry(),
-                                                                   Optional.empty());
-            var resolver = composedType.getDeclaredMethod("resolveSubAgent", Class.class);
-            resolver.setAccessible(true);
-
-            assertThat(resolver.invoke(composedSupplier, HumanAndA2AAgent.class), is(nullValue()));
-            assertThat(recordingService.builder, is(nullValue()));
-
-            var generatedType = Class.forName(getClass().getPackageName()
-                                                      + ".A2AAgentConfigSupportTest_HumanAndA2AAgent__AiAgent");
-            var constructor = generatedType.getDeclaredConstructor(Config.class, ServiceRegistry.class);
-            constructor.setAccessible(true);
-            var supplier = constructor.newInstance(Config.empty(), manager.registry());
-            var get = generatedType.getDeclaredMethod("get");
-            get.setAccessible(true);
-
-            assertThat(get.invoke(supplier), instanceOf(HumanAndA2AAgent.class));
+            assertThat(agent, is(notNullValue()));
+            assertThat(recordingService.builder.agentType.getName(), is(HumanAndA2AAgent.class.getName()));
             assertThat(recordingService.serverUrl, is("https://human-a2a.example.test"));
         } finally {
             manager.shutdown();
@@ -267,22 +205,13 @@ public class A2AAgentConfigSupportTest {
     }
 
     @Test
-    void disabledNestedA2AAgentDoesNotStartDiscovery() throws ReflectiveOperationException {
-        var manager = ServiceRegistryManager.create();
+    void disabledTopLevelA2AAgentDoesNotStartDiscovery() {
+        var manager = registryManager(disabledHumanAgentConfig());
         try {
-            var generatedType = Class.forName(getClass().getPackageName()
-                                                      + ".A2AAgentConfigSupportTest_ComposedAgent__AiAgent");
-            var constructor = generatedType.getDeclaredConstructor(Config.class, ServiceRegistry.class, Optional.class);
-            constructor.setAccessible(true);
-            var supplier = constructor.newInstance(disabledAnnotatedAgentConfig(), manager.registry(), Optional.empty());
-            var resolver = generatedType.getDeclaredMethod("resolveSubAgent", Class.class);
-            resolver.setAccessible(true);
+            var error = assertThrows(IllegalStateException.class,
+                                     () -> manager.registry().get(HumanAndA2AAgent.class));
 
-            var error = assertThrows(InvocationTargetException.class,
-                                     () -> resolver.invoke(supplier, AnnotatedAgent.class));
-
-            assertThat(error.getCause(), instanceOf(IllegalStateException.class));
-            assertThat(error.getCause().getMessage(), containsString("disabled"));
+            assertThat(error.getMessage(), containsString("disabled"));
             assertThat(recordingService.builder, is(nullValue()));
         } finally {
             manager.shutdown();
@@ -290,21 +219,40 @@ public class A2AAgentConfigSupportTest {
     }
 
     @Test
-    void unannotatedA2ASubAgentFallsThroughToLangChain4j() throws ReflectiveOperationException {
-        var manager = ServiceRegistryManager.create();
-        try {
-            var generatedType = Class.forName(getClass().getPackageName()
-                                                      + ".A2AAgentConfigSupportTest_UnannotatedWorkflow__AiAgent");
-            var constructor = generatedType.getDeclaredConstructor(Config.class, ServiceRegistry.class, Optional.class);
-            constructor.setAccessible(true);
-            var supplier = constructor.newInstance(Config.empty(), manager.registry(), Optional.empty());
-            var resolver = generatedType.getDeclaredMethod("resolveSubAgent", Class.class);
-            resolver.setAccessible(true);
+    void composedAgentTakesPrecedenceOverInheritedA2AAgent() {
+        var invalidConfig = invalidHumanAgentConfig();
+        assertThrows(ConfigMappingException.class,
+                     () -> AgentsConfig.create(invalidConfig.get("langchain4j.agents.human-a2a")));
 
-            assertThat(resolver.invoke(supplier, UnannotatedAgent.class), is(nullValue()));
+        var manager = registryManager(invalidConfig);
+        try {
+            var agent = manager.registry().get(ComposedAgent.class);
+
+            assertThat(agent, is(notNullValue()));
+            assertThat(recordingService.builder, is(nullValue()));
         } finally {
             manager.shutdown();
         }
+    }
+
+    @Test
+    void disabledNestedA2AAgentDoesNotStartDiscovery() {
+        var manager = registryManager(disabledAnnotatedAgentConfig());
+        try {
+            var error = assertThrows(IllegalStateException.class,
+                                     () -> manager.registry().get(NestedA2AWorkflow.class));
+
+            assertThat(error.getMessage(), containsString("disabled"));
+            assertThat(recordingService.builder, is(nullValue()));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    private static ServiceRegistryManager registryManager(Config config) {
+        return ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                     .putContractInstance(Config.class, config)
+                                                     .build());
     }
 
     private static Config disabledAnnotatedAgentConfig() {
@@ -313,6 +261,17 @@ public class A2AAgentConfigSupportTest {
                 langchain4j:
                   agents:
                     annotated-a2a:
+                      enabled: false
+                """;
+        return Config.just(ConfigSources.create(yaml, MediaTypes.APPLICATION_X_YAML));
+    }
+
+    private static Config disabledHumanAgentConfig() {
+        // language=YAML
+        String yaml = """
+                langchain4j:
+                  agents:
+                    human-a2a:
                       enabled: false
                 """;
         return Config.just(ConfigSources.create(yaml, MediaTypes.APPLICATION_X_YAML));
@@ -382,18 +341,7 @@ public class A2AAgentConfigSupportTest {
 
     @Ai.Agent("composed-agent")
     public interface ComposedAgent extends AnnotatedAgent {
-        @SequenceAgent(subAgents = AnnotatedAgent.class)
-        String compose(@V("question") String question);
-    }
-
-    public interface UnannotatedAgent {
-        @A2AClientAgent(a2aServerUrl = "https://annotation.example.test/a2a")
-        String ask(@V("question") String question);
-    }
-
-    @Ai.Agent("unannotated-workflow")
-    public interface UnannotatedWorkflow {
-        @SequenceAgent(subAgents = UnannotatedAgent.class)
+        @SequenceAgent(subAgents = HumanAndA2AAgent.class)
         String compose(@V("question") String question);
     }
 
@@ -406,6 +354,12 @@ public class A2AAgentConfigSupportTest {
 
         @A2AClientAgent(a2aServerUrl = "https://human-a2a.example.test")
         String ask(@V("question") String question);
+    }
+
+    @Ai.Agent("nested-a2a-workflow")
+    public interface NestedA2AWorkflow {
+        @SequenceAgent(subAgents = AnnotatedAgent.class)
+        String compose(@V("question") String question);
     }
 
     public static class TypedOutput implements TypedKey<String> {

--- a/extensions/langchain4j/modules/langchain4j/src/test/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupportTest.java
+++ b/extensions/langchain4j/modules/langchain4j/src/test/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupportTest.java
@@ -29,6 +29,7 @@ import io.helidon.config.ConfigSources;
 import io.helidon.service.registry.ServiceRegistryConfig;
 import io.helidon.service.registry.ServiceRegistryManager;
 
+import dev.langchain4j.agentic.Agent;
 import dev.langchain4j.agentic.declarative.A2AClientAgent;
 import dev.langchain4j.agentic.declarative.A2AClientCustomizer;
 import dev.langchain4j.agentic.declarative.A2AServerUrlSupplier;
@@ -42,6 +43,11 @@ import dev.langchain4j.agentic.internal.AgentExecutor;
 import dev.langchain4j.agentic.internal.InternalAgent;
 import dev.langchain4j.agentic.observability.AgentListener;
 import dev.langchain4j.agentic.planner.AgenticSystemConfigurationException;
+import dev.langchain4j.data.message.AiMessage;
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.request.ChatRequest;
+import dev.langchain4j.model.chat.response.ChatResponse;
+import dev.langchain4j.service.UserMessage;
 import dev.langchain4j.service.V;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -236,6 +242,21 @@ public class A2AAgentConfigSupportTest {
     }
 
     @Test
+    void overriddenA2AAnnotationUsesLocalAgent() {
+        var chatModel = new RecordingChatModel();
+        var manager = registryManager(Config.empty(), chatModel);
+        try {
+            var agent = manager.registry().get(OverrideShadowingAgent.class);
+
+            assertThat(agent.ask("local question"), is("local-model-response"));
+            assertThat(chatModel.invocations, is(1));
+            assertThat(recordingService.builder, is(nullValue()));
+        } finally {
+            manager.shutdown();
+        }
+    }
+
+    @Test
     void disabledNestedA2AAgentDoesNotStartDiscovery() {
         var manager = registryManager(disabledAnnotatedAgentConfig());
         try {
@@ -252,6 +273,13 @@ public class A2AAgentConfigSupportTest {
     private static ServiceRegistryManager registryManager(Config config) {
         return ServiceRegistryManager.create(ServiceRegistryConfig.builder()
                                                      .putContractInstance(Config.class, config)
+                                                     .build());
+    }
+
+    private static ServiceRegistryManager registryManager(Config config, ChatModel chatModel) {
+        return ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                     .putContractInstance(Config.class, config)
+                                                     .putContractInstance(ChatModel.class, chatModel)
                                                      .build());
     }
 
@@ -362,7 +390,32 @@ public class A2AAgentConfigSupportTest {
         String compose(@V("question") String question);
     }
 
+    public interface ParentA2AAgent {
+        @A2AClientAgent(a2aServerUrl = "a2a+test:shadowed-parent")
+        String ask(@V("question") String question);
+    }
+
+    @Ai.Agent("override-shadowing-agent")
+    public interface OverrideShadowingAgent extends ParentA2AAgent {
+        @Override
+        @Agent(description = "Local override", outputKey = "answer")
+        @UserMessage("{{question}}")
+        String ask(@V("question") String question);
+    }
+
     public static class TypedOutput implements TypedKey<String> {
+    }
+
+    private static final class RecordingChatModel implements ChatModel {
+        private int invocations;
+
+        @Override
+        public ChatResponse doChat(ChatRequest request) {
+            invocations++;
+            return ChatResponse.builder()
+                    .aiMessage(AiMessage.from("local-model-response"))
+                    .build();
+        }
     }
 
     private static final class RecordingA2AService implements A2AService {

--- a/extensions/langchain4j/modules/providers/cohere/pom.xml
+++ b/extensions/langchain4j/modules/providers/cohere/pom.xml
@@ -101,6 +101,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.common.testing</groupId>
             <artifactId>helidon-common-testing-junit5</artifactId>
             <scope>test</scope>

--- a/extensions/langchain4j/modules/providers/cohere/src/test/java/io/helidon/extensions/langchain4j/providers/cohere/CohereProviderContractTest.java
+++ b/extensions/langchain4j/modules/providers/cohere/src/test/java/io/helidon/extensions/langchain4j/providers/cohere/CohereProviderContractTest.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.providers.cohere;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import dev.langchain4j.data.segment.TextSegment;
+import dev.langchain4j.model.cohere.CohereEmbeddingModel;
+import dev.langchain4j.model.cohere.CohereScoringModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.scoring.ScoringModel;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+@ServerTest
+class CohereProviderContractTest {
+
+    private static final String API_KEY = "contract-api-key";
+    private static final String LOGICAL_MODEL_NAME = "cohere-contract-model";
+    private static final ConcurrentLinkedQueue<CapturedRequest> REQUESTS = new ConcurrentLinkedQueue<>();
+
+    private final URI serverUri;
+
+    CohereProviderContractTest(URI serverUri) {
+        this.serverUri = serverUri;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRules rules) {
+        rules.post("/v2/embed", (req, res) -> {
+            REQUESTS.add(capture(req));
+            res.headers().contentType(MediaTypes.APPLICATION_JSON);
+            res.send("""
+                             {
+                               "id": "embed-v2",
+                               "embeddings": {"float": [[0.125, -0.5, 0.75]]},
+                               "meta": {"billed_units": {"input_tokens": 2}}
+                             }
+                             """);
+        });
+        rules.post("/v1/embed", (req, res) -> {
+            REQUESTS.add(capture(req));
+            res.headers().contentType(MediaTypes.APPLICATION_JSON);
+            res.send("""
+                             {
+                               "id": "embed-v1",
+                               "texts": ["first", "second"],
+                               "embeddings": [[1.0, 0.0], [0.0, 1.0]],
+                               "meta": {"billed_units": {"input_tokens": 2}}
+                             }
+                             """);
+        });
+        rules.post("/v1/rerank", (req, res) -> {
+            REQUESTS.add(capture(req));
+            res.headers().contentType(MediaTypes.APPLICATION_JSON);
+            res.send("""
+                             {
+                               "id": "rerank",
+                               "results": [
+                                 {"index": 1, "relevance_score": 0.25},
+                                 {"index": 0, "relevance_score": 0.9}
+                               ],
+                               "meta": {"billed_units": {"search_units": 1}}
+                             }
+                             """);
+        });
+    }
+
+    @Test
+    void exercisesEmbeddingAndScoringModelsThroughHelidon() {
+        ServiceRegistryManager registryManager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                        .putContractInstance(Config.class,
+                                                                                                             config())
+                                                                                        .build());
+        try {
+            var registry = registryManager.registry();
+            EmbeddingModel embeddingModel = registry.getNamed(EmbeddingModel.class, LOGICAL_MODEL_NAME);
+            ScoringModel scoringModel = registry.getNamed(ScoringModel.class, LOGICAL_MODEL_NAME);
+            assertThat(embeddingModel, instanceOf(CohereEmbeddingModel.class));
+            assertThat(scoringModel, instanceOf(CohereScoringModel.class));
+
+            assertThat(embeddingModel.embed("cohere-v2-prompt").content().vectorAsList(),
+                       contains(0.125F, -0.5F, 0.75F));
+            assertThat(embeddingModel.embedAll(List.of(TextSegment.from("first"), TextSegment.from("second")))
+                                       .content()
+                                       .stream()
+                                       .map(embedding -> embedding.vectorAsList())
+                                       .toList(),
+                       is(List.of(List.of(1.0F, 0.0F), List.of(0.0F, 1.0F))));
+            assertThat(scoringModel.scoreAll(List.of(TextSegment.from("first"), TextSegment.from("second")),
+                                             "contract-query")
+                                   .content(),
+                       contains(0.9, 0.25));
+        } finally {
+            registryManager.shutdown();
+        }
+
+        CapturedRequest v2EmbeddingRequest = REQUESTS.remove();
+        assertThat(v2EmbeddingRequest.path(), is("/v2/embed"));
+        assertCommonRequest(v2EmbeddingRequest);
+        assertThat(compactJson(v2EmbeddingRequest.body()), containsString("\"model\":\"contract-model\""));
+        assertThat(compactJson(v2EmbeddingRequest.body()), containsString("\"input_type\":\"search_document\""));
+        assertThat(compactJson(v2EmbeddingRequest.body()), containsString("\"embedding_types\":[\"float\"]"));
+        assertThat(compactJson(v2EmbeddingRequest.body()),
+                   containsString("\"inputs\":[{\"content\":[{\"type\":\"text\",\"text\":\"cohere-v2-prompt\"}]"));
+
+        CapturedRequest v1EmbeddingRequest = REQUESTS.remove();
+        assertThat(v1EmbeddingRequest.path(), is("/v1/embed"));
+        assertCommonRequest(v1EmbeddingRequest);
+        assertThat(compactJson(v1EmbeddingRequest.body()), containsString("\"model\":\"contract-model\""));
+        assertThat(compactJson(v1EmbeddingRequest.body()), containsString("\"input_type\":\"search_document\""));
+        assertThat(compactJson(v1EmbeddingRequest.body()), containsString("\"texts\":[\"first\",\"second\"]"));
+
+        CapturedRequest scoringRequest = REQUESTS.remove();
+        assertThat(scoringRequest.path(), is("/v1/rerank"));
+        assertCommonRequest(scoringRequest);
+        assertThat(compactJson(scoringRequest.body()), containsString("\"model\":\"contract-model\""));
+        assertThat(compactJson(scoringRequest.body()), containsString("\"query\":\"contract-query\""));
+        assertThat(compactJson(scoringRequest.body()), containsString("\"documents\":[\"first\",\"second\"]"));
+        assertThat(REQUESTS.isEmpty(), is(true));
+    }
+
+    private static void assertCommonRequest(CapturedRequest request) {
+        assertThat(request.authorization(), is("Bearer " + API_KEY));
+        assertThat(request.contentType(), containsString(MediaTypes.APPLICATION_JSON_VALUE));
+        assertThat(request.accept(), containsString(MediaTypes.APPLICATION_JSON_VALUE));
+    }
+
+    private static CapturedRequest capture(ServerRequest request) {
+        Map<String, List<String>> headers = request.headers().toMap();
+        return new CapturedRequest(request.path().absolute().rawPath(),
+                                   header(headers, "authorization"),
+                                   header(headers, "content-type"),
+                                   header(headers, "accept"),
+                                   request.content().as(String.class));
+    }
+
+    private static String compactJson(String json) {
+        return json.replaceAll("\\s", "");
+    }
+
+    private static String header(Map<String, List<String>> headers, String name) {
+        return headers.entrySet()
+                .stream()
+                .filter(entry -> entry.getKey().equalsIgnoreCase(name))
+                .flatMap(entry -> entry.getValue().stream())
+                .findFirst()
+                .orElse("");
+    }
+
+    private Config config() {
+        REQUESTS.clear();
+        String baseUrl = serverUri.resolve("v1/").toString();
+        // language=YAML
+        String yaml = """
+                langchain4j:
+                  models:
+                    %s:
+                      provider: cohere
+                      api-key: %s
+                      model-name: contract-model
+                      base-url: %s
+                      input-type: search_document
+                      timeout: PT5S
+                      max-retries: 0
+                      http-client-builder-discover-services: false
+                      listeners-discover-services: false
+                """.formatted(LOGICAL_MODEL_NAME, API_KEY, baseUrl);
+        return Config.just(ConfigSources.create(yaml, MediaTypes.APPLICATION_X_YAML));
+    }
+
+    private record CapturedRequest(String path, String authorization, String contentType, String accept, String body) {
+    }
+}

--- a/extensions/langchain4j/modules/providers/google-gemini/pom.xml
+++ b/extensions/langchain4j/modules/providers/google-gemini/pom.xml
@@ -106,6 +106,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>dev.langchain4j</groupId>
             <artifactId>langchain4j</artifactId>
             <scope>test</scope>

--- a/extensions/langchain4j/modules/providers/google-gemini/src/test/java/io/helidon/extensions/langchain4j/providers/google/gemini/GoogleGeminiProviderContractTest.java
+++ b/extensions/langchain4j/modules/providers/google-gemini/src/test/java/io/helidon/extensions/langchain4j/providers/google/gemini/GoogleGeminiProviderContractTest.java
@@ -1,0 +1,224 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.providers.google.gemini;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.extensions.langchain4j.Ai;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.googleai.GoogleAiGeminiChatModel;
+import dev.langchain4j.model.googleai.GoogleAiGeminiStreamingChatModel;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+@ServerTest
+class GoogleGeminiProviderContractTest {
+
+    private static final String API_KEY = "contract-api-key";
+    private static final String CHAT_MODEL_NAME = "contract-chat-model";
+    private static final String CUSTOM_HEADER_VALUE = "gemini-contract";
+    private static final String STREAMING_MODEL_NAME = "contract-streaming-model";
+    private static final ConcurrentLinkedQueue<CapturedRequest> REQUESTS = new ConcurrentLinkedQueue<>();
+
+    private final URI serverUri;
+
+    GoogleGeminiProviderContractTest(URI serverUri) {
+        this.serverUri = serverUri;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRules rules) {
+        rules.post("/v1beta/models/contract-model:generateContent", (req, res) -> {
+            REQUESTS.add(capture(req));
+            res.headers().contentType(MediaTypes.APPLICATION_JSON);
+            res.send(response("gemini-sync-ok", true));
+        });
+        rules.post("/v1beta/models/contract-model:streamGenerateContent", (req, res) -> {
+            REQUESTS.add(capture(req));
+            res.headers().contentType(MediaTypes.TEXT_EVENT_STREAM);
+            res.send("data: " + compactJson(response("gemini-", false))
+                             + "\n\ndata: " + compactJson(response("stream-ok", true))
+                             + "\n\n");
+        });
+    }
+
+    @Test
+    void exercisesSyncAndStreamingModelsThroughHelidon() {
+        ServiceRegistryManager registryManager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                        .putContractInstance(Config.class,
+                                                                                                             config())
+                                                                                        .build());
+        try {
+            var registry = registryManager.registry();
+            assertThat(registry.getNamed(ChatModel.class, CHAT_MODEL_NAME),
+                       instanceOf(GoogleAiGeminiChatModel.class));
+            assertThat(registry.getNamed(StreamingChatModel.class, STREAMING_MODEL_NAME),
+                       instanceOf(GoogleAiGeminiStreamingChatModel.class));
+
+            ContractChatService chatService = registry.get(ContractChatService.class);
+            assertThat(chatService.chat("sync-contract-prompt"), is("gemini-sync-ok"));
+
+            ContractStreamingService streamingService = registry.get(ContractStreamingService.class);
+            assertThat(streamingService.chat("stream-contract-prompt").collect(Collectors.joining()),
+                       is("gemini-stream-ok"));
+        } finally {
+            registryManager.shutdown();
+        }
+
+        CapturedRequest syncRequest = REQUESTS.remove();
+        assertThat(syncRequest.path(), is("/v1beta/models/contract-model:generateContent"));
+        assertThat(syncRequest.query().isEmpty(), is(true));
+        assertCommonRequest(syncRequest, "sync-contract-prompt");
+
+        CapturedRequest streamingRequest = REQUESTS.remove();
+        assertThat(streamingRequest.path(), is("/v1beta/models/contract-model:streamGenerateContent"));
+        assertThat(streamingRequest.query().get("alt"), is(List.of("sse")));
+        assertCommonRequest(streamingRequest, "stream-contract-prompt");
+        assertThat(REQUESTS.isEmpty(), is(true));
+    }
+
+    private static void assertCommonRequest(CapturedRequest request, String prompt) {
+        String body = compactJson(request.body());
+        assertThat(request.apiKey(), is(API_KEY));
+        assertThat(request.customHeader(), is(CUSTOM_HEADER_VALUE));
+        assertThat(request.contentType(), containsString(MediaTypes.APPLICATION_JSON_VALUE));
+        assertThat(body, containsString("\"contents\":[{"));
+        assertThat(body, containsString("\"parts\":[{\"text\":\"" + prompt + "\"}]"));
+        assertThat(body, containsString("\"role\":\"user\""));
+        assertThat(body, containsString("\"generationConfig\":{"));
+        assertThat(body, containsString("\"temperature\":0.2"));
+    }
+
+    private static CapturedRequest capture(ServerRequest request) {
+        Map<String, List<String>> headers = request.headers().toMap();
+        return new CapturedRequest(request.path().absolute().rawPath(),
+                                   request.query().toMap(),
+                                   header(headers, "x-goog-api-key"),
+                                   header(headers, "x-contract-header"),
+                                   header(headers, "content-type"),
+                                   request.content().as(String.class));
+    }
+
+    private static String compactJson(String json) {
+        return json.replaceAll("\\s", "");
+    }
+
+    private static String header(Map<String, List<String>> headers, String name) {
+        return headers.entrySet()
+                .stream()
+                .filter(entry -> entry.getKey().equalsIgnoreCase(name))
+                .flatMap(entry -> entry.getValue().stream())
+                .findFirst()
+                .orElse("");
+    }
+
+    private static String response(String text, boolean complete) {
+        return """
+                {
+                  "responseId": "gemini-contract",
+                  "modelVersion": "contract-model",
+                  "candidates": [
+                    {
+                      "content": {"role": "model", "parts": [{"text": "%s"}]},
+                      "finishReason": %s
+                    }
+                  ],
+                  "usageMetadata": {"promptTokenCount": 1, "candidatesTokenCount": 1, "totalTokenCount": 2}
+                }
+                """.formatted(text, complete ? "\"STOP\"" : "null");
+    }
+
+    private Config config() {
+        REQUESTS.clear();
+        String baseUrl = serverUri.resolve("v1beta").toString();
+        // language=YAML
+        String yaml = """
+                langchain4j:
+                  models:
+                    %s:
+                      provider: google-gemini
+                      api-key: %s
+                      model-name: contract-model
+                      base-url: %s
+                      temperature: 0.2
+                      max-retries: 0
+                      timeout: PT5S
+                      custom-headers.X-Contract-Header: %s
+                      http-client-builder-discover-services: false
+                      listeners-discover-services: false
+                    %s:
+                      provider: google-gemini
+                      api-key: %s
+                      model-name: contract-model
+                      base-url: %s
+                      temperature: 0.2
+                      max-retries: 0
+                      timeout: PT5S
+                      custom-headers.X-Contract-Header: %s
+                      http-client-builder-discover-services: false
+                      listeners-discover-services: false
+                """.formatted(CHAT_MODEL_NAME,
+                               API_KEY,
+                               baseUrl,
+                               CUSTOM_HEADER_VALUE,
+                               STREAMING_MODEL_NAME,
+                               API_KEY,
+                               baseUrl,
+                               CUSTOM_HEADER_VALUE);
+        return Config.just(ConfigSources.create(yaml, MediaTypes.APPLICATION_X_YAML));
+    }
+
+    @Ai.Service
+    @Ai.ChatModel(CHAT_MODEL_NAME)
+    public interface ContractChatService {
+        String chat(String prompt);
+    }
+
+    @Ai.Service
+    @Ai.StreamingChatModel(STREAMING_MODEL_NAME)
+    public interface ContractStreamingService {
+        Stream<String> chat(String prompt);
+    }
+
+    private record CapturedRequest(String path,
+                                   Map<String, List<String>> query,
+                                   String apiKey,
+                                   String customHeader,
+                                   String contentType,
+                                   String body) {
+    }
+}

--- a/extensions/langchain4j/modules/providers/ollama/pom.xml
+++ b/extensions/langchain4j/modules/providers/ollama/pom.xml
@@ -96,6 +96,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.helidon.config</groupId>
             <artifactId>helidon-config-yaml</artifactId>
             <scope>test</scope>

--- a/extensions/langchain4j/modules/providers/ollama/src/test/java/io/helidon/extensions/langchain4j/providers/ollama/OllamaProviderContractTest.java
+++ b/extensions/langchain4j/modules/providers/ollama/src/test/java/io/helidon/extensions/langchain4j/providers/ollama/OllamaProviderContractTest.java
@@ -1,0 +1,265 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.providers.ollama;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.extensions.langchain4j.Ai;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.language.LanguageModel;
+import dev.langchain4j.model.ollama.OllamaChatModel;
+import dev.langchain4j.model.ollama.OllamaEmbeddingModel;
+import dev.langchain4j.model.ollama.OllamaLanguageModel;
+import dev.langchain4j.model.ollama.OllamaStreamingChatModel;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+@ServerTest
+class OllamaProviderContractTest {
+
+    private static final String CUSTOM_HEADER_VALUE = "ollama-contract";
+    private static final String LOGICAL_MODEL_NAME = "ollama-contract-model";
+    private static final ConcurrentLinkedQueue<CapturedRequest> REQUESTS = new ConcurrentLinkedQueue<>();
+
+    private final URI serverUri;
+
+    OllamaProviderContractTest(URI serverUri) {
+        this.serverUri = serverUri;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRules rules) {
+        rules.post("/ollama/api/chat", (req, res) -> {
+            String body = req.content().as(String.class);
+            REQUESTS.add(capture(req, body));
+            if (compactJson(body).contains("\"stream\":true")) {
+                res.headers().contentType(MediaTypes.APPLICATION_X_NDJSON);
+                res.send("{\"model\":\"contract-model\",\"message\":{\"role\":\"assistant\","
+                                 + "\"content\":\"ollama-\"},\"done\":false}\n"
+                                 + "{\"model\":\"contract-model\",\"message\":{\"role\":\"assistant\","
+                                 + "\"content\":\"stream-ok\"},\"done_reason\":\"stop\",\"done\":true,"
+                                 + "\"prompt_eval_count\":1,\"eval_count\":1}\n");
+            } else {
+                res.headers().contentType(MediaTypes.APPLICATION_JSON);
+                res.send("""
+                                 {
+                                   "model": "contract-model",
+                                   "message": {"role": "assistant", "content": "ollama-sync-ok"},
+                                   "done_reason": "stop",
+                                   "done": true,
+                                   "prompt_eval_count": 1,
+                                   "eval_count": 1
+                                 }
+                                 """);
+            }
+        });
+        rules.post("/ollama/api/generate", (req, res) -> {
+            REQUESTS.add(capture(req));
+            res.headers().contentType(MediaTypes.APPLICATION_JSON);
+            res.send("""
+                             {
+                               "model": "contract-model",
+                               "response": "ollama-language-ok",
+                               "done": true,
+                               "prompt_eval_count": 1,
+                               "eval_count": 1
+                             }
+                             """);
+        });
+        rules.post("/ollama/api/embed", (req, res) -> {
+            REQUESTS.add(capture(req));
+            res.headers().contentType(MediaTypes.APPLICATION_JSON);
+            res.send("""
+                             {
+                               "model": "contract-model",
+                               "embeddings": [[0.125, -0.5, 0.75]],
+                               "prompt_eval_count": 1
+                             }
+                             """);
+        });
+    }
+
+    @Test
+    void exercisesAllOllamaModelsThroughHelidon() {
+        ServiceRegistryManager registryManager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                        .putContractInstance(Config.class,
+                                                                                                             config())
+                                                                                        .build());
+        try {
+            var registry = registryManager.registry();
+            assertThat(registry.getNamed(ChatModel.class, LOGICAL_MODEL_NAME), instanceOf(OllamaChatModel.class));
+            assertThat(registry.getNamed(StreamingChatModel.class, LOGICAL_MODEL_NAME),
+                       instanceOf(OllamaStreamingChatModel.class));
+
+            LanguageModel languageModel = registry.getNamed(LanguageModel.class, LOGICAL_MODEL_NAME);
+            EmbeddingModel embeddingModel = registry.getNamed(EmbeddingModel.class, LOGICAL_MODEL_NAME);
+            assertThat(languageModel, instanceOf(OllamaLanguageModel.class));
+            assertThat(embeddingModel, instanceOf(OllamaEmbeddingModel.class));
+
+            assertThat(registry.get(ContractChatService.class).chat("sync-contract-prompt"),
+                       is("ollama-sync-ok"));
+            assertThat(registry.get(ContractStreamingService.class)
+                               .chat("stream-contract-prompt")
+                               .collect(Collectors.joining()),
+                       is("ollama-stream-ok"));
+            assertThat(languageModel.generate("language-contract-prompt").content(), is("ollama-language-ok"));
+            assertArrayEquals(new float[] {0.125F, -0.5F, 0.75F},
+                              embeddingModel.embed("embedding-contract-prompt").content().vector());
+        } finally {
+            registryManager.shutdown();
+        }
+
+        CapturedRequest syncRequest = REQUESTS.remove();
+        assertThat(syncRequest.path(), is("/ollama/api/chat"));
+        assertCommonRequest(syncRequest);
+        assertThat(compactJson(syncRequest.body()),
+                   containsString("\"messages\":[{\"role\":\"user\",\"content\":\"sync-contract-prompt\"}]"));
+        assertConfiguredOptions(syncRequest);
+        assertThat(compactJson(syncRequest.body()), containsString("\"stream\":false"));
+
+        CapturedRequest streamingRequest = REQUESTS.remove();
+        assertThat(streamingRequest.path(), is("/ollama/api/chat"));
+        assertCommonRequest(streamingRequest);
+        assertThat(compactJson(streamingRequest.body()),
+                   containsString("\"messages\":[{\"role\":\"user\",\"content\":\"stream-contract-prompt\"}]"));
+        assertConfiguredOptions(streamingRequest);
+        assertThat(compactJson(streamingRequest.body()), containsString("\"stream\":true"));
+
+        CapturedRequest languageRequest = REQUESTS.remove();
+        assertThat(languageRequest.path(), is("/ollama/api/generate"));
+        assertCommonRequest(languageRequest);
+        assertThat(compactJson(languageRequest.body()),
+                   containsString("\"prompt\":\"language-contract-prompt\""));
+        assertConfiguredOptions(languageRequest);
+        assertThat(compactJson(languageRequest.body()), containsString("\"stream\":false"));
+
+        CapturedRequest embeddingRequest = REQUESTS.remove();
+        assertThat(embeddingRequest.path(), is("/ollama/api/embed"));
+        assertCommonRequest(embeddingRequest);
+        assertThat(compactJson(embeddingRequest.body()),
+                   containsString("\"input\":[\"embedding-contract-prompt\"]"));
+        assertThat(compactJson(embeddingRequest.body()), containsString("\"dimensions\":3"));
+        assertThat(REQUESTS.isEmpty(), is(true));
+    }
+
+    private static void assertCommonRequest(CapturedRequest request) {
+        assertThat(request.customHeader(), is(CUSTOM_HEADER_VALUE));
+        assertThat(request.contentType(), containsString(MediaTypes.APPLICATION_JSON_VALUE));
+        assertThat(compactJson(request.body()), containsString("\"model\":\"contract-model\""));
+    }
+
+    private static void assertConfiguredOptions(CapturedRequest request) {
+        String body = compactJson(request.body());
+        assertThat(body, containsString("\"temperature\":0.2"));
+        assertThat(body, containsString("\"top_k\":4"));
+        assertThat(body, containsString("\"top_p\":0.8"));
+        assertThat(body, containsString("\"repeat_penalty\":1.1"));
+        assertThat(body, containsString("\"seed\":42"));
+        assertThat(body, containsString("\"num_predict\":16"));
+        assertThat(body, containsString("\"stop\":[\"STOP\"]"));
+    }
+
+    private static CapturedRequest capture(ServerRequest request) {
+        return capture(request, request.content().as(String.class));
+    }
+
+    private static CapturedRequest capture(ServerRequest request, String body) {
+        Map<String, List<String>> headers = request.headers().toMap();
+        return new CapturedRequest(request.path().absolute().rawPath(),
+                                   header(headers, "x-contract-header"),
+                                   header(headers, "content-type"),
+                                   body);
+    }
+
+    private static String compactJson(String json) {
+        return json.replaceAll("\\s", "");
+    }
+
+    private static String header(Map<String, List<String>> headers, String name) {
+        return headers.entrySet()
+                .stream()
+                .filter(entry -> entry.getKey().equalsIgnoreCase(name))
+                .flatMap(entry -> entry.getValue().stream())
+                .findFirst()
+                .orElse("");
+    }
+
+    private Config config() {
+        REQUESTS.clear();
+        String baseUrl = serverUri.resolve("ollama").toString();
+        // language=YAML
+        String yaml = """
+                langchain4j:
+                  models:
+                    %s:
+                      provider: ollama
+                      model-name: contract-model
+                      base-url: %s
+                      temperature: 0.2
+                      top-k: 4
+                      top-p: 0.8
+                      repeat-penalty: 1.1
+                      seed: 42
+                      num-predict: 16
+                      stop: [STOP]
+                      dimensions: 3
+                      timeout: PT5S
+                      max-retries: 0
+                      custom-headers.X-Contract-Header: %s
+                      http-client-builder-discover-services: false
+                      listeners-discover-services: false
+                """.formatted(LOGICAL_MODEL_NAME, baseUrl, CUSTOM_HEADER_VALUE);
+        return Config.just(ConfigSources.create(yaml, MediaTypes.APPLICATION_X_YAML));
+    }
+
+    @Ai.Service
+    @Ai.ChatModel(LOGICAL_MODEL_NAME)
+    public interface ContractChatService {
+        String chat(String prompt);
+    }
+
+    @Ai.Service
+    @Ai.StreamingChatModel(LOGICAL_MODEL_NAME)
+    public interface ContractStreamingService {
+        Stream<String> chat(String prompt);
+    }
+
+    private record CapturedRequest(String path, String customHeader, String contentType, String body) {
+    }
+}

--- a/extensions/langchain4j/modules/providers/ollama/src/test/java/io/helidon/extensions/langchain4j/providers/ollama/OllamaProviderContractTest.java
+++ b/extensions/langchain4j/modules/providers/ollama/src/test/java/io/helidon/extensions/langchain4j/providers/ollama/OllamaProviderContractTest.java
@@ -45,10 +45,10 @@ import dev.langchain4j.model.ollama.OllamaStreamingChatModel;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 
 @ServerTest
 class OllamaProviderContractTest {
@@ -139,8 +139,8 @@ class OllamaProviderContractTest {
                                .collect(Collectors.joining()),
                        is("ollama-stream-ok"));
             assertThat(languageModel.generate("language-contract-prompt").content(), is("ollama-language-ok"));
-            assertArrayEquals(new float[] {0.125F, -0.5F, 0.75F},
-                              embeddingModel.embed("embedding-contract-prompt").content().vector());
+            assertThat(embeddingModel.embed("embedding-contract-prompt").content().vectorAsList(),
+                       contains(0.125F, -0.5F, 0.75F));
         } finally {
             registryManager.shutdown();
         }

--- a/extensions/langchain4j/modules/providers/open-ai/pom.xml
+++ b/extensions/langchain4j/modules/providers/open-ai/pom.xml
@@ -106,6 +106,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>

--- a/extensions/langchain4j/modules/providers/open-ai/src/test/java/io/helidon/extensions/langchain4j/providers/openai/OpenAiProviderContractTest.java
+++ b/extensions/langchain4j/modules/providers/open-ai/src/test/java/io/helidon/extensions/langchain4j/providers/openai/OpenAiProviderContractTest.java
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.providers.openai;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.config.Config;
+import io.helidon.config.ConfigSources;
+import io.helidon.extensions.langchain4j.Ai;
+import io.helidon.service.registry.ServiceRegistryConfig;
+import io.helidon.service.registry.ServiceRegistryManager;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import dev.langchain4j.model.chat.ChatModel;
+import dev.langchain4j.model.chat.StreamingChatModel;
+import dev.langchain4j.model.embedding.EmbeddingModel;
+import dev.langchain4j.model.openai.OpenAiChatModel;
+import dev.langchain4j.model.openai.OpenAiEmbeddingModel;
+import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ServerTest
+class OpenAiProviderContractTest {
+
+    private static final String API_KEY = "contract-api-key";
+    private static final String CHAT_MODEL_NAME = "contract-chat-model";
+    private static final String CUSTOM_HEADER_VALUE = "openai-contract";
+    private static final String EMBEDDING_MODEL_NAME = "contract-embedding-model";
+    private static final String STREAMING_MODEL_NAME = "contract-streaming-model";
+    private static final ConcurrentLinkedQueue<CapturedRequest> REQUESTS = new ConcurrentLinkedQueue<>();
+
+    private final URI serverUri;
+
+    OpenAiProviderContractTest(URI serverUri) {
+        this.serverUri = serverUri;
+    }
+
+    @SetUpRoute
+    static void routing(HttpRules rules) {
+        rules.post("/v1/chat/completions", (req, res) -> {
+            String body = req.content().as(String.class);
+            REQUESTS.add(capture(req, body));
+            if (compactJson(body).contains("\"stream\":true")) {
+                res.headers().contentType(MediaTypes.TEXT_EVENT_STREAM);
+                res.send("data: {\"id\":\"chatcmpl-stream\",\"model\":\"contract-model\",\"choices\":[{\"index\":0,"
+                                 + "\"delta\":{\"role\":\"assistant\",\"content\":\"openai-stream-ok\"},"
+                                 + "\"finish_reason\":\"stop\"}]}\n\ndata: [DONE]\n\n");
+            } else {
+                res.headers().contentType(MediaTypes.APPLICATION_JSON);
+                res.send("""
+                                 {
+                                   "id": "chatcmpl-sync",
+                                   "created": 1,
+                                   "model": "contract-model",
+                                   "choices": [
+                                     {
+                                       "index": 0,
+                                       "message": {"role": "assistant", "content": "openai-sync-ok"},
+                                       "finish_reason": "stop"
+                                     }
+                                   ],
+                                   "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2}
+                                 }
+                                 """);
+            }
+        });
+        rules.post("/v1/embeddings", (req, res) -> {
+            REQUESTS.add(capture(req, req.content().as(String.class)));
+            res.headers().contentType(MediaTypes.APPLICATION_JSON);
+            res.send("""
+                             {
+                               "model": "contract-model",
+                               "data": [{"index": 0, "embedding": [0.125, -0.5, 0.75]}],
+                               "usage": {"prompt_tokens": 2, "total_tokens": 2}
+                             }
+                             """);
+        });
+    }
+
+    @Test
+    void exercisesModelsThroughHelidon() {
+        ServiceRegistryManager registryManager = ServiceRegistryManager.create(ServiceRegistryConfig.builder()
+                                                                                        .putContractInstance(Config.class,
+                                                                                                             config())
+                                                                                        .build());
+        try {
+            var registry = registryManager.registry();
+            assertThat(registry.getNamed(ChatModel.class, CHAT_MODEL_NAME), instanceOf(OpenAiChatModel.class));
+            assertThat(registry.getNamed(StreamingChatModel.class, STREAMING_MODEL_NAME),
+                       instanceOf(OpenAiStreamingChatModel.class));
+            EmbeddingModel embeddingModel = registry.getNamed(EmbeddingModel.class, EMBEDDING_MODEL_NAME);
+            assertThat(embeddingModel, instanceOf(OpenAiEmbeddingModel.class));
+
+            ContractChatService chatService = registry.get(ContractChatService.class);
+            assertThat(chatService.chat("sync contract prompt"), is("openai-sync-ok"));
+
+            ContractStreamingService streamingService = registry.get(ContractStreamingService.class);
+            assertThat(streamingService.chat("stream contract prompt").collect(Collectors.joining()),
+                       is("openai-stream-ok"));
+            assertArrayEquals(new float[] {0.125F, -0.5F, 0.75F},
+                              embeddingModel.embed("embedding contract prompt").content().vector());
+        } finally {
+            registryManager.shutdown();
+        }
+
+        CapturedRequest syncRequest = REQUESTS.remove();
+        assertThat(syncRequest.path(), is("/v1/chat/completions"));
+        assertCommonRequest(syncRequest);
+        assertThat(compactJson(syncRequest.body()), containsString("\"model\":\"contract-model\""));
+        assertThat(syncRequest.body(), containsString("sync contract prompt"));
+        assertThat(compactJson(syncRequest.body()), containsString("\"messages\":[{"));
+        assertThat(compactJson(syncRequest.body()), containsString("\"role\":\"user\""));
+        assertThat(compactJson(syncRequest.body()), containsString("\"stream\":false"));
+
+        CapturedRequest streamingRequest = REQUESTS.remove();
+        assertThat(streamingRequest.path(), is("/v1/chat/completions"));
+        assertCommonRequest(streamingRequest);
+        assertThat(compactJson(streamingRequest.body()), containsString("\"model\":\"contract-model\""));
+        assertThat(streamingRequest.body(), containsString("stream contract prompt"));
+        assertThat(compactJson(streamingRequest.body()), containsString("\"messages\":[{"));
+        assertThat(compactJson(streamingRequest.body()), containsString("\"role\":\"user\""));
+        assertThat(compactJson(streamingRequest.body()), containsString("\"stream\":true"));
+
+        CapturedRequest embeddingRequest = REQUESTS.remove();
+        assertThat(embeddingRequest.path(), is("/v1/embeddings"));
+        assertCommonRequest(embeddingRequest);
+        assertTrue(embeddingRequest.body()
+                           .matches("(?s).*\"input\"\\s*:\\s*\\[\\s*\"embedding contract prompt\"\\s*].*"));
+        assertThat(compactJson(embeddingRequest.body()), containsString("\"model\":\"contract-model\""));
+        assertThat(compactJson(embeddingRequest.body()), containsString("\"dimensions\":3"));
+        assertThat(compactJson(embeddingRequest.body()), containsString("\"encoding_format\":\"float\""));
+        assertThat(compactJson(embeddingRequest.body()), containsString("\"user\":\"contract-user\""));
+        assertThat(REQUESTS.isEmpty(), is(true));
+    }
+
+    private static void assertCommonRequest(CapturedRequest request) {
+        assertThat(request.authorization(), is("Bearer " + API_KEY));
+        assertThat(request.organization(), is("contract-organization"));
+        assertThat(request.project(), is("contract-project"));
+        assertThat(request.customHeader(), is(CUSTOM_HEADER_VALUE));
+        assertThat(request.contentType(), containsString(MediaTypes.APPLICATION_JSON_VALUE));
+    }
+
+    private static CapturedRequest capture(ServerRequest request, String body) {
+        Map<String, List<String>> headers = request.headers().toMap();
+        return new CapturedRequest(request.path().absolute().rawPath(),
+                                   header(headers, "authorization"),
+                                   header(headers, "openai-organization"),
+                                   header(headers, "openai-project"),
+                                   header(headers, "x-contract-header"),
+                                   header(headers, "content-type"),
+                                   body);
+    }
+
+    private static String header(Map<String, List<String>> headers, String name) {
+        return headers.entrySet()
+                .stream()
+                .filter(entry -> entry.getKey().equalsIgnoreCase(name))
+                .flatMap(entry -> entry.getValue().stream())
+                .findFirst()
+                .orElse("");
+    }
+
+    private static String compactJson(String json) {
+        return json.replaceAll("\\s", "");
+    }
+
+    private Config config() {
+        REQUESTS.clear();
+        String baseUrl = serverUri.resolve("v1/").toString();
+        // language=YAML
+        String yaml = """
+                langchain4j:
+                  models:
+                    %s:
+                      provider: open-ai
+                      api-key: %s
+                      model-name: contract-model
+                      base-url: %s
+                      organization-id: contract-organization
+                      project-id: contract-project
+                      custom-headers.X-Contract-Header: %s
+                      timeout: PT5S
+                      max-retries: 0
+                      http-client-builder-discover-services: false
+                      listeners-discover-services: false
+                    %s:
+                      provider: open-ai
+                      api-key: %s
+                      model-name: contract-model
+                      base-url: %s
+                      organization-id: contract-organization
+                      project-id: contract-project
+                      custom-headers.X-Contract-Header: %s
+                      timeout: PT5S
+                      max-retries: 0
+                      http-client-builder-discover-services: false
+                      listeners-discover-services: false
+                    %s:
+                      provider: open-ai
+                      api-key: %s
+                      model-name: contract-model
+                      base-url: %s
+                      organization-id: contract-organization
+                      project-id: contract-project
+                      custom-headers.X-Contract-Header: %s
+                      dimensions: 3
+                      encoding-format: float
+                      user: contract-user
+                      max-retries: 0
+                      timeout: PT5S
+                      http-client-builder-discover-services: false
+                      listeners-discover-services: false
+                """.formatted(CHAT_MODEL_NAME,
+                               API_KEY,
+                               baseUrl,
+                               CUSTOM_HEADER_VALUE,
+                               STREAMING_MODEL_NAME,
+                               API_KEY,
+                               baseUrl,
+                               CUSTOM_HEADER_VALUE,
+                               EMBEDDING_MODEL_NAME,
+                               API_KEY,
+                               baseUrl,
+                               CUSTOM_HEADER_VALUE);
+        return Config.just(ConfigSources.create(yaml, MediaTypes.APPLICATION_X_YAML));
+    }
+
+    @Ai.Service
+    @Ai.ChatModel(CHAT_MODEL_NAME)
+    public interface ContractChatService {
+        String chat(String prompt);
+    }
+
+    @Ai.Service
+    @Ai.StreamingChatModel(STREAMING_MODEL_NAME)
+    public interface ContractStreamingService {
+        Stream<String> chat(String prompt);
+    }
+
+    private record CapturedRequest(String path,
+                                   String authorization,
+                                   String organization,
+                                   String project,
+                                   String customHeader,
+                                   String contentType,
+                                   String body) {
+    }
+}

--- a/extensions/langchain4j/modules/providers/open-ai/src/test/java/io/helidon/extensions/langchain4j/providers/openai/OpenAiProviderContractTest.java
+++ b/extensions/langchain4j/modules/providers/open-ai/src/test/java/io/helidon/extensions/langchain4j/providers/openai/OpenAiProviderContractTest.java
@@ -43,11 +43,10 @@ import dev.langchain4j.model.openai.OpenAiStreamingChatModel;
 import org.junit.jupiter.api.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ServerTest
 class OpenAiProviderContractTest {
@@ -127,8 +126,8 @@ class OpenAiProviderContractTest {
             ContractStreamingService streamingService = registry.get(ContractStreamingService.class);
             assertThat(streamingService.chat("stream contract prompt").collect(Collectors.joining()),
                        is("openai-stream-ok"));
-            assertArrayEquals(new float[] {0.125F, -0.5F, 0.75F},
-                              embeddingModel.embed("embedding contract prompt").content().vector());
+            assertThat(embeddingModel.embed("embedding contract prompt").content().vectorAsList(),
+                       contains(0.125F, -0.5F, 0.75F));
         } finally {
             registryManager.shutdown();
         }
@@ -154,8 +153,10 @@ class OpenAiProviderContractTest {
         CapturedRequest embeddingRequest = REQUESTS.remove();
         assertThat(embeddingRequest.path(), is("/v1/embeddings"));
         assertCommonRequest(embeddingRequest);
-        assertTrue(embeddingRequest.body()
-                           .matches("(?s).*\"input\"\\s*:\\s*\\[\\s*\"embedding contract prompt\"\\s*].*"));
+        assertThat("Expected embedding input array in: " + embeddingRequest.body(),
+                   embeddingRequest.body()
+                           .matches("(?s).*\"input\"\\s*:\\s*\\[\\s*\"embedding contract prompt\"\\s*].*"),
+                   is(true));
         assertThat(compactJson(embeddingRequest.body()), containsString("\"model\":\"contract-model\""));
         assertThat(compactJson(embeddingRequest.body()), containsString("\"dimensions\":3"));
         assertThat(compactJson(embeddingRequest.body()), containsString("\"encoding_format\":\"float\""));

--- a/extensions/langchain4j/tests/agentic-a2a/pom.xml
+++ b/extensions/langchain4j/tests/agentic-a2a/pom.xml
@@ -1,0 +1,179 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2026 Oracle and/or its affiliates.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>io.helidon.extensions.langchain4j.tests</groupId>
+        <artifactId>helidon-extensions-langchain4j-tests-project</artifactId>
+        <version>27.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>helidon-extensions-langchain4j-tests-agentic-a2a</artifactId>
+    <name>Helidon LangChain4j Agentic A2A Test Project</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.helidon.extensions.langchain4j</groupId>
+            <artifactId>helidon-extensions-langchain4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-agentic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>dev.langchain4j</groupId>
+            <artifactId>langchain4j-agentic-a2a</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.config</groupId>
+            <artifactId>helidon-config-yaml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.logging</groupId>
+            <artifactId>helidon-logging-jul</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-jdk14</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.testing</groupId>
+            <artifactId>helidon-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-all</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver</groupId>
+            <artifactId>helidon-webserver</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.helidon.webserver.testing.junit5</groupId>
+            <artifactId>helidon-webserver-testing-junit5</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- The upstream A2A SDK is not JPMS compatible due to a split package. -->
+            <plugin>
+                <groupId>io.helidon.build-tools</groupId>
+                <artifactId>helidon-services-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-meta-inf-services</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-apt</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.builder</groupId>
+                            <artifactId>helidon-builder-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.service</groupId>
+                            <artifactId>helidon-service-codegen</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.extensions.langchain4j</groupId>
+                            <artifactId>helidon-extensions-langchain4j-codegen</artifactId>
+                            <version>${langchain4j.extension.version}</version>
+                        </path>
+                        <path>
+                            <groupId>io.helidon.codegen</groupId>
+                            <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                            <version>${helidon.version}</version>
+                        </path>
+                    </annotationProcessorPaths>
+                </configuration>
+                <dependencies>
+                    <!-- This is not needed for applications that are not part of Helidon Maven reactor -->
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-apt</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.builder</groupId>
+                        <artifactId>helidon-builder-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.service</groupId>
+                        <artifactId>helidon-service-codegen</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.extensions.langchain4j</groupId>
+                        <artifactId>helidon-extensions-langchain4j-codegen</artifactId>
+                        <version>${langchain4j.extension.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>io.helidon.codegen</groupId>
+                        <artifactId>helidon-codegen-helidon-copyright</artifactId>
+                        <version>${helidon.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>io.helidon.service</groupId>
+                <artifactId>helidon-service-maven-plugin</artifactId>
+                <version>${helidon.version}</version>
+                <executions>
+                    <execution>
+                        <id>create-application</id>
+                        <goals>
+                            <goal>create-application</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extensions/langchain4j/tests/agentic-a2a/src/main/java/io/helidon/extensions/langchain4j/tests/agentica2a/RemoteWriterAgent.java
+++ b/extensions/langchain4j/tests/agentic-a2a/src/main/java/io/helidon/extensions/langchain4j/tests/agentica2a/RemoteWriterAgent.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.tests.agentica2a;
+
+import io.helidon.extensions.langchain4j.Ai;
+
+import dev.langchain4j.agentic.declarative.A2AClientAgent;
+import dev.langchain4j.service.V;
+
+/**
+ * Remote A2A writer used by the loopback contract test.
+ */
+@Ai.Agent("remote-writer")
+public interface RemoteWriterAgent {
+
+    /**
+     * Writes about a topic.
+     *
+     * @param topic topic to write about
+     * @return remote response
+     */
+    @A2AClientAgent(a2aServerUrl = "http://127.0.0.1:1/annotation",
+            outputKey = "annotation-output",
+            async = true)
+    String write(@V("topic") String topic);
+}

--- a/extensions/langchain4j/tests/agentic-a2a/src/main/java/io/helidon/extensions/langchain4j/tests/agentica2a/RemoteWriterWorkflow.java
+++ b/extensions/langchain4j/tests/agentic-a2a/src/main/java/io/helidon/extensions/langchain4j/tests/agentica2a/RemoteWriterWorkflow.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.tests.agentica2a;
+
+import io.helidon.extensions.langchain4j.Ai;
+
+import dev.langchain4j.agentic.declarative.SequenceAgent;
+import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
+import dev.langchain4j.service.V;
+
+/**
+ * Workflow that uses the configured remote writer as a subagent.
+ */
+@Ai.Agent("remote-writer-workflow")
+public interface RemoteWriterWorkflow {
+
+    /**
+     * Runs the remote writer workflow.
+     *
+     * @param topic topic to write about
+     * @return response and agentic scope
+     */
+    @SequenceAgent(outputKey = "configured-output", subAgents = RemoteWriterAgent.class)
+    ResultWithAgenticScope<String> write(@V("topic") String topic);
+}

--- a/extensions/langchain4j/tests/agentic-a2a/src/main/java/io/helidon/extensions/langchain4j/tests/agentica2a/UnannotatedRemoteWriterAgent.java
+++ b/extensions/langchain4j/tests/agentic-a2a/src/main/java/io/helidon/extensions/langchain4j/tests/agentica2a/UnannotatedRemoteWriterAgent.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.tests.agentica2a;
+
+import dev.langchain4j.agentic.declarative.A2AClientAgent;
+import dev.langchain4j.agentic.declarative.A2AServerUrlSupplier;
+import dev.langchain4j.service.V;
+
+/**
+ * Plain LangChain4j A2A agent used to verify fallback when no Helidon agent metadata exists.
+ */
+public interface UnannotatedRemoteWriterAgent {
+    /** System property providing the test server URL. */
+    String SERVER_URL_PROPERTY = "helidon.tests.langchain4j.a2a-server-url";
+
+    /**
+     * Writes about a topic.
+     *
+     * @param topic topic to write about
+     * @return remote response
+     */
+    @A2AClientAgent(outputKey = "fallback-output")
+    String write(@V("topic") String topic);
+
+    /**
+     * Supplies the loopback server URL to upstream LangChain4j.
+     *
+     * @return A2A server URL
+     */
+    @A2AServerUrlSupplier
+    static String serverUrl() {
+        return System.getProperty(SERVER_URL_PROPERTY);
+    }
+}

--- a/extensions/langchain4j/tests/agentic-a2a/src/main/java/io/helidon/extensions/langchain4j/tests/agentica2a/UnannotatedRemoteWriterWorkflow.java
+++ b/extensions/langchain4j/tests/agentic-a2a/src/main/java/io/helidon/extensions/langchain4j/tests/agentica2a/UnannotatedRemoteWriterWorkflow.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.tests.agentica2a;
+
+import io.helidon.extensions.langchain4j.Ai;
+
+import dev.langchain4j.agentic.declarative.SequenceAgent;
+import dev.langchain4j.agentic.scope.ResultWithAgenticScope;
+import dev.langchain4j.service.V;
+
+/**
+ * Workflow containing a plain LangChain4j A2A subagent without {@link Ai.Agent} metadata.
+ */
+@Ai.Agent("unannotated-remote-writer-workflow")
+public interface UnannotatedRemoteWriterWorkflow {
+
+    /**
+     * Runs the remote writer workflow.
+     *
+     * @param topic topic to write about
+     * @return response and agentic scope
+     */
+    @SequenceAgent(outputKey = "fallback-output", subAgents = UnannotatedRemoteWriterAgent.class)
+    ResultWithAgenticScope<String> write(@V("topic") String topic);
+}

--- a/extensions/langchain4j/tests/agentic-a2a/src/main/java/io/helidon/extensions/langchain4j/tests/agentica2a/package-info.java
+++ b/extensions/langchain4j/tests/agentic-a2a/src/main/java/io/helidon/extensions/langchain4j/tests/agentica2a/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Tests for Helidon LangChain4j A2A agent integration.
+ */
+package io.helidon.extensions.langchain4j.tests.agentica2a;

--- a/extensions/langchain4j/tests/agentic-a2a/src/test/java/io/helidon/extensions/langchain4j/tests/agentica2a/A2AAgentContractTest.java
+++ b/extensions/langchain4j/tests/agentic-a2a/src/test/java/io/helidon/extensions/langchain4j/tests/agentica2a/A2AAgentContractTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.extensions.langchain4j.tests.agentica2a;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import io.helidon.common.media.type.MediaTypes;
+import io.helidon.service.registry.Services;
+import io.helidon.webserver.http.HttpRules;
+import io.helidon.webserver.http.ServerRequest;
+import io.helidon.webserver.testing.junit5.ServerTest;
+import io.helidon.webserver.testing.junit5.SetUpRoute;
+
+import dev.langchain4j.agentic.a2a.A2AClientInstance;
+import dev.langchain4j.model.chat.ChatModel;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.everyItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+@ServerTest
+class A2AAgentContractTest {
+
+    private static final ConcurrentLinkedQueue<String> CARD_REQUESTS = new ConcurrentLinkedQueue<>();
+    private static final ConcurrentLinkedQueue<CapturedRequest> MESSAGE_REQUESTS = new ConcurrentLinkedQueue<>();
+
+    private static URI serverUri;
+
+    A2AAgentContractTest(URI serverUri) {
+        A2AAgentContractTest.serverUri = serverUri;
+        System.setProperty(UnannotatedRemoteWriterAgent.SERVER_URL_PROPERTY,
+                           serverUri.resolve("configured").toString());
+        CARD_REQUESTS.clear();
+        MESSAGE_REQUESTS.clear();
+    }
+
+    @AfterAll
+    static void clearServerUrlProperty() {
+        System.clearProperty(UnannotatedRemoteWriterAgent.SERVER_URL_PROPERTY);
+    }
+
+    @SetUpRoute
+    static void routing(HttpRules rules) {
+        rules.get("/configured/.well-known/agent-card.json", (req, res) -> {
+            CARD_REQUESTS.add(req.path().absolute().rawPath());
+            res.headers().contentType(MediaTypes.APPLICATION_JSON);
+            res.send(agentCard());
+        });
+        rules.post("/configured/a2a", (req, res) -> {
+            MESSAGE_REQUESTS.add(capture(req));
+            res.headers().contentType(MediaTypes.APPLICATION_JSON);
+            res.send("""
+                             {
+                               "jsonrpc": "2.0",
+                               "id": 1,
+                               "result": {
+                                 "message": {
+                                   "messageId": "loopback-response",
+                                   "role": "ROLE_AGENT",
+                                   "parts": [{"text": "a2a-loopback-ok"}],
+                                   "metadata": {}
+                                 }
+                               }
+                             }
+                             """);
+        });
+    }
+
+    @Test
+    void configuredA2AAgentWorksTopLevelAndNestedWithoutChatModel() {
+        assertThat(Services.first(ChatModel.class).isEmpty(), is(true));
+
+        RemoteWriterAgent remoteWriter = Services.get(RemoteWriterAgent.class);
+        A2AClientInstance clientInstance = (A2AClientInstance) remoteWriter;
+        assertThat(clientInstance.outputKey(), is("configured-output"));
+        assertThat(clientInstance.async(), is(false));
+
+        assertThat(remoteWriter.write("top-level-topic"), is("a2a-loopback-ok"));
+
+        var workflowResult = Services.get(RemoteWriterWorkflow.class).write("nested-topic");
+        assertThat(workflowResult.result(), is("a2a-loopback-ok"));
+        assertThat(workflowResult.agenticScope().readState("configured-output"), is("a2a-loopback-ok"));
+        assertThat(workflowResult.agenticScope().readState("annotation-output"), is(nullValue()));
+
+        var fallbackResult = Services.get(UnannotatedRemoteWriterWorkflow.class).write("fallback-topic");
+        assertThat(fallbackResult.result(), is("a2a-loopback-ok"));
+        assertThat(fallbackResult.agenticScope().readState("fallback-output"), is("a2a-loopback-ok"));
+
+        assertThat(CARD_REQUESTS, everyItem(is("/configured/.well-known/agent-card.json")));
+        assertThat(CARD_REQUESTS.size(), is(3));
+        assertThat(MESSAGE_REQUESTS.size(), is(3));
+
+        CapturedRequest directRequest = MESSAGE_REQUESTS.remove();
+        assertRequest(directRequest, "top-level-topic");
+        CapturedRequest nestedRequest = MESSAGE_REQUESTS.remove();
+        assertRequest(nestedRequest, "nested-topic");
+        CapturedRequest fallbackRequest = MESSAGE_REQUESTS.remove();
+        assertRequest(fallbackRequest, "fallback-topic");
+        assertThat(MESSAGE_REQUESTS.isEmpty(), is(true));
+    }
+
+    private static void assertRequest(CapturedRequest request, String topic) {
+        String body = compactJson(request.body());
+        assertThat(request.path(), is("/configured/a2a"));
+        assertThat(request.a2aVersion(), is("1.0"));
+        assertThat(request.contentType(), containsString(MediaTypes.APPLICATION_JSON_VALUE));
+        assertThat(body, containsString("\"method\":\"SendMessage\""));
+        assertThat(body, containsString("\"role\":\"ROLE_USER\""));
+        assertThat(body, containsString("\"parts\":[{\"text\":\"" + topic + "\""));
+    }
+
+    private static CapturedRequest capture(ServerRequest request) {
+        Map<String, List<String>> headers = request.headers().toMap();
+        return new CapturedRequest(request.path().absolute().rawPath(),
+                                   header(headers, "a2a-version"),
+                                   header(headers, "content-type"),
+                                   request.content().as(String.class));
+    }
+
+    private static String header(Map<String, List<String>> headers, String name) {
+        return headers.entrySet()
+                .stream()
+                .filter(entry -> entry.getKey().equalsIgnoreCase(name))
+                .flatMap(entry -> entry.getValue().stream())
+                .findFirst()
+                .orElse("");
+    }
+
+    private static String compactJson(String json) {
+        return json.replaceAll("\\s", "");
+    }
+
+    private static String agentCard() {
+        return """
+                {
+                  "name": "Loopback Writer",
+                  "description": "Credential-free A2A test agent",
+                  "version": "1.0.0",
+                  "capabilities": {
+                    "streaming": false,
+                    "pushNotifications": false,
+                    "extendedAgentCard": false
+                  },
+                  "defaultInputModes": ["text/plain"],
+                  "defaultOutputModes": ["text/plain"],
+                  "skills": [],
+                  "supportedInterfaces": [
+                    {
+                      "url": "%s",
+                      "protocolBinding": "JSONRPC",
+                      "protocolVersion": "1.0"
+                    }
+                  ]
+                }
+                """.formatted(serverUri.resolve("configured/a2a"));
+    }
+
+    private record CapturedRequest(String path, String a2aVersion, String contentType, String body) {
+    }
+}

--- a/extensions/langchain4j/tests/agentic-a2a/src/test/resources/application-test.yaml
+++ b/extensions/langchain4j/tests/agentic-a2a/src/test/resources/application-test.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2026 Oracle and/or its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+langchain4j:
+  agents:
+    remote-writer:
+      a2a-server-url: http://localhost:${test.server.port}/configured
+      output-key: configured-output
+      async: false

--- a/extensions/langchain4j/tests/pom.xml
+++ b/extensions/langchain4j/tests/pom.xml
@@ -43,6 +43,7 @@
 
     <modules>
         <module>agentic</module>
+        <module>agentic-a2a</module>
         <module>agentic-mcp</module>
     </modules>
 </project>


### PR DESCRIPTION
### Description

Resolves #132

- Add credential-free HTTP contract tests for the OpenAI, Gemini, Cohere, and Ollama providers as the first commit.
- Add `a2a-server-url`, `output-key`, and `async` overrides for LangChain4j A2A client agents.
- Support generated top-level and nested A2A agents without requiring a local chat model.
- Preserve annotation and supplier fallbacks, client customizers, listeners, composed-agent precedence, and upstream behavior for unannotated A2A subagents.
- Manage the optional `langchain4j-agentic-a2a` dependency in the extension BOM.
- Add unit/code-generation coverage and a credential-free loopback Agent Card/JSON-RPC contract module.

### Documentation

- Document remote A2A agents, configuration precedence, the Agent Card customizer limitation, and the upstream A2A SDK module-path split-package limitation.
- Add `a2a-server-url` to the generated configuration reference.

### Testing

- `bash ./etc/scripts/copyright.sh`
- `bash ./etc/scripts/checkstyle.sh`
- Focused A2A reactor: 11 runtime/code-generation tests and one loopback contract test.
- Existing agentic and agentic-MCP regression selection: 4 agentic and 4 MCP tests.
- Full 21-module `-Pspotbugs,javadoc,tests,examples -DskipTests verify`.
- Provider contract test reactors and the full LangChain4j reactor were validated for the first commit.
- The complete GitHub PR matrix passed on Linux and Windows, including all nine required checks.
