### PR TITLE
Order LangChain4j A2A test fixture members

### DIFF
--- a/extensions/langchain4j/modules/langchain4j/src/test/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupportTest.java
+++ b/extensions/langchain4j/modules/langchain4j/src/test/java/io/helidon/extensions/langchain4j/A2AAgentConfigSupportTest.java
@@ -319,11 +319,6 @@ public class A2AAgentConfigSupportTest {
 
     @Ai.Agent("annotated-a2a")
     public interface AnnotatedAgent {
-        @A2AClientAgent(a2aServerUrl = "a2a+test:annotation",
-                        outputKey = "annotation-output",
-                        async = true)
-        String ask(@V("question") String question);
-
         @A2AClientCustomizer
         static void customize(Object ignored) {
             CUSTOMIZED.set(true);
@@ -333,26 +328,31 @@ public class A2AAgentConfigSupportTest {
         static AgentListener listener() {
             return LISTENER;
         }
+
+        @A2AClientAgent(a2aServerUrl = "a2a+test:annotation",
+                        outputKey = "annotation-output",
+                        async = true)
+        String ask(@V("question") String question);
     }
 
     public interface SuppliedAgent {
-        @A2AClientAgent(typedOutputKey = TypedOutput.class)
-        String ask(@V("question") String question);
-
         @A2AServerUrlSupplier
         static String serverUrl() {
             return "urn:a2a:supplied";
         }
+
+        @A2AClientAgent(typedOutputKey = TypedOutput.class)
+        String ask(@V("question") String question);
     }
 
     public interface ConflictingAgent {
-        @A2AClientAgent(a2aServerUrl = "https://annotation.example.test/a2a")
-        String ask(@V("question") String question);
-
         @A2AServerUrlSupplier
         static String serverUrl() {
             return "https://supplier.example.test/a2a";
         }
+
+        @A2AClientAgent(a2aServerUrl = "https://annotation.example.test/a2a")
+        String ask(@V("question") String question);
     }
 
     public interface MissingUrlAgent {

--- a/extensions/langchain4j/tests/agentic-a2a/src/main/java/io/helidon/extensions/langchain4j/tests/agentica2a/UnannotatedRemoteWriterAgent.java
+++ b/extensions/langchain4j/tests/agentic-a2a/src/main/java/io/helidon/extensions/langchain4j/tests/agentica2a/UnannotatedRemoteWriterAgent.java
@@ -28,15 +28,6 @@ public interface UnannotatedRemoteWriterAgent {
     String SERVER_URL_PROPERTY = "helidon.tests.langchain4j.a2a-server-url";
 
     /**
-     * Writes about a topic.
-     *
-     * @param topic topic to write about
-     * @return remote response
-     */
-    @A2AClientAgent(outputKey = "fallback-output")
-    String write(@V("topic") String topic);
-
-    /**
      * Supplies the loopback server URL to upstream LangChain4j.
      *
      * @return A2A server URL
@@ -45,4 +36,13 @@ public interface UnannotatedRemoteWriterAgent {
     static String serverUrl() {
         return System.getProperty(SERVER_URL_PROPERTY);
     }
+
+    /**
+     * Writes about a topic.
+     *
+     * @param topic topic to write about
+     * @return remote response
+     */
+    @A2AClientAgent(outputKey = "fallback-output")
+    String write(@V("topic") String topic);
 }


### PR DESCRIPTION
### Description

Follow-up to #133.

Orders the LangChain4j A2A test fixture members according to Helidon Development Guideline Rule 2.1. This addresses https://github.com/helidon-io/helidon-extensions/pull/133#discussion_r3944961306.

The change only moves non-private static supplier, customizer, and listener methods before instance agent methods. Annotations, signatures, method bodies, and behavior are unchanged.

### Testing

- `mvn -Ptests -pl extensions/langchain4j/tests/agentic-a2a -am clean test`
- `bash ./etc/scripts/copyright.sh`
- `bash ./etc/scripts/checkstyle.sh`

### Documentation

None
