### PR TITLE
Support split repositories in Maven Invoker builds (27.x)

### DIFF
--- a/extensions/openapi-ui/modules/openapi-ui/pom.xml
+++ b/extensions/openapi-ui/modules/openapi-ui/pom.xml
@@ -149,6 +149,31 @@
                 -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-invoker-plugin</artifactId>
+                <configuration>
+                    <addTestClassPath>true</addTestClassPath>
+                    <settingsFile>src/it/settings.xml</settingsFile>
+                    <mergeUserSettings>true</mergeUserSettings>
+                    <localRepositoryPath>${project.build.directory}/it-repo</localRepositoryPath>
+                    <!--suppress MavenModelInspection -->
+                    <ignoreFailures>${maven.test.failure.ignore}</ignoreFailures>
+                    <showErrors>true</showErrors>
+                    <!--suppress UnresolvedMavenProperty, MavenModelInspection -->
+                    <skipInvocation>${skipTests}</skipInvocation>
+                    <!--suppress UnresolvedMavenProperty, MavenModelInspection -->
+                    <skipInstallation>${skipTests}</skipInstallation>
+                    <pomIncludes>
+                        <pomInclude>projects/*/pom.xml</pomInclude>
+                    </pomIncludes>
+                    <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                    <goals>
+                        <goal>clean</goal>
+                        <goal>install</goal>
+                    </goals>
+                    <extraArtifacts>
+                        <extraArtifact>io.helidon.extensions.openapi-ui:helidon-extensions-openapi-ui-bom:${project.version}:pom</extraArtifact>
+                    </extraArtifacts>
+                    <streamLogs>true</streamLogs>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/extensions/openapi-ui/modules/openapi-ui/pom.xml
+++ b/extensions/openapi-ui/modules/openapi-ui/pom.xml
@@ -143,6 +143,24 @@
                 </dependencies>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>install-openapi-ui-bom</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <file>${project.basedir}/../../bom/pom.xml</file>
+                            <pomFile>${project.basedir}/../../bom/pom.xml</pomFile>
+                            <localRepositoryPath>${project.build.directory}/it-repo</localRepositoryPath>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <!--
                 The following tests a bug fix, without which an added line to the project's module-info.java file triggers a
                 compiler error.
@@ -169,9 +187,6 @@
                         <goal>clean</goal>
                         <goal>install</goal>
                     </goals>
-                    <extraArtifacts>
-                        <extraArtifact>io.helidon.extensions.openapi-ui:helidon-extensions-openapi-ui-bom:${project.version}:pom</extraArtifact>
-                    </extraArtifacts>
                     <streamLogs>true</streamLogs>
                 </configuration>
                 <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
         <version.plugin.exec>3.1.0</version.plugin.exec>
         <version.plugin.failsafe>3.5.5</version.plugin.failsafe>
         <version.plugin.helidon-build-tools>4.0.6</version.plugin.helidon-build-tools>
-        <version.plugin.invoker>3.9.1</version.plugin.invoker>
+        <version.plugin.invoker>3.10.1</version.plugin.invoker>
         <version.plugin.jar>3.3.0</version.plugin.jar>
         <version.plugin.javadoc>3.6.2</version.plugin.javadoc>
         <version.plugin.license>1.16</version.plugin.license>
@@ -625,6 +625,31 @@
                         </executions>
                     </plugin>
                 </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>invoker-split-repository</id>
+            <activation>
+                <property>
+                    <name>aether.enhancedLocalRepository.split</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-invoker-plugin</artifactId>
+                            <configuration>
+                                <properties>
+                                    <aether.enhancedLocalRepository.split>true</aether.enhancedLocalRepository.split>
+                                    <aether.enhancedLocalRepository.localPrefix>${aether.enhancedLocalRepository.localPrefix}</aether.enhancedLocalRepository.localPrefix>
+                                </properties>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
             </build>
         </profile>
         <profile>


### PR DESCRIPTION
Resolves #135

Carry the Maven Invoker split-repository handling from helidon-io/helidon#12516 into Helidon Extensions.

Upgrade Maven Invoker, forward the active split local-repository prefix to nested builds, and run the OpenAPI UI fixture against an isolated repository with its imported BOM staged explicitly.
