### PR TITLE
openapi-generator: support Helidon version shorthand

### DIFF
--- a/extensions/openapi-generator/docs/README.md
+++ b/extensions/openapi-generator/docs/README.md
@@ -58,7 +58,8 @@ The module is packaged as a thin jar. Runtime dependencies are copied to
 
 In the examples below, `4.0.0-SNAPSHOT` is the version of this extension artifact.
 The separate `helidonVersion` option controls which Helidon version is written
-into generated Maven and Gradle projects, and its current default is `4.5.4`.
+into generated Maven and Gradle projects.
+
 The `javaVersion` option controls the generated Maven compiler source and target
 values and the generated Gradle Java toolchain version, and its current default is
 `21`.
@@ -157,7 +158,7 @@ Set these under Maven `<configOptions>` or CLI `--additional-properties`.
 
 | Option | Default | Description |
 |--------|---------|-------------|
-| `helidonVersion` | `4.5.4` | Helidon version written into generated Maven and Gradle builds |
+| `helidonVersion` | `v4` | Helidon version written into generated Maven and Gradle builds; values starting with `v` are resolved to latest version of that major. |
 | `javaVersion` | `21` | Java version written into generated Maven compiler source/target and Gradle toolchain builds |
 | `apiPackage` | `io.helidon.example.api` | Package for generated API, endpoint, client, and error classes |
 | `modelPackage` | `io.helidon.example.model` | Package for generated model classes |
@@ -179,6 +180,11 @@ The schema extension `x-helidon-discriminator-representation` accepts `metadata`
 `readOnlyProperty` and takes precedence over the global option. Without either setting,
 an explicitly declared discriminator property becomes a derived read-only accessor;
 a discriminator used only for polymorphic routing remains metadata-only.
+
+If `helidonVersion` starts with a `v` it is assumed to identify a major version of Helidon, and 
+it will resolve to the latest release of that major version. For example, `v4` resolves to the latest version
+of Helidon 4.X.X. For repeatability it is recommended to use a specific version of Helidon and not
+rely on this shorthand.
 
 ## What Gets Generated
 

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/cascading-validation-mapped-containers/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/cascading-validation-mapped-containers/pom.xml
@@ -30,7 +30,7 @@
     <name>OpenAPI Generator IT Cascading Validation Mapped Containers</name>
 
     <properties>
-        <helidon.version>4.5.4</helidon.version>
+        <helidon.version>4.5.0</helidon.version>
         <inputSpec>${project.basedir}/../../specs/cascading-validation-mapped-containers.yaml</inputSpec>
         <skipGeneratedTests>false</skipGeneratedTests>
     </properties>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/cascading-validation/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/cascading-validation/pom.xml
@@ -30,7 +30,7 @@
     <name>OpenAPI Generator IT Cascading Validation</name>
 
     <properties>
-        <helidon.version>4.5.4</helidon.version>
+        <helidon.version>4.5.0</helidon.version>
         <inputSpec>${project.basedir}/../../specs/cascading-validation.yaml</inputSpec>
         <skipGeneratedTests>false</skipGeneratedTests>
     </properties>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/json-string-enums/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/json-string-enums/pom.xml
@@ -30,7 +30,7 @@
     <name>OpenAPI Generator IT JSON String Enums</name>
 
     <properties>
-        <helidon.version>4.5.4</helidon.version>
+        <helidon.version>4.5.0</helidon.version>
         <inputSpec>${project.basedir}/../../specs/json-string-enums.yaml</inputSpec>
         <skipGeneratedTests>false</skipGeneratedTests>
     </properties>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <!-- Compatibility baseline; feature-specific modules override this when they require Helidon 4.5. -->
-        <helidon.version>4.5.4</helidon.version>
+        <helidon.version>4.5.0</helidon.version>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <mainClass>io.helidon.example.Main</mainClass>

--- a/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/swagger2-contracts/pom.xml
+++ b/extensions/openapi-generator/modules/openapi-generator/src/it/projects/test1/modules/swagger2-contracts/pom.xml
@@ -30,7 +30,7 @@
     <name>OpenAPI Generator IT Swagger 2 Contracts</name>
 
     <properties>
-        <helidon.version>4.5.4</helidon.version>
+        <helidon.version>4.5.0</helidon.version>
         <inputSpec>${project.basedir}/../../specs/swagger2-contracts.yaml</inputSpec>
         <skipGeneratedTests>false</skipGeneratedTests>
     </properties>

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -17,17 +17,12 @@
 package io.helidon.openapi.generator;
 
 import java.io.File;
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -117,8 +112,6 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
     private static final String EXT_DISCRIMINATOR_REPRESENTATION =
             "x-helidon-discriminator-representation";
     private static final String DEFAULT_HELIDON_VERSION = "v4";
-    private static final URI HELIDON_VERSION_RESOLUTION_URI = URI.create("https://helidon.io/api/versions/");
-    private static final Duration HELIDON_VERSION_RESOLUTION_TIMEOUT = Duration.ofSeconds(5);
     private String helidonVersion = DEFAULT_HELIDON_VERSION;
     private String javaVersion = "21";
     private boolean generateClient = true;
@@ -242,10 +235,6 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         return "Generates a Helidon SE 4.x declarative server using @RestServer.Endpoint annotations.";
     }
 
-    // -------------------------------------------------------------------------
-    // Option processing
-    // -------------------------------------------------------------------------
-
     @Override
     public void processOpts() {
         super.processOpts();
@@ -253,7 +242,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         if (additionalProperties.containsKey(OPT_HELIDON_VERSION)) {
             helidonVersion = additionalProperties.get(OPT_HELIDON_VERSION).toString();
         }
-        helidonVersion = resolveHelidonVersion(helidonVersion);
+        helidonVersion = HelidonVersionResolver.resolve(helidonVersion);
         if (additionalProperties.containsKey(OPT_JAVA_VERSION)) {
             javaVersion = normalizeJavaVersion(additionalProperties.get(OPT_JAVA_VERSION));
         }
@@ -346,55 +335,6 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         }
         return text;
     }
-
-    private static String resolveHelidonVersion(String version) {
-        return resolveHelidonVersion(version, HELIDON_VERSION_RESOLUTION_URI);
-    }
-
-    static String resolveHelidonVersion(String version, URI baseUri) {
-        if (!version.startsWith("v")) {
-            return version;
-        }
-
-        String requestedVersion = version.trim();
-        URI requestUri = null;
-        try {
-            requestUri = baseUri.resolve(requestedVersion);
-            HttpRequest request = HttpRequest.newBuilder(requestUri)
-                    .timeout(HELIDON_VERSION_RESOLUTION_TIMEOUT)
-                    .GET()
-                    .build();
-            HttpResponse<String> response = HttpClient.newHttpClient()
-                    .send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
-            if (response.statusCode() < 200 || response.statusCode() >= 300) {
-                throw new IOException("HTTP " + response.statusCode());
-            }
-            return parseResolvedHelidonVersion(requestedVersion, requestUri, response.body());
-        } catch (Exception e) {
-            if (e instanceof InterruptedException) {
-                Thread.currentThread().interrupt();
-            }
-            throw new IllegalArgumentException(helidonVersionResolutionFailure(requestedVersion, requestUri, e.getMessage()));
-        }
-    }
-
-    private static String parseResolvedHelidonVersion(String shorthand, URI requestUri, String body) {
-        String resolvedVersion = body == null ? "" : body.trim();
-        if (resolvedVersion.isEmpty()) {
-            throw new IllegalArgumentException(helidonVersionResolutionFailure(shorthand, requestUri, "Helidon version service returned an empty response body"));
-        }
-        return resolvedVersion;
-    }
-
-    private static String helidonVersionResolutionFailure(
-            String shorthand,
-            URI requestUri,
-            String reason) {
-        return String.format(
-                "Failed to resolve Helidon version '%s' from %s: %s. Set helidonVersion to a specific Helidon release instead of a version shorthand.",
-                shorthand, requestUri, reason);
-    }
-
 
     // -------------------------------------------------------------------------
     // Naming: use plain camelCase (no "Api" suffix) so classname = "Pets", not "PetsApi"

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonDeclarativeCodegen.java
@@ -17,12 +17,17 @@
 package io.helidon.openapi.generator;
 
 import java.io.File;
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -111,7 +116,10 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
     static final String OPT_DISCRIMINATOR_REPRESENTATION = "discriminatorRepresentation";
     private static final String EXT_DISCRIMINATOR_REPRESENTATION =
             "x-helidon-discriminator-representation";
-    private String helidonVersion = "4.5.4";
+    private static final String DEFAULT_HELIDON_VERSION = "v4";
+    private static final URI HELIDON_VERSION_RESOLUTION_URI = URI.create("https://helidon.io/api/versions/");
+    private static final Duration HELIDON_VERSION_RESOLUTION_TIMEOUT = Duration.ofSeconds(5);
+    private String helidonVersion = DEFAULT_HELIDON_VERSION;
     private String javaVersion = "21";
     private boolean generateClient = true;
     private boolean generateErrorHandler = true;
@@ -245,6 +253,7 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         if (additionalProperties.containsKey(OPT_HELIDON_VERSION)) {
             helidonVersion = additionalProperties.get(OPT_HELIDON_VERSION).toString();
         }
+        helidonVersion = resolveHelidonVersion(helidonVersion);
         if (additionalProperties.containsKey(OPT_JAVA_VERSION)) {
             javaVersion = normalizeJavaVersion(additionalProperties.get(OPT_JAVA_VERSION));
         }
@@ -337,6 +346,55 @@ public class HelidonDeclarativeCodegen extends AbstractJavaCodegen {
         }
         return text;
     }
+
+    private static String resolveHelidonVersion(String version) {
+        return resolveHelidonVersion(version, HELIDON_VERSION_RESOLUTION_URI);
+    }
+
+    static String resolveHelidonVersion(String version, URI baseUri) {
+        if (!version.startsWith("v")) {
+            return version;
+        }
+
+        String requestedVersion = version.trim();
+        URI requestUri = null;
+        try {
+            requestUri = baseUri.resolve(requestedVersion);
+            HttpRequest request = HttpRequest.newBuilder(requestUri)
+                    .timeout(HELIDON_VERSION_RESOLUTION_TIMEOUT)
+                    .GET()
+                    .build();
+            HttpResponse<String> response = HttpClient.newHttpClient()
+                    .send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new IOException("HTTP " + response.statusCode());
+            }
+            return parseResolvedHelidonVersion(requestedVersion, requestUri, response.body());
+        } catch (Exception e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new IllegalArgumentException(helidonVersionResolutionFailure(requestedVersion, requestUri, e.getMessage()));
+        }
+    }
+
+    private static String parseResolvedHelidonVersion(String shorthand, URI requestUri, String body) {
+        String resolvedVersion = body == null ? "" : body.trim();
+        if (resolvedVersion.isEmpty()) {
+            throw new IllegalArgumentException(helidonVersionResolutionFailure(shorthand, requestUri, "Helidon version service returned an empty response body"));
+        }
+        return resolvedVersion;
+    }
+
+    private static String helidonVersionResolutionFailure(
+            String shorthand,
+            URI requestUri,
+            String reason) {
+        return String.format(
+                "Failed to resolve Helidon version '%s' from %s: %s. Set helidonVersion to a specific Helidon release instead of a version shorthand.",
+                shorthand, requestUri, reason);
+    }
+
 
     // -------------------------------------------------------------------------
     // Naming: use plain camelCase (no "Api" suffix) so classname = "Pets", not "PetsApi"

--- a/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonVersionResolver.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/main/java/io/helidon/openapi/generator/HelidonVersionResolver.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2026 Oracle and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.helidon.openapi.generator;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+final class HelidonVersionResolver {
+    static final URI RESOLUTION_URI = URI.create("https://helidon.io/api/versions/");
+    private static final Duration TIMEOUT = Duration.ofSeconds(5);
+
+    private HelidonVersionResolver() {
+    }
+
+    static String resolve(String version) {
+        return resolve(version, RESOLUTION_URI);
+    }
+
+    static String resolve(String version, URI baseUri) {
+        if (!version.startsWith("v")) {
+            return version;
+        }
+
+        String requestedVersion = version.trim();
+        URI requestUri = null;
+        try {
+            requestUri = baseUri.resolve(requestedVersion);
+            HttpRequest request = HttpRequest.newBuilder(requestUri)
+                    .timeout(TIMEOUT)
+                    .GET()
+                    .build();
+            HttpResponse<String> response = HttpClient.newHttpClient()
+                    .send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+            if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                throw new IOException("HTTP " + response.statusCode());
+            }
+            return parseResolvedHelidonVersion(requestedVersion, requestUri, response.body());
+        } catch (Exception e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new IllegalArgumentException(helidonVersionResolutionFailure(requestedVersion, requestUri, e.getMessage()));
+        }
+    }
+
+    private static String parseResolvedHelidonVersion(String shorthand, URI requestUri, String body) {
+        String resolvedVersion = body == null ? "" : body.trim();
+        if (resolvedVersion.isEmpty()) {
+            throw new IllegalArgumentException(
+                    helidonVersionResolutionFailure(
+                            shorthand, requestUri, "Helidon version service returned an empty response body"));
+        }
+        return resolvedVersion;
+    }
+
+    private static String helidonVersionResolutionFailure(
+            String shorthand,
+            URI requestUri,
+            String reason) {
+        return String.format(
+                "Failed to resolve Helidon version '%s' from %s: %s. "
+                        + "Set helidonVersion to a specific Helidon release instead of a version shorthand.",
+                shorthand, requestUri, reason);
+    }
+}

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/CascadingValidationGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/CascadingValidationGenerationIT.java
@@ -515,7 +515,7 @@ class CascadingValidationGenerationIT {
                 .setGeneratorName("helidon-declarative")
                 .setInputSpec(inputSpec)
                 .setOutputDir(target.toString())
-                .addAdditionalProperty("helidonVersion", "4.5.4")
+                .addAdditionalProperty("helidonVersion", "4.5.0")
                 .addAdditionalProperty("apiPackage", "io.helidon.example.api")
                 .addAdditionalProperty("modelPackage", "io.helidon.example.model")
                 .addAdditionalProperty("invokerPackage", "io.helidon.example");

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/GlobalSecurityGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/GlobalSecurityGenerationIT.java
@@ -49,6 +49,7 @@ class GlobalSecurityGenerationIT {
                 .setGeneratorName("helidon-declarative")
                 .setInputSpec(specPath)
                 .setOutputDir(outputDir.toString())
+                .addAdditionalProperty("helidonVersion", "4.5.0")
                 .addAdditionalProperty("apiPackage", "io.helidon.example.api")
                 .addAdditionalProperty("modelPackage", "io.helidon.example.model")
                 .addAdditionalProperty("invokerPackage", "io.helidon.example");

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/HelidonDeclarativeCodegenTest.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/HelidonDeclarativeCodegenTest.java
@@ -275,13 +275,13 @@ class HelidonDeclarativeCodegenTest {
     void resolveHelidonVersionLeavesSpecificVersionAlone() {
         URI unusedEndpoint = URI.create("http://127.0.0.1:1/api/versions/");
 
-        assertThat(HelidonDeclarativeCodegen.resolveHelidonVersion("4.5.0", unusedEndpoint), is("4.5.0"));
+        assertThat(HelidonVersionResolver.resolve("4.5.0", unusedEndpoint), is("4.5.0"));
     }
 
     @Test
     void resolveHelidonVersionFetchesVersionShorthand() throws Exception {
         try (TestHttpEndpoint endpoint = TestHttpEndpoint.responding(200, "4.5.9\n")) {
-            String resolved = HelidonDeclarativeCodegen.resolveHelidonVersion("v4", endpoint.baseUri());
+            String resolved = HelidonVersionResolver.resolve("v4", endpoint.baseUri());
 
             assertThat(resolved, is("4.5.9"));
             assertThat(endpoint.requestLine(), containsString("GET /api/versions/v4 HTTP/1.1"));
@@ -289,11 +289,20 @@ class HelidonDeclarativeCodegenTest {
     }
 
     @Test
+    void resolveHelidonVersionFetchesLiveVersionShorthand() {
+        String resolved = HelidonVersionResolver.resolve(
+                "v4",
+                HelidonVersionResolver.RESOLUTION_URI);
+
+        assertThat("Resolved Helidon version: " + resolved, resolved.matches("4\\.\\d+\\.\\d+"), is(true));
+    }
+
+    @Test
     void resolveHelidonVersionRejectsBlankResponse() throws Exception {
         try (TestHttpEndpoint endpoint = TestHttpEndpoint.responding(200, "\n")) {
             IllegalArgumentException exception = assertThrows(
                     IllegalArgumentException.class,
-                    () -> HelidonDeclarativeCodegen.resolveHelidonVersion("v4", endpoint.baseUri()));
+                    () -> HelidonVersionResolver.resolve("v4", endpoint.baseUri()));
 
             assertThat(exception.getMessage(), containsString("Failed to resolve Helidon version 'v4'"));
             assertThat(exception.getMessage(), containsString("Set helidonVersion to a specific Helidon release"));
@@ -305,7 +314,7 @@ class HelidonDeclarativeCodegenTest {
         try (TestHttpEndpoint endpoint = TestHttpEndpoint.responding(404, "not found")) {
             IllegalArgumentException exception = assertThrows(
                     IllegalArgumentException.class,
-                    () -> HelidonDeclarativeCodegen.resolveHelidonVersion("v4", endpoint.baseUri()));
+                    () -> HelidonVersionResolver.resolve("v4", endpoint.baseUri()));
 
             assertThat(exception.getMessage(), containsString("Failed to resolve Helidon version 'v4'"));
             assertThat(exception.getMessage(), containsString("Set helidonVersion to a specific Helidon release"));

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/HelidonDeclarativeCodegenTest.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/HelidonDeclarativeCodegenTest.java
@@ -16,7 +16,15 @@
 
 package io.helidon.openapi.generator;
 
+import java.io.BufferedReader;
 import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.InetAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -223,7 +231,19 @@ class HelidonDeclarativeCodegenTest {
     }
 
     @Test
+    void defaultHelidonVersionOptionIsShorthandV4() {
+        String defaultVersion = codegen.cliOptions().stream()
+                .filter(option -> "helidonVersion".equals(option.getOpt()))
+                .findFirst()
+                .orElseThrow()
+                .getDefault();
+
+        assertThat(defaultVersion, is("v4"));
+    }
+
+    @Test
     void processOptsRejectsNonIntegerJavaVersion() {
+        codegen.additionalProperties().put("helidonVersion", "4.5.0");
         codegen.additionalProperties().put("javaVersion", "1.8");
 
         IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
@@ -235,9 +255,123 @@ class HelidonDeclarativeCodegenTest {
     @Test
     void processOptsExposesIntegerJavaVersion() {
         codegen.additionalProperties().put("javaVersion", "17");
+        codegen.additionalProperties().put("helidonVersion", "4.5.0");
 
         codegen.processOpts();
 
         assertThat(codegen.additionalProperties().get("javaVersion"), is("17"));
+    }
+
+    @Test
+    void processOptsExposesConfiguredHelidonVersion() {
+        codegen.additionalProperties().put("helidonVersion", "4.5.0");
+
+        codegen.processOpts();
+
+        assertThat(codegen.additionalProperties().get("helidonVersion"), is("4.5.0"));
+    }
+
+    @Test
+    void resolveHelidonVersionLeavesSpecificVersionAlone() {
+        URI unusedEndpoint = URI.create("http://127.0.0.1:1/api/versions/");
+
+        assertThat(HelidonDeclarativeCodegen.resolveHelidonVersion("4.5.0", unusedEndpoint), is("4.5.0"));
+    }
+
+    @Test
+    void resolveHelidonVersionFetchesVersionShorthand() throws Exception {
+        try (TestHttpEndpoint endpoint = TestHttpEndpoint.responding(200, "4.5.9\n")) {
+            String resolved = HelidonDeclarativeCodegen.resolveHelidonVersion("v4", endpoint.baseUri());
+
+            assertThat(resolved, is("4.5.9"));
+            assertThat(endpoint.requestLine(), containsString("GET /api/versions/v4 HTTP/1.1"));
+        }
+    }
+
+    @Test
+    void resolveHelidonVersionRejectsBlankResponse() throws Exception {
+        try (TestHttpEndpoint endpoint = TestHttpEndpoint.responding(200, "\n")) {
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> HelidonDeclarativeCodegen.resolveHelidonVersion("v4", endpoint.baseUri()));
+
+            assertThat(exception.getMessage(), containsString("Failed to resolve Helidon version 'v4'"));
+            assertThat(exception.getMessage(), containsString("Set helidonVersion to a specific Helidon release"));
+        }
+    }
+
+    @Test
+    void resolveHelidonVersionFailsClearlyOnHttpError() throws Exception {
+        try (TestHttpEndpoint endpoint = TestHttpEndpoint.responding(404, "not found")) {
+            IllegalArgumentException exception = assertThrows(
+                    IllegalArgumentException.class,
+                    () -> HelidonDeclarativeCodegen.resolveHelidonVersion("v4", endpoint.baseUri()));
+
+            assertThat(exception.getMessage(), containsString("Failed to resolve Helidon version 'v4'"));
+            assertThat(exception.getMessage(), containsString("Set helidonVersion to a specific Helidon release"));
+        }
+    }
+
+    private static final class TestHttpEndpoint implements AutoCloseable {
+        private final ServerSocket serverSocket;
+        private final Thread thread;
+        private final AtomicReference<String> requestLine = new AtomicReference<>();
+
+        private TestHttpEndpoint(ServerSocket serverSocket, int statusCode, String body) {
+            this.serverSocket = serverSocket;
+            this.thread = new Thread(() -> serve(statusCode, body), "helidon-version-test-server");
+            this.thread.setDaemon(true);
+        }
+
+        static TestHttpEndpoint responding(int statusCode, String body) throws IOException {
+            ServerSocket serverSocket = new ServerSocket(0, 1, InetAddress.getByName("127.0.0.1"));
+            TestHttpEndpoint endpoint = new TestHttpEndpoint(serverSocket, statusCode, body);
+            endpoint.thread.start();
+            return endpoint;
+        }
+
+        URI baseUri() {
+            return URI.create("http://127.0.0.1:" + serverSocket.getLocalPort() + "/api/versions/");
+        }
+
+        String requestLine() throws InterruptedException {
+            thread.join(2_000);
+            return requestLine.get();
+        }
+
+        @Override
+        public void close() throws Exception {
+            serverSocket.close();
+            thread.join(2_000);
+        }
+
+        private void serve(int statusCode, String body) {
+            try (serverSocket; Socket socket = serverSocket.accept()) {
+                readRequest(socket);
+                byte[] responseBody = body.getBytes(StandardCharsets.UTF_8);
+                String statusText = statusCode >= 200 && statusCode < 300 ? "OK" : "ERROR";
+                String headers = "HTTP/1.1 "
+                        + statusCode
+                        + " "
+                        + statusText
+                        + "\r\nContent-Type: text/plain; charset=UTF-8\r\nContent-Length: "
+                        + responseBody.length
+                        + "\r\nConnection: close\r\n\r\n";
+                socket.getOutputStream().write(headers.getBytes(StandardCharsets.US_ASCII));
+                socket.getOutputStream().write(responseBody);
+            } catch (IOException ignored) {
+                // The test may close the server socket while the server thread is waiting for a connection.
+            }
+        }
+
+        private void readRequest(Socket socket) throws IOException {
+            BufferedReader reader = new BufferedReader(
+                    new InputStreamReader(socket.getInputStream(), StandardCharsets.US_ASCII));
+            requestLine.set(reader.readLine());
+            String line;
+            while ((line = reader.readLine()) != null && !line.isEmpty()) {
+                // Read headers before writing the response.
+            }
+        }
     }
 }

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/JsonStringEnumGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/JsonStringEnumGenerationIT.java
@@ -152,7 +152,8 @@ class JsonStringEnumGenerationIT {
         CodegenConfigurator configurator = new CodegenConfigurator()
                 .setGeneratorName("helidon-declarative")
                 .setInputSpec(Paths.get(resource.toURI()).toAbsolutePath().toString())
-                .setOutputDir(invalidOutput.toString());
+                .setOutputDir(invalidOutput.toString())
+                .addAdditionalProperty("helidonVersion", "4.5.0");
 
         RuntimeException error = org.junit.jupiter.api.Assertions.assertThrows(
                 RuntimeException.class,
@@ -184,9 +185,9 @@ class JsonStringEnumGenerationIT {
     }
 
     @Test
-    void generatedProjectUsesLatestHelidonReleaseByDefault() throws IOException {
-        assertThat(read(outputDir.resolve("pom.xml")), containsString("<helidon.version>4.5.4</helidon.version>"));
-        assertThat(read(outputDir.resolve("build.gradle")), containsString("def helidonVersion = '4.5.4'"));
+    void generatedProjectUsesConfiguredHelidonRelease() throws IOException {
+        assertThat(read(outputDir.resolve("pom.xml")), containsString("<helidon.version>4.5.0</helidon.version>"));
+        assertThat(read(outputDir.resolve("build.gradle")), containsString("def helidonVersion = '4.5.0'"));
     }
 
     @Test
@@ -208,7 +209,8 @@ class JsonStringEnumGenerationIT {
         CodegenConfigurator configurator = new CodegenConfigurator()
                 .setGeneratorName("helidon-declarative")
                 .setInputSpec(Paths.get(resource.toURI()).toAbsolutePath().toString())
-                .setOutputDir(cookieOutput.toString());
+                .setOutputDir(cookieOutput.toString())
+                .addAdditionalProperty("helidonVersion", "4.5.0");
 
         IllegalArgumentException error = org.junit.jupiter.api.Assertions.assertThrows(
                 IllegalArgumentException.class,
@@ -225,6 +227,7 @@ class JsonStringEnumGenerationIT {
                 .setGeneratorName("helidon-declarative")
                 .setInputSpec(specPath)
                 .setOutputDir(destination.toString())
+                .addAdditionalProperty("helidonVersion", "4.5.0")
                 .addAdditionalProperty("apiPackage", "io.helidon.example.api")
                 .addAdditionalProperty("modelPackage", "io.helidon.example.model")
                 .addAdditionalProperty("invokerPackage", "io.helidon.example");

--- a/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/SecurityGenerationIT.java
+++ b/extensions/openapi-generator/modules/openapi-generator/src/test/java/io/helidon/openapi/generator/SecurityGenerationIT.java
@@ -50,6 +50,7 @@ class SecurityGenerationIT {
                 .setGeneratorName("helidon-declarative")
                 .setInputSpec(specPath)
                 .setOutputDir(outputDir.toString())
+                .addAdditionalProperty("helidonVersion", "4.5.0")
                 .addAdditionalProperty("apiPackage", "io.helidon.example.api")
                 .addAdditionalProperty("modelPackage", "io.helidon.example.model")
                 .addAdditionalProperty("invokerPackage", "io.helidon.example");

--- a/extensions/openapi-generator/pom.xml
+++ b/extensions/openapi-generator/pom.xml
@@ -42,8 +42,8 @@
     </modules>
 
     <properties>
-        <!-- Compatibility baseline for building the generator; generated projects default to 4.5.4. -->
-        <helidon.version>4.5.4</helidon.version>
+        <!-- Compatibility baseline for building the generator -->
+        <helidon.version>4.5.0</helidon.version>
         <version.java>21</version.java>
 
         <version.lib.openapi-generator>7.11.0</version.lib.openapi-generator>


### PR DESCRIPTION
### Description

Implements #129

Supports version shorthands, like `v4`, for the value of `helidonVersion`.

1. Adds support for resolving the shorthand using helidon.io endpoints: [https://helidon.io/api/versions/v4](https://helidon.io/api/versions/v4)
2. Defaults `helidonVersion` to `v4` so we don't need to bump it every time we release Helidon. But we recommend that customers use specific Helidon versions.
4. Uses `4.5.0` as the baseline for testing.
5. Only attempts resolution if version string starts with a `v` -- so avoids network lookup if specific Helidon version is used.
6. Attempts to be robust when errors are encountered and steers user to use a specific version. So specifying an illegal version shorthand, like `v5` results in "java.lang.IllegalArgumentException: Failed to resolve Helidon version 'v5' from https://helidon.io/api/versions/v5: HTTP 404. Set helidonVersion to a specific Helidon release instead of a version shorthand."

Note that there is one (and only one) test that relies on the live endpoint: `resolveHelidonVersionFetchesLiveVersionShorthand`